### PR TITLE
Boismortier header consistency fix

### DIFF
--- a/ftp/BoismortierJBd/O40/Sonate1/Sonate1.ly
+++ b/ftp/BoismortierJBd/O40/Sonate1/Sonate1.ly
@@ -9,8 +9,8 @@
   mutopiacomposer = "BoismortierJBd"
   composer = "Joseph Bodin de Boismortier"
   opus = "40"
-  mutopiatitle = "Six sonates pour deux Baßons, Violoncelles, ou
-  Violes"
+  %mutopiatitle = "Six sonates pour deux Baßons, Violoncelles, ou Violes"
+  mutopiatitle = "Sonata I."
   mutopiainstrument = "2 Bassoons"
   source = "facsimile of first printing 1732"
   style = "Baroque"

--- a/ftp/BoismortierJBd/O40/Sonate2/Sonate2.ly
+++ b/ftp/BoismortierJBd/O40/Sonate2/Sonate2.ly
@@ -12,8 +12,8 @@
   mutopiacomposer = "BoismortierJBd"
   composer = "Joseph Bodin de Boismortier"
   opus = "op. 40 No. 2"
- mutopiatitle = "Six sonates pour deux Baßons, Violoncelles, ou
-  Violes"
+  %mutopiatitle = "Six sonates pour deux Baßons, Violoncelles, ou Violes"
+  mutopiatitle = "Sonata II."
   mutopiainstrument = "2 Bassoons"
   source = "facsimile of first printing 1732"
   style = "Baroque"
@@ -387,7 +387,7 @@
 		f2
 	  }
 	  \repeat volta 2 {
-		\partial 2 a4 b|
+		a4 b|
 		c4 a b8 d c b|
 		a4 f g a|
 %		c2-+ f4 b,|
@@ -432,7 +432,7 @@
 		 f,2
 	   }
 	  \repeat volta 2 {
-		\partial 2 r2|
+		r2|
 		r2 d'4 es|
 		f4 d es8 g f es|
 		d4 b c d|

--- a/ftp/BoismortierJBd/O40/Sonate3/Sonate3.ly
+++ b/ftp/BoismortierJBd/O40/Sonate3/Sonate3.ly
@@ -14,8 +14,8 @@
   mutopiacomposer = "BoismortierJBd"
   composer = "Joseph Bodin de Boismortier"
   opus = "op. 40 No. 3"
-  mutopiatitle = "Six sonates pour deux Baßons, Violoncelles, ou
-  Violes"
+  %mutopiatitle = "Six sonates pour deux Baßons, Violoncelles, ou Violes"
+  mutopiatitle = "Sonata III."
   mutopiainstrument = "2 Bassoons"
   source = "facsimile of first printing 1732"
   style = "Baroque"
@@ -369,7 +369,7 @@ wdheins = \relative c' {
 		h4. ~ h4
 	  }
 	  \repeat volta 2 {
-		\partial 8 d8|
+		d8|
 		h16 c d8 g, fis d fis|
 		g4. a-+|
 		h8\( c\) d d\( c\) h|
@@ -412,7 +412,7 @@ wdheins = \relative c' {
 		h4.~h4
 	   }
 	  \repeat volta 2 {
-		\partial 8 r8|
+		r8|
 		r4 r8 r4 d'8|
 		h16 c d8 g, fis d fis|
 		g8\( a\) h h\( a\) g|

--- a/ftp/BoismortierJBd/O40/Sonate4/Sonate4.ly
+++ b/ftp/BoismortierJBd/O40/Sonate4/Sonate4.ly
@@ -12,8 +12,8 @@
   mutopiacomposer = "BoismortierJBd"
   composer = "Joseph Bodin de Boismortier"
   opus = "op. 40 No. 4"
-  mutopiatitle = "Six sonates pour deux Baßons, Violoncelles, ou
-  Violes"
+  %mutopiatitle = "Six sonates pour deux Baßons, Violoncelles, ou Violes"
+  mutopiatitle = "Sonata IV."
   mutopiainstrument = "2 Bassoons"
   source = "facsimile of first printing 1732"
   style = "Baroque"
@@ -184,7 +184,7 @@
 	  c2
 	}
 	\repeat volta 2{
-	  \partial 1 e4 f4. e8 d4|
+	  e4 f4. e8 d4|
 	  e4 cis d e,8 b' a4 cis|
 	  d4. e8 f4 h,4. c8 d4|
 	  g,2 g4 g4. a8 f4|
@@ -204,7 +204,7 @@
 	  c,2
 	}
 	\repeat volta 2{
-	  \partial 1 cis''4 d4. cis8 b4|
+	  cis''4 d4. cis8 b4|
 	  a4. g8 f4 g a a,|
 	  d4 f d g2 f4|
 	  %Zeile 6


### PR DESCRIPTION
Fix mutopiatitle to match piece name
Fix partial warning in Sonate 2, 3, & 4

I started to create a simple issue to discuss these edits but decided I would make the changes and pull request and it can be rejected if considered inappropriate.

The problem is that the `mutopiatitle` field in all 4 pieces had an embedded carriage return which caused them to be ignored in our compilation software. What got picked up for the title was the value in the `piece` field. My change makes the piece match our RDF, and thus other page output, so this update can be made without a recompilation. (The partial fixes remove the warnings but the pdf output matches the original.)

However, it may be that the author wanted the title shown in Mutopia to be the original `mutopiatitle` so I have corrected the format of the line and then commented it out.

Again, if this is not correct simply reject the request and make the appropriate repair.
