### PR TITLE
Update piano solo template

### DIFF
--- a/contrib/templates/mutopia-templ-keyboard-solo.ly
+++ b/contrib/templates/mutopia-templ-keyboard-solo.ly
@@ -23,7 +23,7 @@
     top-markup-spacing.basic-distance = #6         %-dist. from bottom of top margin to the first markup/title
     markup-system-spacing.basic-distance = #5      %-dist. from header/title to first system
     top-system-spacing.basic-distance = #12        %-dist. from top margin to system in pages with no titles
-    last-bottom-spacing.basic-distance = #12       %-pads music from copyright block
+    %last-bottom-spacing.basic-distance = #12      %-pads music from copyright block on one-page scores only
     ragged-bottom = ##f
     ragged-last-bottom = ##f
 }


### PR DESCRIPTION
Commented out `last-bottom-spacing` paper setting.
The influence of this setting (since 728d57e1383b8633713cfc305ee8973343d2dd65) is limited to single-page scores.

