### PR TITLE
Update BWV 988 var06

### DIFF
--- a/ftp/BachJS/BWV988/bwv-988-v06/bwv-988-v06.ly
+++ b/ftp/BachJS/BWV988/bwv-988-v06/bwv-988-v06.ly
@@ -1,14 +1,14 @@
-\version "2.10.00"
+\version "2.16.1"
 
 \paper {
-    page-top-space = #0.0
-    %indent = 0.0
-    line-width = 18.0\cm
-    ragged-bottom = ##f
-    ragged-last-bottom = ##f
+	markup-system-spacing #'basic-distance = #25 %distance from header/title to 1st system
+	top-system-spacing #'basic-distance = #20 %dist. from top to 1st system when no titles exist
+	system-system-spacing #'basic-distance = #30  %fixed distance between systems
+	ragged-bottom = ##t
+	ragged-last-bottom = ##t
 }
 
-% #(set-default-paper-size "a4")
+%#(set-default-paper-size "letter")
 
 #(set-global-staff-size 19)
 
@@ -21,15 +21,15 @@
         mutopiacomposer = "BachJS"
         opus = "BWV 988"
         date = "1741"
-        mutopiainstrument = "Clavier"
+        mutopiainstrument = "Harpsichord,Clavichord"
         style = "Baroque"
         source = "Bach-Gesellschaft Edition 1853 Band 3"
         copyright = "Creative Commons Attribution-ShareAlike 3.0"
         maintainer = "Hajo Dezelski"
         maintainerEmail = "dl1sdz (at) gmail.com"
 	
