### PR TITLE
Update BWV-988 var10

### DIFF
--- a/ftp/BachJS/BWV988/bwv-988-v10/bwv-988-v10.ly
+++ b/ftp/BachJS/BWV988/bwv-988-v10/bwv-988-v10.ly
@@ -1,14 +1,12 @@
-\version "2.10.33"
+\version "2.16.1"
 
 \paper {
-    page-top-space = #0.0
-    %indent = 0.0
-    line-width = 18.0\cm
+    markup-system-spacing #'basic-distance = #12
+    system-system-spacing #'basic-distance = #22
     ragged-bottom = ##f
-    ragged-last-bottom = ##f
 }
 
-% #(set-default-paper-size "a4")
+% #(set-default-paper-size "letter")
 
 #(set-global-staff-size 19)
 
@@ -21,36 +19,46 @@
         mutopiacomposer = "BachJS"
         opus = "BWV 988"
         date = "1741"
-        mutopiainstrument = "Clavier"
+        mutopiainstrument = "Harpsichord,Clavichord"
         style = "Baroque"
         source = "Bach-Gesellschaft Edition 1853 Band 3"
         copyright = "Creative Commons Attribution-ShareAlike 3.0"
         maintainer = "Hajo Dezelski"
         maintainerEmail = "dl1sdz (at) gmail.com"
 	
