### PR TITLE
Sanz preludio

### DIFF
--- a/ftp/SanzG/sanz-1/sanz-1.ly
+++ b/ftp/SanzG/sanz-1/sanz-1.ly
@@ -18,6 +18,15 @@
   tagline = ##f
 }
 
+\paper {
+  top-margin = 8\mm
+  top-markup-spacing.basic-distance = #6
+  markup-system-spacing #'padding = #5
+  markup-markup-spacing #'padding = #1.2
+  last-bottom-spacing.basic-distance = #12
+  top-system-spacing.basic-distance = #12
+  bottom-margin = 10\mm
+}
 
 global =  {
   \time 2/2


### PR DESCRIPTION
I see 3 differences when comparing the new output with the old PDF:
1. dotted notes merged with \mergeDifferentlyDottedOn now have the dot, which I think it's correct
2. the slurs in the original are close to the note head, while now are close to the stems. It's the default behaviour of LilyPond and I heard that it's the right one. What do you think about it?
3. the vertical space is now more compressed, but unfortunately I don't think that there's any option to control this in the \layout block (I assume I can't/shouldn't use a \paper block).
