### PR TITLE
issue #458: Oaken bucket

### DIFF
--- a/ftp/KiallmarkGF/oakbucket/oakbucket.ly
+++ b/ftp/KiallmarkGF/oakbucket/oakbucket.ly
@@ -27,6 +27,7 @@
   last-bottom-spacing.basic-distance = #12
   top-system-spacing.basic-distance = #12
   bottom-margin = 10\mm
+  line-width = 165\mm
 }
 
 melody = \relative c'' {
@@ -165,7 +166,6 @@ lower = \relative c {
 
   >>
   \layout {
-    line-width = 165\mm
     indent = 8\mm
     #(layout-set-staff-size 16)
   }


### PR DESCRIPTION
I usually prefer using the available options in \layout, but I realized that automatic center of systems when line-width is set works only if line-width is in a \paper block:
http://lists.gnu.org/archive/html/bug-lilypond/2014-09/msg00021.html

Output looks ok to me.

Close #458
