### PR TITLE
Enter and/or standardize some header fields in some files (style and license)

### DIFF
--- a/ftp/AbtF/swallows/swallows.ly
+++ b/ftp/AbtF/swallows/swallows.ly
@@ -12,6 +12,7 @@
   instrument = "Voice and Piano"
   opus = "c. 1846"
   source = ""
+  style = "Song"
   license = "Public Domain"
   enteredby = "Stan Sanderson"
   maintainer = "Stan Sanderson"

--- a/ftp/AdamsS/bluemtns/bluemtns.ly
+++ b/ftp/AdamsS/bluemtns/bluemtns.ly
@@ -13,6 +13,7 @@
   instrument = "Voice and Piano"
   opus = ""
   source = ""
+  style = "Song"
   license = "Public Domain"
   enteredby = "Stan Sanderson"
   maintainer = "Stan Sanderson"

--- a/ftp/AscherJ/alice/alice.ly
+++ b/ftp/AscherJ/alice/alice.ly
@@ -14,6 +14,7 @@
   instrument = "Voice and Piano"
   opus = ""
   source = "Not known"
+  style = "Song"
   license = "Public Domain"
   mutopiacomposer = "AscherJ"
   mutopiastyle = "Song"

--- a/ftp/BachJS/BWV1056/arioso/arioso.ly
+++ b/ftp/BachJS/BWV1056/arioso/arioso.ly
@@ -167,6 +167,7 @@ pianolefthand = \relative c {
     maintainer = "Hermógenes Hebert Pereira Oliveira"
 
     mutopiaopus = "BWV 1056"
+    style = "Baroque"
     mutopiastyle = "Baroque"
 
  footer = "Mutopia-2014/01/19-1902"

--- a/ftp/BachJS/BWV248/Bach_BrichAn/Bach_BrichAn.ly
+++ b/ftp/BachJS/BWV248/Bach_BrichAn/Bach_BrichAn.ly
@@ -16,7 +16,7 @@
   mutopiapoet = "Johann Rist"
   mutopiaopus = "BWV 248"
   mutopiainstrument = "Choir (SATB)"
-  license = "cc-by-sa"
+  license = "Creative Commons Attribution-ShareAlike 4.0"
   date = "1734"
   lastupdated = "2014-01-12"
   % footer = "Mutopia-2014/01/00-000"

--- a/ftp/BachJS/BWV277/Bach_ChristLag/Bach_ChristLag.ly
+++ b/ftp/BachJS/BWV277/Bach_ChristLag/Bach_ChristLag.ly
@@ -16,7 +16,7 @@
   mutopiapoet = "Martin Luther"
   mutopiaopus = "BWV 277"
   mutopiainstrument = "Choir (SATB)"
-  license = "cc-by-sa"
+  license = "Creative Commons Attribution-ShareAlike 4.0"
   date = "unknown"
   lastupdated = "2015-02-23"
 

--- a/ftp/BishopHR/homeshome/homeshome.ly
+++ b/ftp/BishopHR/homeshome/homeshome.ly
@@ -11,6 +11,7 @@
   instrument = "Voice and Piano"
   date = "1852"
   source = "Not known"
+  style = "Song"
   license = "Public Domain"
   enteredby = "Stan Sanderson"
   maintainer = "Stan Sanderson"

--- a/ftp/CareyH/sally/sally.ly
+++ b/ftp/CareyH/sally/sally.ly
@@ -10,6 +10,7 @@
   instrument = "Voice and Piano"
   opus = ""
   source = ""
+  style = "Song"
   license = "Public Domain"
   enteredby = "Stan Sanderson"
   maintainer = "Stan Sanderson"

--- a/ftp/Claribel/oldsong/oldsong.ly
+++ b/ftp/Claribel/oldsong/oldsong.ly
@@ -9,6 +9,7 @@
   instrument = "Voice and Piano"
   date = "1868"
   source = "Not known"
+  style = "Song"
   license = "Public Domain"
   enteredby = "Stan Sanderson"
   maintainer = "Stan Sanderson"

--- a/ftp/DandrieuJ/Fugue_sur_l_Ave_maris_stella/Fugue_sur_l_Ave_maris_stella.ly
+++ b/ftp/DandrieuJ/Fugue_sur_l_Ave_maris_stella/Fugue_sur_l_Ave_maris_stella.ly
@@ -14,6 +14,7 @@
     opus = ""
     mutopiainstrument = "Organ"
     mutopiacomposer = "DandrieuJ"
+    style = "Baroque"
     mutopiastyle = "Baroque"
     enteredby = "Gérard Gréco"
     maintainer = "Gérard Gréco"

--- a/ftp/GloverCW/thinkhome/thinkhome.ly
+++ b/ftp/GloverCW/thinkhome/thinkhome.ly
@@ -11,6 +11,7 @@
   instrument = "Voice and Piano"
   opus = "circ. 1851"
   source = ""
+  style = "Song"
   license = "Public Domain"
   enteredby = "Stan Sanderson"
   maintainer = "Stan Sanderson"

--- a/ftp/GrignyNd/Grigny-Fugue_a_5/Grigny-Fugue_a_5.ly
+++ b/ftp/GrignyNd/Grigny-Fugue_a_5/Grigny-Fugue_a_5.ly
@@ -15,6 +15,7 @@
     enteredby = "G. Gréco"
     mutopiacomposer = "GrignyNd"
     mutopiainstrument = "Organ"
+    style = "Baroque"
     mutopiastyle = "Baroque"
     maintainer = "Gérard Gréco"
 

--- a/ftp/HandelGF/BWV351/LaRej/LaRej.ly
+++ b/ftp/HandelGF/BWV351/LaRej/LaRej.ly
@@ -17,6 +17,7 @@
   mutopiaopus = "HWV 351"
   mutopiacomposer = "HandelGF"
   mutopiainstrument = "Trumpet, Organ/Piano"
+  style = "Baroque"
   mutopiastyle = "Baroque"
   mutopiamaintainer = "Cyprien Lecourt"
 

--- a/ftp/HullahJ/fish/fish.ly
+++ b/ftp/HullahJ/fish/fish.ly
@@ -10,6 +10,7 @@
   poet = "Rev. C. Kingsley"
   instrument = "Voice and Piano"
   source = "New York: S. T. Gordon, 1856"
+  style = "Song"
   license = "Public Domain"
   enteredby = "Stan Sanderson"
   maintainer = "Stan Sanderson"

--- a/ftp/KiallmarkGF/oakbucket/oakbucket.ly
+++ b/ftp/KiallmarkGF/oakbucket/oakbucket.ly
@@ -9,6 +9,7 @@
   instrument = "Voice and Piano"
   opus = "1826"
   source = ""
+  style = "Song"
   license = "Public Domain"
   enteredby = "Stan Sanderson"
   maintainer = "Stan Sanderson"

--- a/ftp/MooreT/lrose/lrose.ly
+++ b/ftp/MooreT/lrose/lrose.ly
@@ -11,6 +11,7 @@
   instrument = "Voice and Piano"
   opus = ""
   source = "Not known"
+  style = "Song"
   license = "Public Domain"
   enteredby = "Stan Sanderson"
   maintainer = "Stan Sanderson"

--- a/ftp/MorelandC/oldshawl/oldshawl.ly
+++ b/ftp/MorelandC/oldshawl/oldshawl.ly
@@ -9,6 +9,7 @@
   instrument = "Voice and Piano"
   source = "G. W. Warren & Co., Evansville, Ind."
   date = "1885"
+  style = "Song"
   license = "Public Domain"
   enteredby = "Stan Sanderson"
   maintainer = "Stan Sanderson"

--- a/ftp/MussorgskyM/nobm/nobm.ly
+++ b/ftp/MussorgskyM/nobm/nobm.ly
@@ -15,6 +15,7 @@
 	maintainer = "Robert Clausecker"
 	maintainerEmail = "fuz@fuz.su"
 	moreInfo = "Piano arrangement by Konstantin Chernov"
+	style = "Romantic"
 	mutopiastyle = "Romantic"
 
  footer = "Mutopia-2013/12/08-1892"

--- a/ftp/RootGF/MusAirCh/MusAirCh.ly
+++ b/ftp/RootGF/MusAirCh/MusAirCh.ly
@@ -9,6 +9,7 @@
   instrument = "Voice (SATB) and Piano"
   source = "Boston: Russell and Richardson"
   date = "1857"
+  style = "Song"
   license = "Public Domain"
   enteredby = "Stan Sanderson"
   maintainer = "Stan Sanderson"

--- a/ftp/RootGF/chair/chair.ly
+++ b/ftp/RootGF/chair/chair.ly
@@ -7,6 +7,7 @@
   composer = "Geo. F. Root (1820-1895)"
   mutopiacomposer = "RootGF"
   instrument = "Voice and Piano"
+  style = "Song"
   license = "Public Domain"
   enteredby = "Stan Sanderson"
   maintainer = "Stan Sanderson"

--- a/ftp/RootGF/musicinair/musicinair.ly
+++ b/ftp/RootGF/musicinair/musicinair.ly
@@ -9,6 +9,7 @@
   instrument = "Voice and Piano"
   source = "Boston: Russell and Richardson"
   date = "1857"
+  style = "Song"
   license = "Public Domain"
   enteredby = "Stan Sanderson"
   maintainer = "Stan Sanderson"

--- a/ftp/SanzG/sanz-1/sanz-1.ly
+++ b/ftp/SanzG/sanz-1/sanz-1.ly
@@ -3,7 +3,6 @@
 
 \header {
   instrument = "Classical Guitar"
-  license = "Public Domain"
   maintainer = "Stan Sanderson"
   maintainerEmail = "physinfoman@ameritech.net"
   title = "Preludio"
@@ -11,6 +10,7 @@
   opus = "1640-1710"
   mutopiainstrument = "Guitar"
   mutopiacomposer = "SanzG"
+  style = "Classical"
   license = "Public Domain"
 
   mutopiaopus = " "

--- a/ftp/SilcherF/loreley/loreley.ly
+++ b/ftp/SilcherF/loreley/loreley.ly
@@ -17,6 +17,7 @@
   instrument = "Voice and Piano"
   opus = "circ. 1837"
   source = ""
+  style = "Song"
   license = "Public Domain"
   mutopiacomposer = "SilcherF"
   mutopiapoet = "H. Heine"

--- a/ftp/TitelouzeJ/Veni_Creator-2e_verset/Veni_Creator-2e_verset.ly
+++ b/ftp/TitelouzeJ/Veni_Creator-2e_verset/Veni_Creator-2e_verset.ly
@@ -25,6 +25,7 @@
   mutopiatitle = "Veni Creator (2e verset)"
   mutopiacomposer = "TitelouzeJ"
   mutopiainstrument = "Organ"
+  style = "Baroque"
   mutopiastyle = "Baroque"
  footer = "Mutopia-2011/09/18-551"
  tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-column { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \line { \teeny www. \hspace #-1.0 MutopiaProject \hspace #-1.0 \teeny .org \hspace #0.5 } • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \line { \teeny www. \hspace #-1.0 LilyPond \hspace #-1.0 \teeny .org } by \maintainer \hspace #-1.0 . \hspace #0.5 Copyright © 2011. \hspace #0.5 Reference: \footer } } \line { \teeny \line { Licensed under the Creative Commons Attribution-ShareAlike 3.0 (Unported) License, for details see: \hspace #-0.5 \with-url #"http://creativecommons.org/licenses/by-sa/3.0" http://creativecommons.org/licenses/by-sa/3.0 } } } }

--- a/ftp/TitelouzeJ/Veni_Creator-3e_verset/Veni_Creator-3e_verset.ly
+++ b/ftp/TitelouzeJ/Veni_Creator-3e_verset/Veni_Creator-3e_verset.ly
@@ -35,6 +35,7 @@
   mutopiatitle = "Veni Creator (3e verset)"
   mutopiacomposer = "TitelouzeJ"
   mutopiainstrument = "Organ"
+  style = "Baroque"
   mutopiastyle = "Baroque"
 
  footer = "Mutopia-2011/09/18-549"

--- a/ftp/TitelouzeJ/Veni_Creator-4e_verset/Veni_Creator-4e_verset.ly
+++ b/ftp/TitelouzeJ/Veni_Creator-4e_verset/Veni_Creator-4e_verset.ly
@@ -25,6 +25,7 @@
   mutopiatitle = "Veni Creator (4e verset)"
   mutopiacomposer = "TitelouzeJ"
   mutopiainstrument = "Organ"
+  style = "Baroque"
   mutopiastyle = "Baroque"
 
  footer = "Mutopia-2011/09/18-476"


### PR DESCRIPTION
Creates missing style fields and standardizes license fields for all single .ly file works with a version of 2.14 or greater.  I was working on this for local purposes and thought I would contribute it upstream.  Halfway through I realized that some of these have a 'mutopiastyle' and/or 'mutopialicense' that aren't listed on the website[1].  So I'm not sure what is up with those.  
[1] http://www.mutopiaproject.org/contribute.html
