### PR TITLE
BWV 1043 - fix incorrect notes in third movement

### DIFF
--- a/ftp/BachJS/BWV1043/concerto-in-d-minor/concerto-in-d-minor-lys/solo_violin1_3.ly
+++ b/ftp/BachJS/BWV1043/concerto-in-d-minor/concerto-in-d-minor-lys/solo_violin1_3.ly
@@ -57,7 +57,7 @@ soloViolinBD =  \relative c' {
     b(  c) c,8 r4 r4 |
     <e cis'>8 q q q q q |
     <d d'> q q q q q |
-    <e c'> q q q q q |
+    <e d'> q q q q q |
     <e c'> q q q q q |
     <d c'> q <d b'> q q q |
     <c b'> q <c a'> q q q |

--- a/ftp/BachJS/BWV1043/concerto-in-d-minor/concerto-in-d-minor-lys/violin2_3.ly
+++ b/ftp/BachJS/BWV1043/concerto-in-d-minor/concerto-in-d-minor-lys/violin2_3.ly
@@ -113,7 +113,7 @@ violinCD =  \relative c' {
     cis,8 r e! r r4 |
     d8 r gis, r r4 |
     e8 r c' r r4 |
-    b8 r d r r4 |
+    bes8 r d r r4 |
     c8 r e r r4 |
     d8 r r a16 g a8 r |
     R2. |


### PR DESCRIPTION
Some notes were wrong in the lilypond / midi files, third movement, specifically:
* C -> D in top part of solo I double stops, bar 43.
* B -> B-flat in violins II, bar 109.

Source = IMSLP#2300. http://imslp.org/wiki/Special:ReverseLookup/2300