### PR TITLE
Update Bach BWV 988 v28

### DIFF
--- a/ftp/BachJS/BWV988/bwv-988-v28/bwv-988-v28.ly
+++ b/ftp/BachJS/BWV988/bwv-988-v28/bwv-988-v28.ly
@@ -1,16 +1,18 @@
-\version "2.11.44"
+\version "2.16.1"
 
 \paper {
-    page-top-space = #0.0
-    %indent = 0.0
+    top-markup-spacing  #'basic-distance = 6\mm
+    markup-system-spacing #'basic-distance = #15
+    system-system-spacing #'basic-distance = #23
+    top-system-spacing #'basic-distance = #13
     line-width = 18.0\cm
-    ragged-bottom = ##f
-    ragged-last-bottom = ##f
+    ragged-bottom = ##t
+    ragged-last-bottom = ##t
 }
 
-% #(set-default-paper-size "a4")
+ #(set-default-paper-size "a4")
 
-#(set-global-staff-size 19)
+#(set-global-staff-size 18)
 
 \header {
         title = "Clavierübung Vierter Teil Aria mit 30 Veränderungen"
@@ -21,17 +23,24 @@
         mutopiacomposer = "BachJS"
         opus = "BWV 988"
         date = "1741"
-        mutopiainstrument = "Clavier"
+        mutopiainstrument = "Harpsichord,Clavichord"
         style = "Baroque"
         source = "Bach-Gesellschaft Edition 1853 Band 3"
         copyright = "Creative Commons Attribution-ShareAlike 3.0"
         maintainer = "Hajo Dezelski"
         maintainerEmail = "dl1sdz (at) gmail.com"
 	
- footer = "Mutopia-2008/05/18-1420"
- tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-align { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \line { \teeny www. \hspace #-1.0 MutopiaProject \hspace #-1.0 \teeny .org \hspace #0.5 } • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \line { \teeny www. \hspace #-1.0 LilyPond \hspace #-1.0 \teeny .org } by \maintainer \hspace #-1.0 . \hspace #0.5 Copyright © 2008. \hspace #0.5 Reference: \footer } } \line { \teeny \line { Licensed under the Creative Commons Attribution-ShareAlike 3.0 (Unported) License, for details see: \hspace #-0.5 \with-url #"http://creativecommons.org/licenses/by-sa/3.0" http://creativecommons.org/licenses/by-sa/3.0 } } } }
+ footer = "Mutopia-2013/03/06-1420"
+ tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-column { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \line { \concat { \teeny www. \normalsize MutopiaProject \teeny .org } \hspace #0.5 } • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \line { \concat { \teeny www. \normalsize LilyPond \teeny .org }} by \concat { \maintainer . } \hspace #0.5 Copyright © 2013. \hspace #0.5 Reference: \footer } } \line { \teeny \line { Licensed under the Creative Commons Attribution-ShareAlike 3.0 (Unported) License, for details \concat { see: \hspace #0.3 \with-url #"http://creativecommons.org/licenses/by-sa/3.0" http://creativecommons.org/licenses/by-sa/3.0 } } } } }
 }
 
+%--------MACROS
+flatBeam = \once \override Beam #'positions = #'(-0.8 . -0.8 )
+flatBeamTwo = \once \override Beam #'positions = #'( 0.3 . 0.4 )
+liftBeam = \once \override Beam #'positions = #'(-3.8 . -2.8 )
+liftBeamTwo = \once \override Beam #'positions = #'(-1.5 . -0.8 )
+shiftNote = \once \override NoteColumn #'force-hshift = #0.5
+%--------------
 
 sopranoOne =   \relative b'' {
     \repeat volta 2 { %begin repeated section
@@ -40,11 +49,11 @@ sopranoOne =   \relative b'' {
         a16 r16 r8 d16 r16 r8 fis,16 r16 r8 | % 2
         g16 r16 r8 b16 r16 r8 a16 r16 r8 | % 3
         fis16 r16 r8 cis'16 r16 r8 d16 r16 r8 | % 4
-        g,8 [ g,, ] a [ e'' ] f [ d ] | % 5
-        e8 [ a,, ] b [ fis'' ] s8 a8 | % 6
+        \stemDown g,8 [ \clef bass g,, ] \stemUp a [ \clef treble e'' ] f [ d ] | % 5
+        e8 [ \clef bass a,, ] b [ \clef treble fis'' ] s8 a8 | % 6
         b8 [ \clef "bass" a,,8 ] b [ e, ] fis r8 | % 7
-        r8 \clef "treble" c'''8 b [ a ] g [ fis ] | % 8
-        <b, d g b>16 [ g'16 fis g ] 
+        r8 \clef "treble" c'''8 b [ a ] << { g [ fis ] } \\ {s4 } \\ { s4 } \\ {  s8 \shiftNote a, } >> | % 8
+        <b d g b>16 [ g'16 fis g ] 
 		\stemDown e [ b a b ] g [ b e g ] | % 9
         a16 [ fis e fis ] d [ a g a ] fis [ a d fis ] | % 10
         g16 [ e dis e ] 
@@ -60,8 +69,8 @@ sopranoOne =   \relative b'' {
 		\stemDown d [ fis e fis ] a [ fis c a ] | % 17
         b16 [ d c d ] g [ b a b ] d [ b f d ] | % 18
         e8 [ b8 ] 
-		\stemUp c8 [ dis,8 ] e8 [ g,8 ] | % 19
-        fis8 [ e''8 ] 
+		\stemUp c8 [ dis,8 ] e8 [ \clef bass g,8 ] | % 19
+        fis8 [ \clef treble e''8 ] 
 		\stemDown dis16 [ fis e fis ] a [ fis dis fis] | % 20
         r32 g32 [ a g a g a g ] 
 		r32 g32 [ a g a g a g ] 
@@ -75,19 +84,19 @@ sopranoOne =   \relative b'' {
 		\stemDown
         e16 [ g, fis g ] b [ e dis e ] g32 [  (f e16 ) f32 ( e d16 ) ] 
 		\stemUp| % 24
-        e8 [ e,8 ] dis8 [ d8 ] cis8 [ e'8 ] | % 25
-        d8 [ d,8 ] cis8 [ c8 ] b8 [ d'8 ] | % 26
+        e8 [ e,8 ] dis8 [ d8 ] \flatBeam cis8 [ \stemDown e'8 ] \stemNeutral | % 25
+        d8 [ d,8 ] cis8 [ c8 ] \flatBeam b8 [ \stemDown d'8 ] \stemUp | % 26
         r32 c32 [ d c d c d c ] 
-		r32 d32 [ c d c d c ] 
-		r32 c32 [ d c d c d c ] r32 | % 27
+		r32 c32 [ d c d c d c ] 
+		r32 c32 [ d c d c d c ]  | % 27
         r32 c32 [ d c d c d c ] 
 		r32 c32 [ d c d c d c ] 
 		r32 c32 [ d c d c d c ] | % 28
         b16 r16 r8 c16 r16 r8 d16 r16 r8 | % 29
         e,8 [ e'8 ] 
 		\stemDown f8 [ fis8 ] g8 [ gis8 ] | % 30
-        a16 [ fis, e fis ] 
-		\stemUp g [ b a b ] c [ a fis d ] | % 31
+        \flatBeamTwo a16 [ \stemUp fis, e fis ] 
+		g [ b a b ] c [ a fis d ] | % 31
         g16 [ b a b ] 
 		\stemDown d [ g fis g ] b4 | % 32
 
@@ -111,10 +120,10 @@ sopranoTwo =   \relative c' {
         r32 d32 [ e d e d e d ] 
 		r32 d32 [ e d e d e d ] 
 		r32 d32 [ e d e d e d ]  | % 4
-		s1*3/4 | % 5
+		s2 s8 b | % 5
         c8 s8*3 g'8  [ cis,8 ]  | % 6
 		d8 [ \clef "bass"   fis,,8 ]  g8 [cis,] d [d,] | % 7
-        g8 [ \clef "treble" e'''8 ] d [ c ] b [ < a c >8] | % 8
+		g8 [ \clef "treble" e'''8 ] d [ c ] b [  c ]  | % 8
         b16 s16 s8 s2 | % 9
 		s1*3/4 | % 10
 		s1*3/4 | % 11
@@ -170,25 +179,25 @@ bassOne = \relative g {
         e,8 [ g'8 ] fis8 [ g,8 ] a8 [ e'8 ] | % 3
         d,8 [ fis'8 ] e8 [ g,8 ] fis8 [ c'8 ] \clef "treble" | % 4
 		\stemUp
-        r32 g'32 [ a g a g a g ] 
-		r32 g32 [ a g a g a g ] 
-		r32 g32 [ a g a g a g ] | % 5
-        r32 g32 [ a g a g a g ] 
-		r32 g32 [ a g a g a g ] 
-		r32 g32 [ a g a g a g ] | % 6
-        r32 g32 [ a g a g a g ] 
-		r32 g32 [ a g a g a g ] 
-		r32 fis32 [ g fis g fis g fis ] | % 7
-        r32 g32 [ a g a g a g ] 
-		g32 [ a g a g a g ] 
-		r32 g32 [ a g a g a ] s16 | % 8
+        b'32\rest g32 [ a g a g a g ] 
+		b32\rest g32 [ a g a g a g ] 
+		b32\rest g32 [ a g a g a g ] | % 5
+        b32\rest g32 [ a g a g a g ] 
+		b32\rest g32 [ a g a g a g ] 
+		b32\rest g32 [ a g a g a g ] | % 6
+        b32\rest g32 [ a g a g a g ] 
+		d'32\rest g,32 [ a g a g a g ] 
+		b32\rest fis32 [ g fis g fis g fis ] | % 7
+        b32\rest g32 [ a g a g a g ] 
+		b32\rest g32 [ a g a g a g ] 
+		b32\rest g32 [ a g a g a g ]  | % 8
         g,16 [ b a b ] e [ g fis g ] b [ g e cis ] | % 9
         fis,16 [ a g a ] d [ fis e fis ] a [ fis d b ] | % 10
         e,16 [ g fis g ] b [ e dis e ] g [ e b g ] | % 11
         a16 [ e' d e ] g [ a g a ] g [ e cis a ] \clef "bass" | % 12
         r32 fis32 [ g fis g fis g fis ] 
 		r32 fis32 [ g fis g fis g fis ] 
-		r32 fis32 [ g fis g fis g ] r32 | % 13
+		r32 fis32 [ g fis g fis g fis ]  | % 13
         r32 fis32 [ g fis g fis g fis ] 
 		r32 fis32 [ g fis g fis g fis ] 
 		r32 fis32 [ g fis g fis g fis ] | % 14
@@ -199,29 +208,29 @@ bassOne = \relative g {
 
     } %end of repeated section
   	    \repeat volta 2 { %begin repeated section
-        d'8 [ e,8 ] fis8 [ c'8 ] d,8 [ \clef "treble" fis'8 ] | % 17
+        \stemDown d'8 [ e,8 ] fis8 [ c'8 ] \stemNeutral d,8 [ \clef "treble" fis'8 ] | % 17
         g8 [ a,8 ] b8 [ f'8 ] g,8 [ d''8 ] | % 18
         c16 [ g f g ] e [ c b c ] a [ c e a ]  | % 19
         dis,16 [b ais b ] \clef "bass" fis16 [ dis cis dis ] b [ dis fis a ] \clef "treble" | % 20
-        r32 e'32 [ fis e fis e fis e ] 
-		r32 e32 [ fis e fis e fis e ] 
-		e32 [ fis e fis e fis ] s16 | % 21
-        r32 e32 [ fis e fis e fis e ] 
-		r32 e32 [ fis e fis e fis e ] 
-		r32 e32 [ fis e fis e fis e ] | % 22
-        r32 e32 [ fis e fis e fis e ] 
-		r32 e32 [ fis e fis e fis e ] 
-		r32 dis32 [ e dis e dis e dis ] | % 23
+        b'32\rest e,32 [ fis e fis e fis e ] 
+		b'32\rest e,32 [ fis e fis e fis e ] 
+		b'32\rest e,32 [ fis e fis e fis e ] | % 21
+        b'32\rest e,32 [ fis e fis e fis e ] 
+		b'32\rest e,32 [ fis e fis e fis e ] 
+		b'32\rest e,32 [ fis e fis e fis e ] | % 22
+        b'32\rest e,32 [ fis e fis e fis e ] 
+		b'32\rest e,32 [ fis e fis e fis e ] 
+		b'32\rest dis,32 [ e dis e dis e dis ] | % 23
         e,16 [ e' dis e ] b [ g fis g ] e [ g b d ] | % 24
-        r32 g32 [ a g a g a g ] 
-		r32 g32 [ a g a g a g ] 
-		r32 g32 [ a g a g ] r16 | % 25
-        r32 g32 [ a g a g a g ] 
-		r32 g32 [ a g a g a g ] 
-		g32 [ a g a g a ] s16 | % 26
-        a,8 [ e''8 ] 
+        b'32\rest g32 [ a g a g a g ] 
+		b32\rest g32 [ a g a g a g ] 
+		b32\rest g32 [ a g a g a g ] | % 25
+        b32\rest g32 [ a g a g a g ] 
+		b32\rest g32 [ a g a g a g ] 
+		b32\rest g32 [ a g a g a g ] | % 26
+        \flatBeam a,8 [ \stemDown e''8 ] \stemNeutral 
 		\stemDown f8 [ fis8 ] g8 [  \clef "bass" fis,,8 ]| % 27
-        d8 [ \clef "treble" fis''8 ] g8 [ gis8 ] a8 [ \clef "bass" d,,8 ] 
+        \liftBeam d8 [ \clef "treble" fis''8 ] g8 [ gis8 ] \liftBeamTwo a8 [ \clef "bass" d,,8 ] 
 		\stemUp | % 28
         g,8 [ g,8 ] as8 [ a8 ] bes8 [ b8 ] | % 29
         r32 c'32 [ d c d c d c ] 
@@ -271,20 +280,33 @@ bassTwo = \relative c' {
 		s1*3/4 | % 27
         s1*3/4 | % 28
         s1*3/4 | % 29
-        c,16 r16 r8 d16 r16 r8 e16 r16 r8 | % 30
+        c,16 d16\rest d8\rest d16 d16\rest d8\rest e16 d16\rest d8\rest | % 30
 		s1*3/4 | % 31
 		s1*3/4 | % 32
  
     } %end repeated section
 }
 
-bass = << \bassOne \\ \bassTwo>>
+nb = \noBreak
+myBreaks = {
+	\repeat unfold 4 { s2. \nb s2. } %system1-4
+	\pageBreak
+	s2. \repeat unfold 3 { \nb s2. } %system5
+	\repeat unfold 2 { s2. \nb s2. } %system6-7
+	s2. \repeat unfold 3 { \nb s2. } %system8
+	s2. \nb s2.			 %system9
+	\pageBreak
+	s2. \nb s2. \nb s2.		 %system10
+	\repeat unfold 2 { s2. \nb s2. } %system11-12
+	s2. \nb s2. \nb s2.		 %system13
+}
+
+bass = << \bassOne \\ \bassTwo \\ \myBreaks >>
 
 %% Merge score - Piano staff
 
 \score {
     \context PianoStaff <<
-        \set PianoStaff.instrumentName = "Clavier  "
         \set PianoStaff.midiInstrument = "harpsichord"
         \new Staff = "upper" { \clef treble \key g \major \time 3/4 \soprano  }
         \new Staff = "lower"  { \clef bass \key g \major \time 3/4 \bass }


### PR DESCRIPTION
bar 8: bass clef lower voice add 32nd rest on beat 2, add "g32" at the end
bar13: bass clef lower voice add "f" at end of bar, remove r32
bar21: bass clef lower voice add 32nd rest on beat 3, add "e32" at the end
bar25: bass clef lower voice add "a32 g32" at the end, remove r16 at end
bar26: bass clef lower voice add rest 32nd rest on beat 3, add "g32" at the end
bar27: treble clef upper voice beat 2 add "c32", remove r32 at the end
(Steve Shorter)
Update to v2.16.1
bar 5: treble clef, add lower voice "b" eigth to end
bar 8: treble clef, last note column, split "a" to separate voice
(Javier Ruiz-Alma)
close #88
