### PR TITLE
gitignore: add .patch and .midi extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /*.html
 /*.rss
+*.patch

--- a/ftp/.gitignore
+++ b/ftp/.gitignore
@@ -1,4 +1,5 @@
 *.mid
+*.midi
 *.pdf
 *.ps.gz
 *-preview.png


### PR DESCRIPTION
- linux uses the .midi extension
- .patch files generated by git may be useful in some cases