### PR TITLE
Initial release of Pachelbel's Canon_per_3_Violini_e_Basso

### DIFF
--- a/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/Makefile
+++ b/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/Makefile
@@ -1,0 +1,32 @@
+LILYPOND=lilypond
+COMMON_FILES = violin_common.ily header.ily  midi.ily paper.ily
+
+all: canon_per_3_violini_e_basso violin_one_part violin_two_part violin_three_part violoncellopart
+
+canon_per_3_violini_e_basso: canon_per_3_violini_e_basso.pdf
+
+violin_one_part: violin_one_part.pdf
+
+violin_two_part: violin_two_part.pdf
+
+violin_three_part: violin_three_part.pdf
+
+violoncellopart: violoncellopart.pdf
+
+canon_per_3_violini_e_basso.pdf: canon_per_3_violini_e_basso.ly $(COMMON_FILES) violin_one.ily violin_two.ily violin_three.ily violoncello.ily 
+	$(LILYPOND) canon_per_3_violini_e_basso.ly
+
+violin_one_part.pdf: violin_one_part.ly violin_one.ily $(COMMON_FILES)
+	$(LILYPOND) violin_one_part.ly
+
+violin_two_part.pdf: violin_two_part.ly violin_two.ily $(COMMON_FILES)
+	$(LILYPOND) violin_two_part.ly
+
+violin_three_part.pdf: violin_three_part.ly violin_three.ily $(COMMON_FILES)
+	$(LILYPOND) violin_three_part.ly
+
+violoncellopart.pdf: violoncellopart.ly violoncello.ily $(COMMON_FILES)
+	$(LILYPOND) violoncellopart.ly
+
+clean:
+	rm -f *.aux *.log *.pdf *.midi *.~?~ 

--- a/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/canon_per_3_violini_e_basso.ly
+++ b/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/canon_per_3_violini_e_basso.ly
@@ -1,0 +1,57 @@
+\version "2.18.2"
+
+#(set-global-staff-size 18)
+
+\include "header.ily"
+
+\include "violin_one.ily"
+\include "violin_two.ily"
+\include "violin_three.ily"
+\include "violoncello.ily"
+
+\score {
+  <<
+    \context StaffGroup = strings <<
+      \new Staff = violinI \with {
+        midiInstrument = #"violin"
+        instrumentName = \markup {
+          \center-column { "Violin I"  }
+        }
+   %     shortInstrumentName = #"Vl.I"
+      }
+      \violinone
+
+      \new Staff = violinII \with {
+        midiInstrument = #"violin"
+        instrumentName = \markup {
+          \center-column {"Violin II" }
+        }
+  %      shortInstrumentName = #"Vl.II"
+      }
+      \violintwo
+      
+      \new Staff = violinIII \with {
+        midiInstrument = #"violin"
+        instrumentName = \markup {
+          \center-column { "Violin III" }
+        }
+%        shortInstrumentName = #"Vl.III"
+      }
+      \violinthree 
+
+      \context Staff = violoncello \with {
+        midiInstrument = #"cello"
+        instrumentName = \markup {
+          \center-column { "Violoncello" }
+        }
+ %       shortInstrumentName = #"Vc."
+      } <<
+        \clef "bass"
+	\violoncello 
+      >>
+    >>
+>>
+
+\include "paper.ily"
+\include "midi.ily"
+}

