### PR TITLE
Update Bach BWV-988 var16

### DIFF
--- a/ftp/BachJS/BWV988/bwv-988-v16/bwv-988-v16.ly
+++ b/ftp/BachJS/BWV988/bwv-988-v16/bwv-988-v16.ly
@@ -25,7 +25,7 @@
         mutopiacomposer = "BachJS"
         opus = "BWV 988"
         date = "1741"
-        mutopiainstrument = "Clavier"
+        mutopiainstrument = "Harpsichord,Clavichord"
         style = "Baroque"
         source = "Bach-Gesellschaft Edition 1853 Band 3"
 		comment = "Kollidierende Notenspalten ignorieren."
@@ -431,7 +431,6 @@ bass = << \bassOne \\ \bassTwo \\ \breaks >>
 
 \score {
     \context PianoStaff <<
-        \set PianoStaff.instrumentName = "Clavier  "
         \set PianoStaff.midiInstrument = "harpsichord"
         \new Staff = "upper" \with { \consists "Span_arpeggio_engraver" }
 	        { \clef treble \key g \major \time 2/2 \soprano  }


### PR DESCRIPTION
\time 4/4->2/2
bar5: treble clef, ornament prallprall->prallmordent
bar15: add turn
bar18: add turn (Javier Ruiz-Alma: no turn in Gesellschaft, but noted on Nuremberg)
bar48: incorrect b in treble clef, should be octave lower in the bass
bar9:  bass clef, first 2 beats split beam
bar32: treble clef, lower voice, last "g"->"gis"
bar32: treble clef upper voice first "d"->"e"
(Steve Shorter)
Update to v2.16.1
Rest, slur, tie alignments
bar 6: bass 1st "c" add prallmordent
bar 7: treble 1st beat add arpeggio
last bar: add termination
(Javier Ruiz-Alma)
close #65