- footer = "Mutopia-2008/04/21-1387"
- tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-align { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \line { \teeny www. \hspace #-1.0 MutopiaProject \hspace #-1.0 \teeny .org \hspace #0.5 } • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \line { \teeny www. \hspace #-1.0 LilyPond \hspace #-1.0 \teeny .org } by \maintainer \hspace #-1.0 . \hspace #0.5 Copyright © 2008. \hspace #0.5 Reference: \footer } } \line { \teeny \line { Licensed under the Creative Commons Attribution-ShareAlike 3.0 (Unported) License, for details see: \hspace #-0.5 \with-url #"http://creativecommons.org/licenses/by-sa/3.0" http://creativecommons.org/licenses/by-sa/3.0 } } } }
+ footer = "Mutopia-2013/02/06-1387"
+ tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-column { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \line { \concat { \teeny www. \normalsize MutopiaProject \teeny .org } \hspace #0.5 } • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \line { \concat { \teeny www. \normalsize LilyPond \teeny .org }} by \concat { \maintainer . } \hspace #0.5 Copyright © 2013. \hspace #0.5 Reference: \footer } } \line { \teeny \line { Licensed under the Creative Commons Attribution-ShareAlike 3.0 (Unported) License, for details \concat { see: \hspace #0.3 \with-url #"http://creativecommons.org/licenses/by-sa/3.0" http://creativecommons.org/licenses/by-sa/3.0 } } } } }
 }
 
 % Macros %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
-% staffUpper = {\change Staff = upper \stemDown}
-% staffLower = {\change Staff = lower \stemUp}
+ staffUpper = {\change Staff = upper \stemDown}
+ staffLower = {\change Staff = lower \stemUp}
+
+ indentRests = \override Voice.Rest #'extra-offset = #'(5.5 . 0.0 )
+ noIndentRests = \revert Voice.Rest #'extra-offset
+ ignoreClashNote = \once \override NoteColumn #'ignore-collision = ##t
+
+ nb = \noBreak
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+global = { \key g \major   \time 2/2 }
 
 sopranoOne =   \relative c'' {
     \repeat volta 2 { %begin repeated section
     \stemUp
-        r1 | % 1
-        r1 | % 2
-        r1 | % 3
-        r1 | % 4
-        r1 | % 5
-        r1 | % 6
-        r1 | % 7
-        r1 | % 8
-        g'2 ^\mordent g4. ^\prall fis16 [ g ] | % 9
+    \indentRests
+        d1\rest | % 1
+        d1\rest | % 2
+        d1\rest | % 3
+        d1\rest | % 4
+        d1\rest | % 5
+        d1\rest | % 6
+        d1\rest | % 7
+        d1\rest | % 8
+     \noIndentRests
+        g2 ^\mordent g4. ^\prallprall fis16 [ g ] | % 9
         a4 fis d fis | % 10
         b,4 e e, d' | % 11
         cis4 ^\prall b8 [ cis ] a [ b cis a ]| % 12
@@ -62,7 +70,7 @@ sopranoOne =   \relative c'' {
     } %end of repeated section
   
     \repeat volta 2 { %begin repeated section
-        fis2 ^\mordent fis4. ^\prall e16 [ fis ] | % 17
+        fis2 ^\downmordent fis4. ^\prallprall e16 [ fis ] | % 17
         g4 d b d | % 18
         c4 f f, e' | % 19
         dis4 ^\prall cis8 [ dis ] b [ cis dis b ] | % 20
@@ -72,7 +80,7 @@ sopranoOne =   \relative c'' {
         e2 ~ e8 [ d cis b ] | % 24
         a4 g'2 f8 [ e ] | % 25
         f2. e8 [ d ]|  % 26
-        e2. fis8 [ g ] | % 27
+        e2. fis!8 [ g ] | % 27
         a8 [ b g a ] fis4 a ~ | % 28
         a4 g8 [ fis ] g4 b, ~ | % 29
         b4 a8 [ b ] c2 ~ | % 30
@@ -84,47 +92,57 @@ sopranoOne =   \relative c'' {
 sopranoTwo =   \relative c'' {
     \repeat volta 2 { %begin repeated section
     \stemDown
-        r1 | % 1
-        r1 | % 2
-        r1 | % 3
-        r1 | % 4
-        r1 | % 5
-        r1 | % 6
-        r1 | % 7
-        r1 | % 8
-        r1 | % 9
-        r1 | % 10
-        r1 | % 11
-        r1 | % 12
-        a2 a4. _\prall g16 [ a ] | % 13
+    \indentRests
+        g1\rest | % 1
+        g1\rest | % 2
+        g1\rest | % 3
+        g1\rest | % 4
+        g1\rest | % 5
+        g1\rest | % 6
+        g1\rest | % 7
+        g1\rest | % 8
+        e1\rest | % 9
+        e1\rest | % 10
+        a,1\rest | % 11
+        c1\rest | % 12
+     \noIndentRests
+        a'2 a4. _\prallprall g16 [ a ] | % 13
         b4 g e g | % 14
-        e4 a a, g' | % 15
+        e4 a \staffLower \stemDown a, \staffUpper g' | % 15
         fis4 _\prall e8 [ fis ] d2 | % 16
 	
     } %end of repeated section
   
     \repeat volta 2 { %begin repeated section
+    	\indentRests
         r1 | % 17
         r1 | % 18
         r1 | % 19
         r1 | % 20
-        b'2 b4. _\prall a16 [ b ]| % 21
+        \noIndentRests
+        b'2 b4. _\prallprall a16 [ b ]| % 21
         c4 a fis a | % 22
         fis4 b b, a'| % 23
-        g4 fis8 [ g ] e2 ~| % 24
+        g4_\prall fis8 [ g ] e2 ~| % 24
         e4 r4 a2 ~| % 25
         a4 d b g | % 26
         g4 c8 [ b ] c2 (| % 27
         c2. ) c4| % 28
-        b2 r4 g4| % 29
-        e2. a8 [ g ] | % 30
+        \ignoreClashNote b2 a4\rest g4| % 29
+        <e>2. a8 [ g ] | % 30
         fis4 g ~ g fis | % 31
         g8 [ d c d ] b2| % 32
     } %end repeated section
 }
+systemBreaks = {
+	s1 \repeat unfold 5 {\nb s1}  %System1
+	s1 \repeat unfold 6 {\nb s1}  %System2
+	s1 \repeat unfold 6 {\nb s1}  %System3
+	s1 \repeat unfold 5 {\nb s1}  %System4
+	s1 \repeat unfold 5 {\nb s1}  %System5
+}
 
-
-soprano = << \sopranoOne \\ \sopranoTwo>>
+soprano = << \sopranoOne \\ \sopranoTwo \\ \systemBreaks >>
 
 
 %%
@@ -133,40 +151,46 @@ soprano = << \sopranoOne \\ \sopranoTwo>>
 
 bassOne =   \relative d' {
     \repeat volta 2 { %begin repeated section
-    \stemUp \clef "bass" 
-        r1 | % 1
-        r1 | % 2
-        r1 | % 3
-        r1 | % 4
-		d2 ^\mordent d4. ^\prall c16 [ d ] | % 5
+    \stemUp \clef "bass"
+    \indentRests
+        e1\rest | % 1
+        e1\rest | % 2
+        e1\rest | % 3
+        e1\rest | % 4
+     \noIndentRests
+	d2 ^\mordent d4. ^\prallprall c16 [ d ] | % 5
         e4 c a c | % 6
         a4 d d, c' | % 7
         b4 ^\prall a8 [ b ] g [ b a c ] | % 8
         b8 [ a ] b4 e2 ~ | % 9
         e4 a, d2 ~ | % 10
-        d4 b e2 | % 11
-        e4 d cis e | % 12
-        a,8 [ b a g ] fis2 | % 13
+        d4 b \staffUpper e2_~ | % 11
+        e4 \staffLower d cis \staffUpper e | % 12
+        \staffLower a,8 [ b a g ] fis2 | % 13
         g2 r2 | % 14
-        r4 e4 a2 ~ | % 15
+        r4 e4 \stemUp a2 ~ | % 15
         a8 [ a g a ] fis2 | % 16	
     } %end of repeated section
   
     \repeat volta 2 { %begin repeated section
-        r1 | % 17
-        r1 | % 18
-        r1 | % 19
-        r1 | % 20
-        r1 | % 21
-        r1 | % 22
-        r1 | % 23
-        r1 | % 24
-        r1 | % 25
-        r1 | % 26
-        r1 | % 27
-        r1 | % 28
-        d'2 d4. ^\prall c16 [ d ] | % 29
-        e4 c a c | % 30
+        \indentRests
+    	d'1\rest | % 17
+        d1\rest | % 18
+        d1\rest | % 19
+        d1\rest | % 20
+        d1\rest | % 21
+        d1\rest | % 22
+        d1\rest | % 23
+        d1\rest | % 24
+        \override Voice.Rest #'extra-offset = #'(2.8 . 0.0 )
+        d1\rest | % 25
+        \indentRests
+        d1\rest | % 26
+        d1\rest | % 27
+        d1\rest | % 28
+        \noIndentRests \staffUpper
+        d2 d4. _\prallprall c16 [ d ] | % 29
+        \staffLower <e>4 c a c | % 30
         a4 d d, c' | % 31
         b4 ^\prall a8 [ b ] g2 | % 32 
     } %end repeated section
@@ -175,7 +199,7 @@ bassOne =   \relative d' {
 bassTwo =   \relative c'' {
     \repeat volta 2 { %begin repeated section
     \stemDown
-        g,2 ^\mordent g4. ^\prall fis16 [ g ] | % 1
+        g,2^\mordent g4. ^\prallprall fis16 [ g ] | % 1
         a4 fis4 d fis | % 2
         e4 a a, g' | % 3
         fis4 ^\prall e8 [ fis ] d [ e c d ] | % 4
@@ -195,16 +219,16 @@ bassTwo =   \relative c'' {
   
     \repeat volta 2 { %begin repeated section
         d8 [ e fis g ] a4 c, | % 17
-        b8 [ d e fis ] g [ a ] b4 ~ | % 18
-        b4 a8 [ gis8 ] a2 ~ | % 19
+        b8 [ d e fis ] g [ a ] b4 ^~ | % 18
+        b4 a8 [ gis8 ] a2 ^~ | % 19
         a4 fis b a | % 20
         g8 [ a b a ] g [ fis g e ] | % 21
         a8 [ b c b ] a [ g a fis ] | % 22
         b8 [ a g a ] b [ a b b, ] | % 23
-        e8 [ b a b ] g [ fis g e ] | % 24
-        cis'2 cis4. _\prall b16 [ cis ] | % 25
+        e8 ^[ b a b ] g ^[ fis g e ] | % 24
+        \stemUp cis'2 cis4.^\prallprall b16 [ cis ] | % 25
         d4 b g b | % 26
-        c4 e a, g' | % 27
+        c4 e a, \stemDown g' | % 27
         fis4 e8 [ fis ] d [ e fis d ] | % 28
         g4 a b g | % 29
         c,2 r4 a'4 | % 30
@@ -217,16 +241,14 @@ bassTwo =   \relative c'' {
 bass = << \bassOne \\ \bassTwo>>
 
 
-%% Merge score - Piano staff in key of G Major, 12/8 time.
+%% Merge score - Piano staff
 
 \score {
     \context PianoStaff <<
-        \set PianoStaff.instrumentName = "Clavier  "
         \set PianoStaff.midiInstrument = "harpsichord"
-        \context Staff = "upper" { \clef "treble" \key g \major \time 4/4 \soprano  }
-        \context Staff = "lower"  { \clef "bass" \key g \major \time 4/4 \bass }
+        \context Staff = "upper" { \clef "treble" \global \soprano  }
+        \context Staff = "lower"  { \clef "bass" \global \bass }
     >>
-    \layout{  }
+    \layout{ }
     \midi { }
-
 }


### PR DESCRIPTION
\time 4/4->2/2
bar 11-12: 3rd voice (is now in treble clef for 2 notes) "e2" should be tied over
bar 26-27: 2nd voice "g" should be tied over
(Steve Shorter)
Bar 11-12: set "e"s to the upper staff as shown in source
(Felix Janda)
Update to v2.16.1
Adjust rest positions, tie direction
Bar1: bass: second note prall->prallprall
Bar5: bass: top voice 2nd note prall-> prallprall
Bar9: treble: 1st voice 2nd note prall-> prallprall
Bar13: treble 2nd voice 2nd note prall-> prallprall
Bar15: treble low "a" to lower staff
Bar17: treble \mordent->\upmodent
Bar21: treble \prall->\prallprall
Bar24: treble 2nd voice 1st 'g' add prall
Bar25: prall->prallprall
Bar29: prall->prallprall
(Javier Ruiz-Alma)

Close #62