--- a/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/header.ily
+++ b/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/header.ily
@@ -1,0 +1,26 @@
+\version "2.18.2"
+
+\header {
+ mutopiatitle = "Canon per 3 Violini e Basso"
+ mutopiacomposer = "PachelbelJ"
+ mutopiainstrument = "3 Violins, Cello"
+ date = "1694"
+ source = "IMSLP"
+ style = "Baroque"
+ license = "Creative Commons Attribution 4.0"
+ maintainer = "Michael Fischer v. Mollard"
+ maintainerEmail = "konfusator@gmail.com"
+ lastupdated = "XXXX/XX/XX"
+ title = " Canon per 3 Violini e Basso"
+ composer = "Johann Pachelbel (1653-1706)"
+
+ footer = "Mutopia-2015/XX/XX-XXX"
+ copyright = \markup { \override #'(baseline-skip . 0 ) \right-column { \sans \bold \with-url #"http://www.MutopiaProject.org" { \abs-fontsize #9  "Mutopia " \concat { \abs-fontsize #12 \with-color #white \char ##x01C0 \abs-fontsize #9 "Project " } } } \override #'(baseline-skip . 0 ) \center-column { \abs-fontsize #11.9 \with-color #grey \bold { \char ##x01C0 \char ##x01C0 } } \override #'(baseline-skip . 0 ) \column { \abs-fontsize #8 \sans \concat { " Typeset using " \with-url #"http://www.lilypond.org" "LilyPond " \char ##x00A9 " " 2015 " by " \maintainer " " \char ##x2014 " " \footer } \concat { \concat { \abs-fontsize #8 \sans{ " " \with-url #"http://creativecommons.org/licenses/by-sa/4.0/" "Creative Commons Attribution ShareAlike 4.0 International License " \char ##x2014 " free to distribute, modify, and perform" } } \abs-fontsize #13 \with-color #white \char ##x01C0 } } }
+ tagline = ##f
+}
+
+\layout {
+  indent = 20.0 \mm
+  short-indent = 10.0 \mm
+  \pointAndClickOff
+}

--- a/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/midi.ily
+++ b/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/midi.ily
@@ -1,0 +1,3 @@
+\version "2.18.2"
+
+\midi { \tempo 4=55 }

--- a/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/paper.ily
+++ b/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/paper.ily
@@ -1,0 +1,10 @@
+\version "2.18.2"
+
+\layout { 
+
+  \context  {
+    \Score
+    \override TimeSignature.style = #'C
+    \override BarNumber.padding = #3
+  }
+}

--- a/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/violin_common.ily
+++ b/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/violin_common.ily
@@ -1,0 +1,68 @@
+\version "2.18.2"
+
+% It's a canon so I'm writing it only once 
+% The bar number checks would be for violin I
+
+violinCommon  =  \relative c'' {
+	fis4 e d cis |
+	b a b cis |
+				% \barNumberCheck #5
+	d cis b a |
+	g fis g e |
+	d8 fis a g fis d  fis e |
+	d b d a' g b a g |
+	fis d e cis' d fis a a, |
+				% \barNumberCheck #10
+	b g a fis d d' d8. cis16 |
+	d cis d d, cis a' e fis d d' cis b cis fis a b |
+	g fis e g fis e d cis b a g fis e g fis e |
+	d e fis g a e a g fis b a g a g fis e |
+	d b b' cis d cis b a g fis e b' a b a g |
+				% \barNumberCheck #15
+	fis8 fis' e4 r8 d fis 4 |
+	b a b cis |
+	d8 d, cis4 r8 b d4 |
+	d4. d8 d g e a |
+	a16 fis32 g a16fis32 g a a, b cis d e fis g fis16 d32 e fis16 fis,32 g a b a g a fis g a |
+				% \barNumberCheck #20
+	g16 b32 a g16 fis32 e fis e d e fis g a b g16 b32 a b16 cis32 d a b cis d e fis g a |
+	fis16 d32 e fis16 e32 d e cis d e fis e d cis d16 b32 cis d16 d,32 e fis g fis e fis d' cis d |
+	b16 d32 cis b16 a32 g a g fis g a b cis d b16 d32 cis d16 cis32 b cis d e d cis d b cis |
+	d8 r cis r b r d r |
+	d, r d r d r e r |
+				% \barNumberCheck #25
+	r a r a r fis r a |
+	r g r fis r g r e' |
+	fis16 fis, g fis e e' fis e d fis, d b' a a, g a |
+	b b' cis b  a a, g a  b b' a b  cis cis, b cis |
+	d d' e d  cis cis, d cis  b b'a b cis cis, fis e |
+				% \barNumberCheck #30
+	d d' e g   fis fis, a fis'   d g fis g   e a, g a |
+	fis a a a   a a a a   fis fis fis fis   fis fis a a |
+	g g g d'  d d d d   d d b b  a a e' cis |
+	a fis' fis fis   e e e e   d d d d   a' a a a |
+	b b b b   a a a a   b b b b   cis cis, cis cis |
+				% \barNumberCheck #35
+	d d,32 e fis16 d   cis cis'32 d e16 cis   b b,32 cis d16 b   cis a'32 g fis16 e |
+	d g32 fis e16 g   fis d32 e fis16 a    g b32 a g16 fis   e a32 g fis16 e |
+	fis d'32cis d16 fis,   a a32 b cis16 a   fis d'32 e fis16 d   fis fis32 e d16 cis |
+	b b32 a b16 cis   d fis32 e d16 fis   g d32 cis b16 b   a e a a |
+	a4. a8 d,4. a'8 |
+				% \barNumberCheck #40
+	g4 a4 g8 d d8. cis16 |
+	d8 d' cis4 b a |
+	d,8. e16   fis4   b   e,8. e16 |
+	fis8. fis'16   fis g fis e   d8. d16   d e d cis |
+	b4   d4   d16 c  b c   a8. a16-. |
+				% \barNumberCheck #45
+	a8. a'16   a b a g  fis8. fis16   fis g fis e |
+	d c b c   a8. a16 g8 d' cis8. cis16 |
+	d8 d4 cis b a8~ |
+	a g4 fis8~fis8. e16 e4 |
+	fis8 fis'4 e8 d d'4 c8 |
+				% \barNumberCheck #50
+	b4 d8 a b4 a |
+	a a,8. g16 fis4 fis'8. e16 |
+	d4. d8 d4 cis |
+	% end of common part - the rest is written in the violin parts
+      }

--- a/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/violin_one.ily
+++ b/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/violin_one.ily
@@ -1,0 +1,15 @@
+\version "2.18.2"
+
+\include "violin_common.ily"
+
+violinone =  \relative c'' {
+	\time 4/4
+	\key d \major
+	R1*2
+	\violinCommon
+	d8 d,  cis cis'   b b, a a' |
+	g g'   fis fis, e b' e, e' |
+	fis fis,   e e'   d d,   cis cis' |
+	b b'  a a,  g8. e'16   a,8 a |
+	a4 r r2 \bar "|."
+      }

--- a/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/violin_one_part.ly
+++ b/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/violin_one_part.ly
@@ -1,0 +1,21 @@
+\version "2.18.2"
+
+#(set-global-staff-size 20)
+
+\include "header.ily"
+\include "violin_one.ily"
+
+\score {
+  << 
+  \compressFullBarRests
+    \new Staff = violinI \with {
+      midiInstrument = #"violin"
+      instrumentName = \markup {
+        \center-column { "Violin I" }
+      }
+    }
+    \violinone
+  >>
+\include "paper.ily"
+\include "midi.ily"
+}

--- a/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/violin_three.ily
+++ b/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/violin_three.ily
@@ -1,0 +1,11 @@
+\version "2.18.2"
+
+\include "violin_common.ily"
+
+violinthree =   \relative c'' {
+	\time 4/4
+	\key d \major
+	R1*6
+	\violinCommon
+	d4 r r2 \bar "|."
+}

--- a/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/violin_three_part.ly
+++ b/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/violin_three_part.ly
@@ -1,0 +1,20 @@
+\version "2.18.2"
+
+#(set-global-staff-size 20)
+\include "header.ily"
+\include "violin_three.ily"
+
+\score {
+  << 
+  \compressFullBarRests
+    \new Staff = violinIII \with {
+      midiInstrument = #"violin"
+      instrumentName = \markup {
+        \center-column {"Violin III" }
+      }
+    }
+    \violinthree
+  >>
+\include "paper.ily"
+\include "midi.ily"
+}

--- a/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/violin_two.ily
+++ b/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/violin_two.ily
@@ -1,0 +1,15 @@
+\version "2.18.2"
+
+\include "violin_common.ily"
+
+violintwo =   \relative c'' {
+	\time 4/4
+	\key d \major
+
+	R1*4
+	\barNumberCheck #5
+	\violinCommon
+	d8 d,  cis cis'   b b, a a' |
+	g g'   fis fis, e b' e, e' |
+	fis4 r r2 \bar "|."
+      }

--- a/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/violin_two_part.ly
+++ b/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/violin_two_part.ly
@@ -1,0 +1,21 @@
+\version "2.18.2"
+
+#(set-global-staff-size 20)
+
+\include "header.ily"
+\include "violin_two.ily"
+
+\score {
+  <<
+    \compressFullBarRests
+    \new Staff = violinII \with {
+      midiInstrument = #"violin"
+      instrumentName = \markup {
+        \center-column {"Violin II" }
+      }
+    }
+    \violintwo
+  >>
+\include "paper.ily"
+\include "midi.ily"
+}

--- a/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/violoncello.ily
+++ b/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/violoncello.ily
@@ -1,0 +1,11 @@
+\version "2.18.2"
+
+violoncello = \relative c {
+	\time 4/4
+	\key d \major
+	\repeat unfold 28 {
+	  d4 a b fis |
+	  g d g a | 
+	}
+	d r 4 r 2 \bar "|."
+}

--- a/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/violoncellopart.ly
+++ b/ftp/PachelbelJ/Canon_per_3_Violini_e_Basso/Canon_per_3_Violini_e_Basso-lys/violoncellopart.ly
@@ -1,0 +1,22 @@
+\version "2.18.2"
+
+#(set-global-staff-size 20)
+
+\include "header.ily"
+\include "violoncello.ily"
+
+\score {
+    << 
+      \context Staff = violoncello \with {
+        midiInstrument = #"cello"
+        instrumentName = \markup {
+          \center-column { "Violoncello" }
+        }
+      } <<
+        \clef "bass"
+	\violoncello
+      >>
+    >>
+\include "paper.ily"
+\include "midi.ily"
+}


### PR DESCRIPTION
This is an initial release of Pachelbel's Canon for 3 violins and cello. It is based on IMSLP material. There is a „CanonInD“ in Mutopia (Mutopia-2009/09/07-1700) but that one is a highly simplified version so I decided to add the original version instead of modifying the existing version.