- footer = "Mutopia-2008/04/21-1385"
- tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-align { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \line { \teeny www. \hspace #-1.0 MutopiaProject \hspace #-1.0 \teeny .org \hspace #0.5 } • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \line { \teeny www. \hspace #-1.0 LilyPond \hspace #-1.0 \teeny .org } by \maintainer \hspace #-1.0 . \hspace #0.5 Copyright © 2008. \hspace #0.5 Reference: \footer } } \line { \teeny \line { Licensed under the Creative Commons Attribution-ShareAlike 3.0 (Unported) License, for details see: \hspace #-0.5 \with-url #"http://creativecommons.org/licenses/by-sa/3.0" http://creativecommons.org/licenses/by-sa/3.0 } } } }
+ footer = "Mutopia-2013/02/01-1385"
+ tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-column { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \line { \concat { \teeny www. \normalsize MutopiaProject \teeny .org } \hspace #0.5 } • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \line { \concat { \teeny www. \normalsize LilyPond \teeny .org }} by \concat { \maintainer . } \hspace #0.5 Copyright © 2013. \hspace #0.5 Reference: \footer } } \line { \teeny \line { Licensed under the Creative Commons Attribution-ShareAlike 3.0 (Unported) License, for details \concat { see: \hspace #0.3 \with-url #"http://creativecommons.org/licenses/by-sa/3.0" http://creativecommons.org/licenses/by-sa/3.0 } } } } }
 }
 
 % Macros %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -37,101 +37,116 @@
 staffUpper = {\change Staff = upper \stemDown}
 staffLower = {\change Staff = lower \stemUp}
 
+
+extendLaissezVibrer = #(define-music-function (parser location further) (number?) 
+#{
+   \once \override LaissezVibrerTie  #'X-extent = #'(0 . 0)
+   \once \override LaissezVibrerTie  #'details #'note-head-gap = #(/ further -2)
+   \once \override LaissezVibrerTie  #'extra-offset = #(cons (/ further 2) -0.8)
+#})
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 sopranoOne =   \relative a'' {
-     s1*3/8 | % 1
+    \once \override Voice.Rest #'extra-offset = #'(7.9 . 0 ) r1*3/8 | % 1
     \repeat volta 2 { %begin repeated section
     \stemUp
+        
     a4. ( | % 2
     a8 ) [ g16 fis e d ] | % 3
     c4. ( | % 4
     c8 ) [ b16 a g fis ] | % 5
     e4. ( | % 6
     e8 ) [ d16 c b a ] | % 7
-    b4. ( | % 8
-    b16 ) [ a c b a g ] |  % 9
-    a16 a'4 ( s16 | % 10
+    b4._( | % 8
+    b16 ) [ \staffLower a c b a g ] |  % 9
+    a8 \staffUpper \stemUp a'4 (  | % 10
     a8 ) [ g16 fis e d ] | % 11
-    cis16 [ e a b c8 ( ] | % 12
+    cis16 [ e a b c!8 ( ] | % 12
     c8 ) [ b16 a g fis ] | % 13
     e4. ( | % 14
     e16 ) [ d cis e d cis ] | % 15
     }  %end of repeated section
     \alternative {
-	    {d16 [ c b a g fis ] | % 16
-	    g''4. ~}% 17
-	    { d,4. a''4.}
+	    {d16 [ c! \staffLower b a g fis ] | % 16
+	    \staffUpper \extendLaissezVibrer #9 g''4._\laissezVibrer}% 17
+	    { \stemNeutral d,4. \once \override Voice.Rest #'extra-offset = #'(6.6 . 0.0 ) a''1*3/8\rest}
     } %end of alternative
-  
+    \pageBreak
     \repeat volta 2 { %begin repeated section
-    b4. ~ | % 18
+    \stemUp b4. ~ | % 18
     b8 [ a16 g16 fis16 e16 ] | % 19
     dis8 d4 ( | % 20
     d8 ) [ c16 b16 a16 g16 ] | % 21
     fis4. ( | % 22
-    fis16 ) [ e16 d16 fis16 e16 d16 ] | % 23
-    e16 [ d16 c16 b16 a16 gis16 ] | % 24
+    fis16 ) [ e16 dis!16 fis16 e16 dis16 ] | % 23
+    \break
+    e16 [ d!16 c16 \staffLower b16 a16 gis16 ] | % 24
     a8 r8 r8 | % 25
-    d4. ~ | % 26
-    d16  [ b16 c16 a16 c16 e16 ] | % 27
-    fis4. ( | % 28
-    fis16 ) [ dis16 e16 c16 e16 g16 ] | % 29
+    \staffUpper \stemNeutral d4. ~ | % 26
+    d16 ^[ b16 c16 a16 c16 e16 ] | % 27
+    \stemNeutral fis4. ( | % 28
+    fis16_) [ dis16 e16 c16 e16 g16 ] | % 29
     a4. ~ | % 30
     a16 [ g16 fis16 a16 g16 fis16 ] | % 31
     } %end repeated section
     \alternative {
-	  {g16 [ fis16 e16 d16 c16 b16 ] | % 32
-	  a''4.} % 33
-	  { g4. }
+	  {g16^[ fis16 e16 d16 c16 \staffLower b16 ] | % 32
+	   a8 c8\rest c8\rest } %33
+	  { b4.}
     } %end alternative
 }
 
 sopranoTwo =   \relative a'' {
 	 g4. ( | % 1
     \repeat volta 2 { %begin repeated section
+   	    
     \stemDown
     g8 ) [ fis16 e16 d16 c16 ] | % 2
     b4. ( | % 3
     b8 ) [ a16 g16 fis16 e16 ] | % 4
     d4. ( | % 5
-    d8 ) [ c16 b16 a16 g16 ] | % 6
-    a4. ( | % 7
+    \once \override Beam #'positions = #'(-3.8 . -3.8)
+    d8 ) [ \staffLower c16 b16 a16 g16 ] | % 6
+    a4.^( | % 7
     a16 ) [ g16 b16 a16 g16 fis16 ] | % 8
-    g8 g'4 ( | % 9
-    g8 ) [ fis16 e16 d16 c16 ] | % 10
-    b16 [ d16 g16 a16 bes8 ( ] | % 11
-    bes8 ) [ a16 g16 fis16 e16 ] | % 12
+    g8 \staffUpper g'4 ( | % 9
+    g8 ) [ fis16 e16 d16 c!16 ] | % 10
+    \staffLower b16 [ \staffUpper d16 g16 a16 bes8 ~ ] | % 11
+    bes8 [ a16 g16 fis16 e16 ] | % 12
     d4. ( | % 13
-    d16 ) [ cis16 b16 d16 cis16 b16 ] | % 14
+    d16 ) [ \staffLower cis16 b16 d16 cis16 b16 ] | % 14
     cis16 [ b16 a16 g16 fis16 e16 ] | % 15
     } %end of repeated section
     \alternative {
-	    { fis8 r8 r8 | % 16
-	    g8 r8 r8}
-	    { fis4. | r1*3/8}
+	    { fis8 f8\rest d8\rest | % 16
+	    g8 a8\rest a8\rest}
+	    { fis4. | \staffUpper a''4.~}
     }
      
     \repeat volta 2 { %begin repeated section
-    a''8 [ g16 fis16 e16 d16 ] | % 18
+    a8 [ g16 fis16 e16 d16 ] | % 18
     cis8 c4 ~ | % 19
-    c8 [ b16 a16 g16 fis16 ] | % 20
+    c8 [ b16 a16 gis16 fis16 ] | % 20
     e4. ~ | % 21
     e16 [ dis16 cis16 e16 dis16 cis16 ] | % 22
-    dis16 [ cis16 b16 a16 g16 fis16 ] | % 23
-    g8 r8 r8 | % 24
-    c4. ~ | % 25
+    dis16 [ cis16 \staffLower b16 a16 g16 fis16 ] | % 23
+    g8 \staffLower c8\rest \once \override Voice.Rest #'extra-offset = #'(-0.8 . 0.3 ) e,8\rest | % 24
+    \staffUpper c'4. ~ | % 25
     c16 [ a16 b16 g16 b16 d16 ] | % 26
+    \once \override Tie #'control-points = #'( ( 0.8759 . -3.6791) ( 3.3287 . -5.6062) ( 15.942 . -5.4311) ( 18.746 . -2.8907) )
     e4. ~ | % 27
     e16  [ cis16 d16 b16 d16 fis16 ] | % 28
+    \break
     g4. ( | % 29
     g16 ) [ fis16 e16 g16 fis16 e16 ] | % 30
-    fis16 [ e16 d16 c16 b16 a16 ] | % 31
+    \once \override Beam #'positions = #'(-5 . -5)
+    fis16 [ e16 d16 c16 \staffLower b16 a16 ] | % 31
     } %end repeated section
     \alternative {
-	    {g8 r8 r8 | % 32
-	    a8 r8 r8}
-	    { b4.}
+	    {g8 c8\rest c8\rest | % 32
+	    \staffUpper \extendLaissezVibrer #11 a''4.\laissezVibrer } % 33
+	    { g,4. }
     } %end alternative
 }
 
@@ -150,19 +165,19 @@ bass = \relative g, {
     b16 [ a g a b g ] | % 5
     c16 [ b a g fis e ] | % 6
     fis16 [ e fis d e fis ] | % 7
-    g16 [ e d c b a ] | % 8
-    g16 [ fis' e d c b ] | % 9
-    cis16 [ a d e fis d ] | % 10
+    g16_[ e d c b a ] | % 8
+    g16_[ fis' e d c b ] | % 9
+    cis16_[ a d e fis d ] | % 10
     g16 [ fis e fis g e ] | % 11
     a16 [ g fis g a fis ] | % 12
     b16 [ a g a b a ] | % 13
-    gis8 [ gis, ] s8 | % 14
-    a'8 [ a,, ] r8 | % 15
+    gis8_[ gis, ] g8\rest | % 14
+    a8_[ a, ] e'8\rest | % 15
     } %end of repeated section
     \alternative {
-	    {d8 [ d'16 c b a ] | % 16
-	    g fis g a b g } % 17
-	    { d8 g b | % 16
+	    {d8_[ d'16 c b a ] | % 16
+	    g_[ fis g a b g ] } % 17
+	    { d8_[ g b ] | % 16
 	    d16 cis d e fis d } %17 
     } %end of repeated alternative
   
@@ -172,20 +187,20 @@ bass = \relative g, {
     b16 [ a gis a b gis ] | % 20
     c16 [ b a b c b ] | % 21
     ais8 [ ais,8 ] r8 | % 22
-    b'8 [ b,8 ] r8 | % 23
-    e,8 [ e'16 d c b ] |  %24
+    b8_[ b,8 ] r8 | % 23
+    e8_[ e'16 d c b ] |  %24
     a16 [ c e g fis e ] | % 25
-    fis8 [ g,8 ] r8 | % 26
+    fis8_[ g,8 ] r8 | % 26
     g'8 [ a,8 ] r8 | % 27
     a'8 [ b,8 ] r8 | % 28
     b'8 [ c,8 ] r8 | % 29
-    cis8 [ cis,8 cis'8 ] | % 30
-    d8 [ d,8 d'8 ] | % 31
+    cis8_[ cis,8 cis'8 ] | % 30
+    d8_[  d,8  d'8 ] | % 31
     } %end repeated section
     \alternative {
-	    {g,8 [ g'16 fis e g ] | % 32
+	    {g,8_[ g'16 fis e g ] | % 32
 	    fis16 [ e d e fis d ]} % 33
-	    { g,8 d' g}
+	    { g,8_[ d' g ] }
 	    }
 }
 
@@ -194,12 +209,11 @@ bass = \relative g, {
 
 \score {
     \context PianoStaff <<
-        \set PianoStaff.instrumentName = "Clavier  "
         \set PianoStaff.midiInstrument = "harpsichord"
         \context Staff = "upper" { \clef "treble" \key g \major \time 3/8 << \soprano >>  }
         \context Staff = "lower"  { \clef "bass" \key g \major \time 3/8 \bass }
     >>
-    \layout{  }
+    \layout{ }
     \midi { }
 
 }


### PR DESCRIPTION
bar10: middle voice in treble "a16"-> a8
bar15: bass "a" should be octave lower
bar25: bass "b" should be octave lower
bar19: top voice "a" should be tied to the B section
bar35: top voice "a" should be tied over to the repeat
bar36: (last bar) top voice "g" should be octave lower
(Steve Shorter)
bar 1: top voice add rest
bar14: bass voice add rest
bar17: top voice "g" now tied over to the repeat
bar12: "bes" slur -> tie
bar25: third and last note top voice d->dis
bar22: middle voice g->gis
Update to 2.16.1
Adjust beam, slur, tie directions
Adjust staff positioning
(Javier Ruiz)
Close #59
