### PR TITLE
Update to Bach BWV 988 aria

### DIFF
--- a/ftp/BachJS/BWV988/bwv-988-aria/bwv-988-aria.ly
+++ b/ftp/BachJS/BWV988/bwv-988-aria/bwv-988-aria.ly
@@ -1,16 +1,16 @@
-\version "2.10.23"
+\version "2.16.1"
 
 % Uncomment paper block below for fewer pages.
 %\paper {
-%       between-system-padding = #0.1
-%       between-system-space = #0.1
+%       obsolete-between-system-padding = #0.1  system-system-spacing #'padding = #(/ obsolete-between-system-padding staff-space)  score-system-spacing #'padding = #(/ obsolete-between-system-padding staff-space)
+%       obsolete-between-system-space = #0.1  system-system-spacing #'basic-distance = #(/ obsolete-between-system-space staff-space)  score-system-spacing #'basic-distance = #(/ obsolete-between-system-space staff-space)
 %       ragged-last-bottom = ##f
 %       ragged-bottom = ##f
 %}
 
 %Uncomment paper block below for evenly-filled pages.
 %\paper {
-%    page-top-space = #0.0
+%    obsolete-page-top-space = #0.0  top-system-spacing #'basic-distance = #(/ obsolete-page-top-space staff-space)
 %    %indent = 0.0
 %    line-width = 18.0\cm
 %    ragged-bottom = ##f
@@ -31,14 +31,14 @@
         mutopiacomposer = "BachJS"
         opus = "BWV 988"
         date = "1741"
-        mutopiainstrument = "Clavier"
+        mutopiainstrument = "Harpsichord,Clavichord"
         style = "Baroque"
         source = "Bach-Gesellschaft"
         copyright = "Creative Commons Attribution-ShareAlike 3.0"
         maintainer = "JD Erickson"
         maintainerEmail = "erickson.jd@gmail.com"
- footer = "Mutopia-2007/05/20-979"
- tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-align { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \line { \teeny www. \hspace #-1.0 MutopiaProject \hspace #-1.0 \teeny .org \hspace #0.5 } • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \line { \teeny www. \hspace #-1.0 LilyPond \hspace #-1.0 \teeny .org } by \maintainer \hspace #-1.0 . \hspace #0.5 Copyright © 2007. \hspace #0.5 Reference: \footer } } \line { \teeny \line { Licensed under the Creative Commons Attribution-ShareAlike 3.0 (Unported) License, for details see: \hspace #-0.5 \with-url #"http://creativecommons.org/licenses/by-sa/3.0" http://creativecommons.org/licenses/by-sa/3.0 } } } }
+ footer = "Mutopia-2013/01/06-979"
+ tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-column { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \line { \concat { \teeny www. \normalsize MutopiaProject \teeny .org } \hspace #0.5 } • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \line { \concat { \teeny www. \normalsize LilyPond \teeny .org }} by \concat { \maintainer . } \hspace #0.5 Copyright © 2013. \hspace #0.5 Reference: \footer } } \line { \teeny \line { Licensed under the Creative Commons Attribution-ShareAlike 3.0 (Unported) License, for details \concat { see: \hspace #0.3 \with-url #"http://creativecommons.org/licenses/by-sa/3.0" http://creativecommons.org/licenses/by-sa/3.0 } } } } }
 }
 
 % Macros %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -67,14 +67,15 @@ soprano = \relative c'' {
 
         %6-10
         e8 \appoggiatura d16 c8 \appoggiatura b16 \stemUp a4. \stemDown fis'8\turn
-        \stemDown g32[( fis16.) a32( g16.)] fis32[( e16.) d32( c16.)] \appoggiatura c8 a'8. c,16
+        \stemDown g32[( fis16.) a32( g16.)] fis32[( e16.) d32( c16.)] \once \override Slur #'direction = #UP \appoggiatura c8 a'8. c,16
         \stemUp b32[( g16.) fis8] \appoggiatura fis8 g2\prallmordent
         b4 b4( cis8.\prallmordent) d16
         d16 cis16 b16 a16_~ \stemDown a2 \stemUp
 
         %11-15
         <g b e g>4\arpeggio \stemDown g'4.\downprall fis16 g16
-        g8 \appoggiatura fis16 e8 cis4.\downprall e8
+        \override NoteColumn #'ignore-collision = ##t
+        g8 \appoggiatura fis16 e8 \once \override Stem #'length-fraction = #(magstep -6) cis4.\downprall e8
         a16( g16 fis16 e16) d8 \stemUp a4_~ a32 b32 c16
         b16( a16 g16 fis16) e8 \appoggiatura d'16 cis4_~ cis32 d32 e16
         d16^( cis16 b16 a16) g'8 b,4 cis8
@@ -84,14 +85,14 @@ soprano = \relative c'' {
     } %end of repeated section
     \repeat volta 2 { %begin repeated section
         a4\prallmordent a4_~\downprall a16[ a32( b32 c32 d32 e16)]
-        \appoggiatura e16 d8 \appoggiatura c16 b8 \appoggiatura a8 g4. e'8
+        \appoggiatura e16 d8 \appoggiatura c16 b8 \appoggiatura a8 g4. g'8
         \appoggiatura fis16 e8. fis32 dis32 \appoggiatura dis8 e4.\prallmordent a32 b32 a32 g32
         a8. fis16 \appoggiatura e8 dis4. b8
 
         %21-25
-        \stemDown g'8. fis16 \appoggiatura fis8 e4^~ e16[ b16 c32( b32 a32 b32)]
+        \stemDown g'8. \prallup fis16 \appoggiatura fis8 e4^~ e16[ b16 c32( b32 a32 b32)]
         g'32[( e16.) fis32( dis16.)] \appoggiatura dis8 e4^~ \stemUp e16 g,16 fis16 e16
-        fis8. e'16 \appoggiatura e16 dis8 a'8 g8 fis8
+        fis8. e'16 \appoggiatura e16 dis8 a'8 \prallup g8 fis8
         \appoggiatura fis16 e8. fis32 dis32 \appoggiatura dis8 e2
         \stemDown e8 \appoggiatura d16 c8 \appoggiatura b16 a4. b16[ c16]
 
@@ -124,7 +125,7 @@ bassOne = \relative c' {
     %6-10
     c2_~ c8 d8
     e8 c8 d2
-    g,4. d'8 e8.\prallmordent fis16
+    g,4. d'8[ e8.\prallmordent fis16]
     g2._~
     g4 fis8\prallprall e8 fis8 b8
 
@@ -158,7 +159,7 @@ bassOne = \relative c' {
 
     %31-32
     fis8 d8 g8 b8 d8 d,8
-    g4. d8 g,4_\fermata
+    g4. d8 \stemUp \once \override Script #'padding = #.8 g,4_\fermata
 }
 
 bassTwo = \relative c' {
@@ -171,7 +172,7 @@ bassTwo = \relative c' {
     f'4\rest d,2
 
     %6-10
-    s4. e4.
+    s4 e4. s8
     f'8\rest c8^~ c8[ b16 a16] g16 fis16 e16 fis16
     g8 a8 b2
     s4 b2
@@ -186,8 +187,8 @@ bassTwo = \relative c' {
 
     %16-20
     g4 fis2 
-    \staffLower a8\rest e8 \stemDown fis2^\prallmordent
-    \stemUp f8\rest c8 d2
+    \staffLower a8\rest e8 \once \override Stem #'length-fraction = #(magstep -2) fis2^\prallmordent
+    f8\rest c8 d2
     f8\rest e8 g4 fis8^\prallprall e8
     dis8 e8 \staffUpper fis2
 
@@ -248,7 +249,7 @@ bassThree = \relative c' {
     f'4\rest f4\rest a,4^~
 
     %26-30
-    a8 fis8 \appoggiatura e16 d8[ e16 fis16] g16[ fis16 g8]^~
+    a8 fis8 \once \override Slur #'direction = #DOWN \appoggiatura e16 d8[ e16 fis16] g16[ fis16 g8]^~
     g8[ e8] a8 a8\rest a4\rest
     
 }
@@ -261,7 +262,6 @@ bass = << \bassOne \\ \bassTwo \\ \bassThree >>
 
 \score {
     \context PianoStaff <<
-        \set PianoStaff.instrumentName = "Clavier  "
         \set PianoStaff.midiInstrument = "harpsichord"
         \context Staff = "upper" { \clef treble \key g \major \time 3/4 << \soprano >>  }
         \context Staff = "lower"  { \clef bass \key g \major \time 3/4 \bass }


### PR DESCRIPTION
Bar 6: correct 2nd bass dotted quarter note, beat 2.5->beat 2
Bar 18: correct e->g in last eight note in treble
(Steve Shorter)
update to v2.16.1
minor cosmetics
Bar 21: add prallup to first treble note
Bar 23: add prallup to the 'a' in first voice
(Javier Ruiz-Alma)
Close #12
