### PR TITLE
Update Beethoven Op84-Overture

### DIFF
--- a/ftp/BeethovenLv/O84/Egmont/Egmont-lys/Egmont.ly
+++ b/ftp/BeethovenLv/O84/Egmont/Egmont-lys/Egmont.ly
@@ -1,4 +1,4 @@
-\version "2.4.0"
+\version "2.18.2"
 
 \include "flautoone.ly"
 \include "flautotwo.ly"
@@ -15,119 +15,135 @@
 \include "violoncello.ly"
 \include "basso.ly"
 
+
+%#(set-default-paper-size "letter")
+#(set-global-staff-size 16)
+
 \header {
   title = "Overture to Egmont - Opus 84"
   composer = "Ludwig van Beethoven"
-  mutopiatitle = "Overture to Egmont - Opus 84"
+  mutopiatitle = "Overture to Egmont"
   mutopiacomposer = "BeethovenLv"
-  mutopiapoet = "Ludwig van Beethoven"
+  mutopiatitle = "Overture to Egmont"
+  mutopiaopus = "Op.84"
   mutopiainstrument = "Orchestra"
-  date = "19th Century"
+  date = "1810"
   source = "Dover Publications - Breitkopf and Hartel"
   style = "Classical"
-  copyright = "Public Domain"
   maintainer = "Stelios Samelis"
-  lastupdated = "2005/March/29"
   
-  footer = "Mutopia-2005/04/10-547"
-  tagline = "\\raisebox{10mm}{\\parbox{188mm}{\\quad\\small\\noindent " + \footer + " \\hspace{\\stretch{1}} This music is part of the Mutopia project: \\hspace{\\stretch{1}} \\texttt{http://www.MutopiaProject.org/}\\\\ \\makebox[188mm][c]{It has been typeset and placed in the public domain by " + \maintainer + ".} \\makebox[188mm][c]{Unrestricted modification and redistribution is permitted and encouraged---copy this music and share it!}}}"
+  license = "Public Domain"
+ 
+ footer = "Mutopia-2015/09/02-547"
+ copyright =  \markup { \override #'(baseline-skip . 0 ) \right-column { \sans \bold \with-url #"http://www.MutopiaProject.org" { \abs-fontsize #9  "Mutopia " \concat { \abs-fontsize #12 \with-color #white \char ##x01C0 \abs-fontsize #9 "Project " } } } \override #'(baseline-skip . 0 ) \center-column { \abs-fontsize #11.9 \with-color #grey \bold { \char ##x01C0 \char ##x01C0 } } \override #'(baseline-skip . 0 ) \column { \abs-fontsize #8 \sans \concat { " Typeset using " \with-url #"http://www.lilypond.org" "LilyPond" " by " \maintainer " " \char ##x2014 " " \footer } \concat { \concat { \abs-fontsize #8 \sans{ " Placed in the " \with-url #"http://creativecommons.org/licenses/publicdomain" "public domain" " by the typesetter " \char ##x2014 " free to distribute, modify, and perform" } } \abs-fontsize #13 \with-color #white \char ##x01C0 } } }
+ tagline = ##f
 }
 
-#(set-global-staff-size 16)
+\paper {
+  top-margin = 15 \mm
+  ragged-bottom = ##t
+}
 
 \score {
 
   {
- \context StaffGroup <<
+ \new StaffGroup <<
 
- \context GrandStaff = "firstsystem" <<
+ \new GrandStaff = "firstsystem" <<
 
- \context Staff = "one" {
- \set Staff.midiMaximumVolume = 1
- \flautoone
-}
-
- \context Staff = "two" {
- \set Staff.midiMaximumVolume = 1
- \flautotwo
-} >>
-
- \context Staff = "three"  {
- \set Staff.midiMaximumVolume = 1
- \oboi
+ \new Staff = "one" 
+    {
+      \set Staff.midiMaximumVolume = 1
+      \flautoone
  }
 
- \context Staff = "four" {
- \transposition ais 
- \set Staff.midiMaximumVolume = 1
- \clarinetti
-}
+ \new Staff = "two" {
+   \set Staff.midiMaximumVolume = 1
+   \flautotwo
+   }
+ >>
 
- \context Staff = "five" {
- \set Staff.midiMaximumVolume = 1
- \fagotti
+ \new Staff = "three"  {
+   \set Staff.midiMaximumVolume = 1
+   \oboi
  }
 
- \context GrandStaff = "secondsystem"
+ \new Staff = "four" {
+   \transposition ais 
+   \set Staff.midiMaximumVolume = 1
+   \clarinetti
+}
+
+ \new Staff = "five" {
+   \set Staff.midiMaximumVolume = 1
+   \fagotti
+ }
+
+ \new GrandStaff = "secondsystem"
  <<
- \context Staff = "six" {
- \set Staff.midiMaximumVolume = 1
- \transposition f 
- \cornif
+ \new Staff = "six" {
+   \set Staff.midiMaximumVolume = 1
+   \transposition f 
+   \cornif
  }
 
- \context Staff = "seven"  {
- \set Staff.midiMaximumVolume = 1
- \transposition dis 
- \cornies 
+ \new Staff = "seven"  {
+   \set Staff.midiMaximumVolume = 1
+   \transposition dis 
+   \cornies 
  }
  >>
 
- \context Staff = "eight"  {
- \set Staff.midiMaximumVolume = 1
- \transposition f 
- \trombe
+ \new Staff = "eight"  {
+   \set Staff.midiMaximumVolume = 1
+   \transposition f 
+   \trombe
  }
 
- \context Staff = "nine" {
- \set Staff.midiMaximumVolume = 1
- \timpani
+ \new Staff = "nine" {
+   \set Staff.midiMaximumVolume = 1
+   \timpani
  }
 
- \context GrandStaff = "thirdsystem" <<
+ \new GrandStaff = "thirdsystem" <<
 
- \context Staff = "ten"  {
- \set Staff.midiMaximumVolume = 1
- \violinoone
+ \new Staff = "ten"  {
+   \set Staff.midiMaximumVolume = 1
+   \violinoone
  }
 
- \context Staff = "eleven"  {
- \set Staff.midiMaximumVolume = 1
- \violinotwo
- } >>
+ \new Staff = "eleven"  {
+   \set Staff.midiMaximumVolume = 1
+   \violinotwo
+ } 
+ >>
 
- \context Staff = "twelve"  {
- \set Staff.midiMaximumVolume = 1
- \viola
+ \new Staff = "twelve"  {
+   \set Staff.midiMaximumVolume = 1
+   \viola
  }
 
- \context GrandStaff = "fourthsystem" <<
+ \new GrandStaff = "fourthsystem" <<
 
- \context Staff = "thirteen"  {
- \set Staff.midiMaximumVolume = 1
- \violoncello
+ \new Staff = "thirteen"  {
+   \set Staff.midiMaximumVolume = 1
+   \violoncello
  }
 
- \context Staff = "fourteen"  {
- \set Staff.midiMaximumVolume = 1
- \basso
- } >>
+ \new Staff = "fourteen"  {
+   \set Staff.midiMaximumVolume = 1
+   \basso
+ }
+ >>
 
 >>
 }
 
- \layout {}
+ \layout { }
 
- \midi { \tempo 4 = 84 }
+ 
+  \midi {
+    \tempo 4 = 84
+    }
 
 }

--- a/ftp/BeethovenLv/O84/Egmont/Egmont-lys/basso.ly
+++ b/ftp/BeethovenLv/O84/Egmont/Egmont-lys/basso.ly
@@ -1,30 +1,31 @@
-\version "2.4.0"
+\version "2.18.2"
+
+\include "defs.ily"
 
  basso =  {
- \set Staff.instrument = "Basso"
+ \set Staff.instrumentName = "Basso"
  \set Staff.midiInstrument = "contrabass"
  \clef bass
  \key f \minor
  \time 3/2
- \override Staff.AccidentalPlacement   #'padding = #0.5
- << {  f,1.\fermata } \\
- { \override DynamicLineSpanner   #'padding = #2.0 s2\f s4 s4\> s4 s4\! } >>
- f,2\staccato_"marcato" f,2\staccato r4 r8 f,8
+ \moreAccidentalPadding
+ f,1.\fermata_\forteSforzato-\hideF
+ f,2\staccato_\txtMarcato f,2\staccato r4 r8 f,8
  ees,2\staccato aes,2\staccato r4 r8 aes,8 g,2\staccato g,2\staccato r4 r8 g8\p
  c4 r4 r2 r2 R1. R1.
- << { r2 c1 } \\ { s4 s4\< s4\!\> s4\! s2 } >> f,1.\ff
+ << { r2 c1 } \\ { s4. s8\< s4\> s8 s4.\! s4 } >> f,1.\ff
  f,2\staccato f,2\staccato r4 r8 f,8 ees,2\staccato aes,2\staccato r2 R1. R1.
  r2 r2 aes,2\p des4\pp\staccato r4 r2 r4 r8 des8 des2\staccato des2\staccato r4 r8 des8
  c2\staccato c2\staccato r4 r8 c8 a,2 a,2 r4 r8 a,8 bes,2 bes,2 r4 r8 bes,8
  g,2 g,2 r4 r8 g,8 e,2 c2 r4 r8 c8 c4 r4 r2 r4 r8 c8
  c4 r4 r2 r4 r8 c8 c4 r4 r2 r2 \bar "||"
 
- \time 3/4 R2. R2. R2. r4 r4 f,4\sfp ~ f,4 r4 r4 R2. R2. r4 r4 c4\sfp ~ c4 r4 r4 R2. R2.
- r4 r4 << { f,4( bes,2.) } \\ { s4\< s4\!\> s4 s4\! } >>
- f,4 r4 << { f,4( bes,2.) } \\ { s4\< s4\!\> s4 s4\! } >>
- f,4 r4 << { f,4( bes,2.) } \\ { s4\< s4\!\> s4 s4\! } >>
+ \time 3/4 R2._\allegro R2. R2. r4 r4 f,4\sfp ~ f,4-\hideP r4 r4 R2. R2. r4 r4 c4\sfp ~ c4 r4 r4 R2. R2.
+ r4 r4 << { f,4_( bes,2.) } \\ { \hairpinPastBarline s4-\hideP\< s4\!\> s4 s4\! } >>
+ f,4 r4 << { f,4_( bes,2.) } \\ { \hairpinPastBarline s4-\hideP\< s4\!\> s4 s4\! } >>
+ f,4 r4 << { f,4_( bes,2.) } \\ { \hairpinPastBarline s4-\hideP\< s4\!\> s4 s4\! } >>
  f,8 c8 c2 c8 c c2 c8 c c2 c8 c c2 c8 c c2
- \cresc c8 c c2 bes,8 bes, bes,2 g,8 g, g,2 e,8 e, e,2
+ c8\cresc c c2 bes,8 bes, bes,2 g,8 g, g,2 e,8 e, e,2
  c8 c c2 bes,8 bes, bes,2 g,8 g, g,2 e,8 e, e,2 c8 c c2 c8 c c2 c8 c c2 c4 r4 f,4\ff ~
  f,2. ~ f,2. ~ f,4 f,4( aes, c) r4 c4\ff ~ c2. ~ c2. ~ c4 c c f8 f f2 f8 f f2 f8 f f2
  f4 f f f,8 f, f,2 f,8 f, f,2 f,8 f, f,2 f,4 f,4 fes,
@@ -42,34 +43,35 @@
  bes,4\staccato r r R2. R2. R2. a,4\p r r R2. f,4 r r r r f4\f\staccato
  bes,4\staccato r r R2. R2. r4 r g,\p R2. r4 r g4\p\<( aes g ees c aes, g,\! ees,\> ees c\!)
  g,4\< r g( aes g f d b, g f d b,\!) R2. R2. R2. R2. R2. R2. R2. R2. R2.
- r4 r f,^\markup { \italic \large "pizz." } f, f, r r f, r r f, r r c r r c r r c r r c r
- r4 f,^\markup { \italic \large "arco" }
- \override DynamicLineSpanner   #'padding = #2.0
- f,\<( bes,2.\!\>) f,4\! r r R2. r4 r f,\<( bes,2.\!\>) f,8\! c c2
+ r4 r f,^\txtPizz f, f, r r f, r r f, r r c r r c r r c r r c r
+ r4 f,^\txtArco
+ \spaceSpannerE
+ \hairpinPastBarline f,\<( bes,2.\!\>) f,4\! r r R2.
+ r4 r \hairpinPastBarline f,\<( bes,2.\!\>) f,8\! c c2
  c8 c c2 c8 c c2 c8 c c2 c8 c c2
- \cresc c8 c c2 bes,8 bes, bes,2 g,8 g, g,2 e,8 e, e,2
+ c8\cresc c c2 bes,8 bes, bes,2 g,8 g, g,2 e,8 e, e,2
  c8 c c2 bes,8 bes, bes,2 g,8 g, g,2 e,8 e, e,2
  c8 c c2 c8 c c2 c8 c c2 c4 r f,\ff ~ f,2. ~ f,2. ~ f,4 f,( aes, c) r
  c4\ff ~ c2. ~ c2. ~ c4 c c f f, f,4\f
  bes,2\sf bes,4 f,4 r r R2. r4 r f,4 bes,2\sf bes,4 f,4 r r
  des8 des des2 des8 des des2 des8 des des2 des4 des des
  des8 des des2 des8 des des2 des8 des des2 bes,4 bes, aes,
- g,8[ ees] ees[ ees ees ees] ees ees ees ees ees ees
+ g,!8[ ees] ees[ ees ees ees] ees ees ees ees ees ees
  aes,2.\sf aes,2.\sf aes,2.\sf aes,2.\sf aes,2.\sf aes,2.\sf aes,2.\sf aes,4 r r
- des4\ff\staccato des4\staccato r8 des ges,4 ges, r R2. R2.
- des4\ff des4 r8 des ges,4 ges, r R2. R2.
- des4\ff des4 r8 des ges,4 ges, r R2. R2. R2. R2. R2. R2.
- ees2.\f aes,2.\ff des2.\sf ges,2.\sf ees,2.\sf aes,2.\sf
- des8\sf des des des des des des des des des des des des2.:8 des2.:8 des2.:8 des2.:8
+ \stemUp des4\ff\staccato des4\staccato r8 des \stemNeutral ges,4 ges, r R2. R2.
+ \stemUp des4\ff des4 r8 des \stemNeutral ges,4 ges, r R2. R2.
+ \stemUp des4\ff des4 r8 des \stemNeutral ges,4 ges, r R2. R2. R2. R2. R2. R2.
+ ees2.\f aes,2.\ff des!2.\sf ges,2.\sf ees,2.\sf aes,2.\sf
+ des8\f des des des des des des des des des des des des2.:8 des2.:8 des2.:8 des2.:8
  des2.:8\sf des2.:8\sf des2.:8\sf des2.:8\sf des2.:8\sf des2.:8\sf des4 r r
  R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2.
  f,4\ff f, r8 f, f,4 f, r8 f, e,4 e, r r4 r r8 r^\fermata
  R2. R2. R2. R2. R2. R2. R2. R2.^\fermataMarkup \bar "||"
 
- \key f \major \times 4/4
+ \key f \major \time 4/4
  c8\pp ( b,) c\staccato c\staccato c c c c c( b,) c\staccato c\staccato c c c c
  c8( b,) c\staccato c\staccato c c c c c( b,) c\staccato c\staccato c c c c
- c8_\markup { \italic \large "cresc." }( b,) c\staccato c\staccato c( b,) c\staccato c\staccato
+ c8_\txtCresc( b,) c\staccato c\staccato c( b,) c\staccato c\staccato
  c8( b,) c\staccato c\staccato c( b,) c\staccato c\staccato
  c( b,) c\staccato c\staccato c( b,) c\staccato c\staccato c8 c' c' c' c' c' c' c'
  f2\ff ~ f8( c) a,\staccato c\staccato f2\sf ~ f8( c) a,\staccato c\staccato
@@ -80,7 +82,7 @@
  f8\sf( c) a,\staccato c\staccato f\sf( c) a,\staccato c\staccato f2 d bes,4 g, c c f, r r2 R1
  R1 R1 R1 R1 f4\sf( ees d fis) g\sf( des c bes,)
  g,8\ff g, bes, c d c bes, a, bes,\sf a, bes, g, c c, c c
- f,2_\markup { \italic \large "marcato" } e, f, g, gis,4 a,2. ~ a,1 c4 c c c c c c c
+ f,2_\txtMarcato e, f, g, gis,4 a,2. ~ a,1 c4 c c c c c c c
  f,4. f,8 e,4. e,8 f,4. f,8 g,4. g,8 gis,4 a,2. ~ a,1 c4 c c c c c c c
  f2.\sf c4 f\staccato c\staccato a,\staccato c\staccato
  f2.\sf c4 f\staccato c\staccato a,\staccato c\staccato f2\staccato a\staccato

--- a/ftp/BeethovenLv/O84/Egmont/Egmont-lys/clarinetti.ly
+++ b/ftp/BeethovenLv/O84/Egmont/Egmont-lys/clarinetti.ly
@@ -1,45 +1,46 @@
-\version "2.4.0"
+\version "2.18.2"
+
+\include "defs.ily"
 
  clarinetti =  {
- \set Staff.instrument = \markup { \column < "Clarinetti" "in B" > }
+ \set Staff.instrumentName = \markup { \center-column { "Clarinetti" "in B" } }
  \set Staff.midiInstrument = "clarinet"
  \clef treble
  \key g \minor
  \time 3/2
- \override Staff.AccidentalPlacement   #'padding = #0.5
- << { <g' g''>1.\fermata } \\ { s2\f s4 s4\> s4 s4\! } >>
+ \moreAccidentalPadding
+ <g' g''>1.\fermata_\forteSforzato-\hideF
  R1. R1. R1. R1. r4^\p bes'4( a' e''2) e''4 e''2( d''4) r4 r2 R1.
  <g' g''>1.\ff
  <g' bes'>2\staccato  <g' bes'>2\staccato r4 r8  <g' bes'>8\staccato
  <a' c''>2\staccato  <bes' d''>\staccato r2
- << { g''4\rest ees''!^\p( d'' c''' bes'' aes'' g'' f'' ees''! d'' ees'' c'')
+ << { \posDynamicTxtB g''4\rest^\p \insideSlur \shapeSlurC ees''!( d'' c''' bes'' aes'' g'' f'' ees''! d'' ees'' c'')
  bes'2( aes'2. f'4) ees'4 } \\
- { e'2\rest e'2\rest r4 aes'4\p( g')\< d'' bes'\! aes'\> g' f'\! g'2( f' d') ees'4 } >>
+ { e'2\rest e'2\rest r4 aes'4\p( \hairpinNarrow g')^\< d'' \hairpinNarrow bes'\!^\> aes' g' f'\! g'2( f' d') ees'4 } >>
  r4 r2 r2 
- << { g''4\rest
- \override Slur   #'attachment = #'(stem . stem)
- g''4\pp( aes''8 g'' f'' ees'') ees''4 r4 r2 aes'2 aes' r2 aes'2 aes'
+ << { \posDynamicTxtB g''4\rest^\pp
+ g''4( aes''8 g'' f'' ees'') ees''4 r4 r2 aes'2 aes' r2 aes'2 aes'
  r2 ees' c'' } \\ { R1. R1. R1. R1. } >>
  r2 <ees' c''>2 <ees' c''>2 R1. r4
- <a' c''>4_\markup { \italic "espressivo" }( <bes' d''>8 <a' c''> <g' bes'> <fis' a'>)
+ \once \stemUp <a' c''>4_\markup { \italic "espressivo" }_( <bes' d''>8 <a' c''> <g' bes'> <fis' a'>)
  <fis' a'>4 r4 R1. R1. \bar "||"
 
  \time 3/4 R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2.
- r4 r4 << { <d' d''>4\p( <ees' c''>2. <d' bes'>4) } \\ { s4\< s4\!\> s4 s4\! s4 } >> r4 r4 R2.
- bes'4\p r4 r4 R2. R2. R2. R2.
- r4 \cresc <a' c''> r r <a' c''> r r <a' c''> r r <a' c''> r r <a' c''> r
+ r4 \posDynamicTxtA r4\p \hairpinPastBarline <d' d''>4-\hideP^(\< <ees' c''>2.\!\> <d' bes'>4)\! r4 r4 R2.
+ << { bes'4\p d''4\rest d''\rest }\\{ R2. }>> R2. R2. R2. R2.
+ r4 <a' c''>\cresc r r <a' c''> r r <a' c''> r r <a' c''> r r <a' c''> r
  r4 <a' c''> r r <a' c''> r r <a' c''> r r <a' c''> r r <a' c''> r r <a' c''> r r4 <a' c''>
- <bes' d''>4\ff( <bes' g''>2.) ~ <bes' g''> ~ <bes' g''>4 <bes' d''> <bes' d''> <a' c''> r
- <c'' fis''>4\ff( <a' c''>2.) ~ <a' c''>2. ~ <a' c''>4 <a' c''> <a' c''>
+ \doubleSlursOn <bes' d''>4\ff( <bes' g''>2.) ~  \doubleSlursOff <bes' g''> ~ <bes' g''>4 <bes' d''> <bes' d''> <a' c''> r
+ \doubleSlursOn <c'' fis''>4\ff( <a' c''>2.) ~ \doubleSlursOff <a' c''>2. ~ <a' c''>4 <a' c''> <a' c''>
  <g' bes'>4 r r <a' c''> r r <bes' d''> r r <c'' ees''> <c'' ees''> <c'' d''>
  <bes' d''>4 r r <a' c''> r r <bes' d''> r <bes' d''> <bes' ees''> <bes' ees''> <bes' e''>
  <a' c''>2.\sf <bes' d''>2.\sf <bes' c''>2.\sf <a' c''>2.\sf
  <a' c''>2.\sf <bes' d''>2.\sf <bes' c''>2.\sf <a' c''>4 r r R2. R2.
- << { f''4 c'' ees'' d''2. } \\ { a'2._\markup { \italic \large "p dolce" }( bes'2.) } >>
+ << { f''4-\hideP( c'' ees'' d''2.) } \\ { a'2.-\hideP_\pDolce( bes'2.) } >>
  R2. R2.
- << { f''4 c'' ees'' d''2. } \\ { a'2._\markup { \italic \large "p dolce" }( bes'2.) } >>
+ << { f''4( c'' ees'' d''2.) } \\ { a'2._\pDolce( bes'2.) } >>
  R2. R2.
- <b' b''>2._\markup { \italic \large "p cresc." } ~ <b' b''>2. ~
+ <b' b''>2._\pCresc ~ <b' b''>2. ~
  <b' b''>2. ~ <b' b''>2. ~ <b' b''>2. ~ <b' b''>2.
  <c'' c'''>2.\f <ees''! c'''>2.\ff <d'' d'''>4 <d'' f''>
  \slurDown <d'' bes''>4\sf( ~ <g'' bes''>4) <ees'' g''> <ees'' g''>\sf ~
@@ -49,49 +50,48 @@
  f''2 a'4\staccato f''2 bes'4\staccato f''2 } \\
  { f''2\sf a'4 f''2\sf a'4 f''2\sf bes'4 f''2\sf a'4 f''2\sf bes'4 f''2\sf } >>
  <a' a'' >4\staccato <bes' bes''>4\staccato r r
- << { f''4\rest f''\rest f''_\markup { \italic \large "dolce" }( g'' f'' d'' bes')
+ << { f''4\rest f''\rest \shapeSlurA f''_\dolce( \noBreak g'' f'' d'' \noBreak bes')
  d''\rest d''\rest } \\ { R2. R2. R2. } >> R2. R2.
- << { d''4\rest d''\rest c''4_\markup { \italic \large "dolce" }(
- ees'' c'') c''\staccato d''\staccato } \\ { R2. e'4\rest e'\rest a'\f bes'\f } >> r4 r
- << { f''4\rest f''\rest f''_\markup { \italic \large "dolce" }( g'' f'' d'' bes')
+ << { d''4\rest d''\rest c''4_\dolce(
+ ees'' c'') c''\staccato d''\staccato } \\ { R2. e'4\rest e'\rest a'\f bes' } >> r4 r
+ << { f''4\rest f''\rest f''_\dolce( g'' f'' d'' bes')
  d''\rest d''\rest } \\ { R2. R2. R2. } >> R2. R2.
- r4 r \slurUp <b' d''>_\markup { \italic \large "dolce" }( <d'' f''>
+ r4 r \slurUp <b' d''>_\dolce( <d'' f''>
  <b' d''>) <b' d''>4\f\staccato <c'' ees''>\staccato r r
- << { g''4\rest g''\rest \override Slur   #'attachment = #'(stem . stem)
- g''_\markup { \italic \large "dolce" }( aes'' g'' ees'' c'')
+ << { g''4\rest g''\rest 
+ \shapeSlurB g''_\dolce( aes'' g'' ees'' c'')
  d''\rest d''\rest } \\ { R2. R2. R2. } >> R2. R2.
- r4 r \slurUp <b' d''>_\markup { \italic \large "dolce" }( <d'' f''> <b' d''>)
+ r4 r \slurUp <b' d''>_\dolce( <d'' f''> <b' d''>)
  <b b'>4\f\staccato <c' c''> r r
- << { g''4\rest g''\rest \override Slur   #'attachment = #'(stem . stem)
- g''_\markup { \italic \large "dolce" }( aes'' g'' ees'' c'')
+ << { g''4\rest g''\rest \shapeSlurA
+ g''_\dolce( aes'' g'' ees'' c'')
  d''\rest d''\rest } \\ { R2. R2. R2. } >> r4 r <cis'' e''>\p( <e'' g''> <cis'' e''>) r
  R2. R2. R2. R2. R2. R2. R2. <g' cis''>2.\pp <g' cis''>2. <g' cis''>2. ~ <g' cis''>2.
  <a' c''!>2.\pp\staccato <a' c''>2.\staccato
- \cresc <a' c''>2. ~ <a' c''>2. ~ <a' c''>2. ~ <a' c''>2 <bes' d''>4\sfp
+ <a' c''>2._\txtCresc ~ <a' c''>2. ~ <a' c''>2. ~ <a' c''>2 <bes' d''>4\sfp
  <bes' d''>4 <bes' d''>4 r r <bes' d''>4 r r <g' bes'>4 r r <a' c''>4 r r <a' c''>4 r
  r4 <a' c''>4 r r <a' c''>4 r r <bes' d''> r R2.
- r4 r \override DynamicLineSpanner   #'padding = #1.0
- <bes d'>4\<( <c' ees'>2.\!\> <bes d'>4\!) r4 r R2. bes'4\p r r R2. R2. R2. R2.
- r4 \cresc <a' c''> r r <a' c''> r r <a' c''> r r <a' c''> r r <a' c''> r r <a' c''> r
+ r4 r \spaceSpannerC
+ \hairpinPastBarline <bes d'>4\<_( <c' ees'>2.\!\> <bes d'>4\!) r4 r R2. <<{ bes'4\p d''\rest d''\rest }\\{ R2. }>> R2. R2. R2. R2.
+ r4 <a' c''>\cresc r r <a' c''> r r <a' c''> r r <a' c''> r r <a' c''> r r <a' c''> r
  r <a' c''> r r <a' c''> r r <a' c''> r r <a' c''> r r <a' c''> r r <a' c''>
- <bes' d''>4\ff( <bes' g''>2.) ~ <bes' g''>2. ~ <bes' g''>4 <bes' d''> <bes' d''>
- <a' d''>4 r <c'' fis''>4\ff( <a' c''>2.) ~ <a' c''>2. ~ <a' c''>4 <a' c''> <a' c''>
+ \doubleSlursOn <bes' d''>4\ff( <bes' g''>2.) ~ \doubleSlursOff <bes' g''>2. ~ <bes' g''>4 <bes' d''> <bes' d''>
+ <a' d''>4 r \doubleSlursOn <c'' fis''>4\ff( <a' c''>2.) ~ \doubleSlursOff <a' c''>2. ~ <a' c''>4 <a' c''> <a' c''>
  <g' bes'>4 r r R2. r4 r
- << { \override Slur   #'attachment = #'(stem . stem)
- g''4( f''2 ees''4) d'' } \\ { bes'4\f( c''2.) bes'4 } >> r4 r
+ << { g''4( f''2 ees''4) d'' } \\ { bes'4\f( c''2.) bes'4 } >> r4 r
  R2. r4 r <bes' ees''>4\ff
- <g' ees''>4 r r <aes' ees''> r r <bes' ees''> r r <aes' c''> <c'' ees''> <aes' d''>
+ <g' ees''>4 r r <aes' ees''> r r <bes' ees''> r r <aes' c''> <c'' ees''!> <aes' d''>
  <g' ees''> r r <aes' ees''> r r <bes' ees''> r r <c'' f''> <c'' f''> <d'' f''>
  <c'' f''>2. ~ <c'' f''>2.
  <d'' f''>2.\sf <ees'' g''>2.\sf <ees'' f''>2.\sf <d'' f''>2.\sf
  <d'' f''>2.\sf <bes' ees''>2.\sf <c'' ees''>2.\sf <bes' d''>4 r r
- R2. R2. << { \override Slur   #'attachment = #'(stem . stem) bes''4( f'' aes'') g''2. }
- \\ { f'2._\markup { \italic \large "p dolce" }( g'2.) } >>
- R2. R2. << { \override Slur   #'attachment = #'(stem . stem) bes''4( f'' aes'') g''2. }
- \\ { f'2._\markup { \italic \large "p dolce" }( g'2.) } >>
- R2. R2. R2. R2. R2. R2. R2. <c'' c'''>2._\markup { \italic \large "cresc." }
- <c'' c'''>2.\f <d'' d'''>2.\ff <ees'' ees'''>4 <g' ees''> <g' ees''>\sf( <c'' ees''>)
- <aes' c''>4 <aes' c''>\sf ~ <aes' c''> <aes' c''> <aes' c''>\sf( <aes' d''>) <aes' d''> <aes' d''>
+ R2. R2. << { \shapeSlurB bes''4-\hideP( f'' aes'') g''2. }
+ \\ { f'2._\pDolce-\hideP( g'2.) } >>
+ R2. R2. << { \shapeSlurB bes''4( f'' aes'') g''2. }
+ \\ { f'2._\pDolce( g'2.) } >>
+ R2. R2. R2. R2. R2. R2. R2. <c'' c'''>2._\txtCresc
+ <c'' c'''>2.\f <d'' d'''>2.\ff <ees'' ees'''>4 <g' ees''> \doubleSlursOn <g' ees''>\sf( <c'' ees''>)
+ <aes' c''>4 <aes' c''>\sf ~ <aes' c''> <aes' c''> <aes' c''>\sf( <aes' d''>) \doubleSlursOff <aes' d''> <aes' d''>
  <g' ees''>4\f r r R2. <g' ees''>4 r r R2. <g' ees''>4 r r r <ees'' g''> <ees'' g''>
  <bes' bes''>2\sf <d' d''>4\staccato <bes' bes''>2\sf <d' d''>4\staccato
  <bes' bes''>2\sf <ees' ees''>4\staccato <bes' bes''>2\sf <d' d''>4\staccato
@@ -106,7 +106,7 @@
 
  \key g \major \time 4/4
  <fis' a'>1\pp <fis' a'> <g' bes'>1 <g' bes'>1
- <a' c''>2_\markup { \italic \large "cresc." } <a' c''>2 <g' b'!> <g' b'> <fis' a'> <g' b'>
+ <a' c''>2_\txtCresc <a' c''>2 <g' b'!> <g' b'> <fis' a'> <g' b'>
  <a' c''>8( <gis' b'>) <a' c''>\staccato <b' d''>\staccato
  <c'' e''>\staccato <d'' fis''>\staccato <e'' g''!>\staccato <fis'' a''>\staccato
  <g'' b''>2\ff ~ <g'' b''>8( <fis'' a''>) <d'' g''>\staccato <fis'' a''>\staccato
@@ -125,10 +125,10 @@
  <g'' b''>8\sf( <fis'' a''>) <d'' g''>\staccato <fis'' a''>\staccato
  << { b''8 a'' g'' fis'' g'' fis'' e'' dis'' e'' d''! c'' b' c'' a' d'' d'' g'4 } \\
  { g''8 a' g' fis' g' fis' e' dis'' e'' d''! c'' b' c'' a' d'' d'' g'4 } >> r4 r2 R1 R1 R1 R1 R1
- r8 \cresc b'16( c'') d''8\staccato r r
- \set tupletSpannerDuration = #(ly:make-moment 1 4) \times 2/3 { b'16[ c'' d''] }
+ r8-\hideF b'16(\cresc^\aDue c'') d''8\staccato r r
+ \tupletSpan 4 \tuplet 3/2 { b'16[ c'' d''] }
  e''8\staccato r
- r8 a'16([ b']) c''8\staccato r r \times 2/3 { a'16[ b' c''] } d''8[ d'']
+ r8 a'16([ b']) c''8\staccato r r \tuplet 3/2 { a'16[ b' c''] } d''8[ d'']
  <g' g''>4\ff( <f' f''> <e' e''> <gis' gis''>) <a' a''>\sf( <ees' ees''> <d' d''> <fis'! fis''!>)
  << { g'2 a' b' c'' cis''4 d''2. ~ d''1 } \\ { g'2 a' b' c'' cis''4 d''2. ~ d''1 } >>
  <a' fis''>4 <a' fis''> <a' fis''> <a' fis''> <a' fis''> <a' fis''> <a' fis''> <a' fis''>

--- a/ftp/BeethovenLv/O84/Egmont/Egmont-lys/cornies.ly
+++ b/ftp/BeethovenLv/O84/Egmont/Egmont-lys/cornies.ly
@@ -1,23 +1,23 @@
-\version "2.4.0"
+\version "2.18.2"
 
  cornies =  {
- \set Staff.instrument = "Corni in Es"
+ \set Staff.instrumentName = "Corni in Es"
  \set Staff.midiInstrument = "english horn"
  \clef treble
  \key c \major
  \time 3/2
- \override Staff.AccidentalPlacement   #'padding = #0.5
- << { <d'' d''>1.\fermata } \\ { s2\f s4 s4\> s4 s4\! } >>
+ \moreAccidentalPadding
+ <d'' d''>1.\fermata-\hideF_\forteSforzato
  R1. R1. R1. R1. R1. R1. R1. <d'' d''>1.\ff
  << { d''2\staccato d''2\staccato } \\ { d''2 d''2 } >> r4 r8 << { d''8 } \\ { d''8 } >>
  <c' c''>2\staccato <c' c''>2\staccato r2 R1. R1. R1.
- << { r2 d''\pp\staccato d''2\staccato r2 d''2\staccato d''2\staccato
+ << { r2 \posDynamicTxtC d''_\pp\staccato d''2\staccato r2 d''2\staccato d''2\staccato
  r2 c''2\staccato c''2\staccato r2 c'' c'' r2 g' d'' r2 g' g' } \\
  { R1. R1. R1. R1. R1. R1. } >>
  r2 <g' e''>2\pp <g' e''>2 R1. R1. R1. \bar "||"
 
  \time 3/4 R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2.
- << { r4 r4 d''4 ~ d''2. ~ d''4 r4 r4 } \\ { s2 s4\< s4\!\> s4 s4\! s2. } >>
+ r4 r4 \hairpinPastBarline d''4\p\< ~ d''2.\> ~ d''4\! r4 r4
  R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. r4 r4
  <d'' f''>4\ff ~ <d'' f''>2. ~ <d'' f''>2. ~ <d'' f''>4 <d'' f''> <d'' f''>
  << { e''4 } \\ { e''4 } >> r4
@@ -29,8 +29,8 @@
  << { f''4 f'' f'' } \\ { f''4 f'' f''} >>
  <c' c''>2.\sf <c' c''>2.\sf <c' c''>2.\sf <c' c''>2.\sf
  <c' c''>2.\sf <c' c''>2.\sf <c' c''>2.\sf <c' c''>4 r r R2. R2.
- << { c''2._\markup { \italic \large "p dolce" } ~ c''2. } \\ { R2. R2. } >> R2. R2.
- << { c''2._\markup { \italic \large "p dolce" } ~ c''2. } \\ { R2. R2. } >> R2. R2.
+ << { c''2._\pDolce-\hideP ~ c''2. } \\ { R2. R2. } >> R2. R2.
+ << { c''2._\pDolce ~ c''2. } \\ { R2. R2. } >> R2. R2.
  R2. R2. R2. R2. R2. R2. <g' d''>2.\f <c' c''>2.\ff <c' c''>4 <c' c''> <c' c''>\sf
  << { d''4 d'' d'' ~ d'' d'' d'' ~ d'' } \\ { d'' d'' d''\sf ~ d'' d'' d''\sf ~ d'' } >>
  <c' c''>4 <c' c''> <c' c''>4\f r r R2. <c' c''>4 r r R2.
@@ -41,14 +41,14 @@
  r4 r << { d''4\staccato d''4\staccato } \\ { d''4\f d''4 } >> r4 r R2. R2. R2. R2. R2. R2.
  r4 r << { d''4\staccato d''4\staccato } \\ { d''4\f d''4 } >> r4 r R2. R2. R2. R2.
  r4 r << { \tieNeutral <e' e''>4\p ~ <e' e''>2. ~ <e' e''>2. ~ <e' e''>2 <e' e''>4 ~ <e' e''>4 }
- \\ { \override DynamicLineSpanner   #'padding = #2.0
- s4\< s2. s2 s4\! s4\> s2 s4\! } >> r4
- \override DynamicLineSpanner   #'padding = #2.0
+ \\ { \spaceSpannerE
+ s8-\hideP s8\< s2. s2 s4\! \hairpinPastBarline s4\> s2 s4\! } >> r4
+ \spaceSpannerE
  <e' e''>\< ~ <e' e''>2. ~ <e' e''>2. ~ <e' e''>2 <e' e''>4\! R2. R2. R2. R2.
- << { e''4\pp f''\rest f''\rest e'' f''\rest f''\rest \cresc e''2. ~ e''2. ~ e''2. ~ e''2 d''4\sfp
+ << { e''4\pp f''\rest f''\rest e'' f''\rest f''\rest e''2.\cresc ~ e''2. ~ e''2. ~ e''2 d''4\sfp
  f''4\rest d'' f''\rest f''\rest d'' f''\rest f''\rest d'' f''\rest } \\
  { R2. R2. R2. R2. R2. R2. R2. R2. R2. } >> R2. R2. R2. R2. R2. R2.
- r4 r << { d''4 ~ d''2. ~ d''4 } \\ { d''4\< ~ d''2.\!\> ~ d''4\! } >> r4 r R2. R2.
+ r4 r << { d''4 ~ d''2. ~ d''4 } \\ { \hairpinPastBarline d''4-\hideP\< ~ d''2.\!\> ~ d''4\! } >> r4 r R2. R2.
  R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. r4 r
  <d'' f''>4\ff ~ <d'' f''>2. ~ <d'' f''>2. ~ <d'' f''>4 <d'' f''> <d'' f''>
  << { e''4 } \\ { e''4 } >> r4
@@ -62,7 +62,7 @@
  <c' c''>2.\sf << { d''2. } \\ { d''2.\sf } >> <c' c''>2.\sf <c' c''>2.\sf
  <c' c''>2.\sf << { d''2. } \\ { d''2.\sf } >> <c' c''>2.\sf << { f''4 } \\ { f''4 } >> r4 r
  R2. R2. R2. R2. R2. R2. R2. R2.
- R2. R2. R2. R2. R2. R2. R2. <g' d''>2._\markup { \italic \large "cresc." }
+ R2. R2. R2. R2. R2. R2. R2. <g' d''>2._\txtCresc
  << { c''2. f''2. d''4 } \\ { c''2.\f f''2.\ff d''4 } >> r4 r R2.
  << { c''4 c'' c'' ~ c'' c'' c'' d'' } \\ { c''4 c'' c''\sf ~ c'' c'' c'' d''\f } >> r4 r R2.
  << { d''4 } \\ { d''4 } >> r4 r R2. <d'' f''>4 r r r <d'' f''> <d'' f''>
@@ -88,7 +88,7 @@
  << { d''4. } \\ { d''4.\sf } >> r8 r2 << { e''4. } \\ { e''4.\sf } >> r8 r2
  << { d''4. } \\ { d''4.\sf } >> r8 r2 << { e''4. } \\ { e''4.\sf } >> r8 r2
  << { d''4. } \\ { d''4.\sf } >> r8 r2 << { e''4. } \\ { e''4.\sf } >> r8 r2
- << { d''4. } \\ { d''4._\markup { \italic \large "cresc." } } >> r8 << { d''8 } \\ { d''8 } >> r8 r4
+ << { d''4. } \\ { d''4._\txtCresc } >> r8 << { d''8 } \\ { d''8 } >> r8 r4
  << { e''4. } \\ { e''4.\sf } >> r8 << { e''8 } \\ { e''8 } >> r8 r4
  d''8\ff d'' r4 d''8 d'' r4 e''8 e'' r4 e''8 e'' r4 d''2 e'' d'' g'' r4 d''2. ~ d''1
  e''4 e'' e'' e'' e'' e'' e'' e''

--- a/ftp/BeethovenLv/O84/Egmont/Egmont-lys/cornif.ly
+++ b/ftp/BeethovenLv/O84/Egmont/Egmont-lys/cornif.ly
@@ -1,14 +1,13 @@
-\version "2.4.0"
+\version "2.18.2"
 
  cornif =  {
- \set Staff.instrument = "Corni in F"
+ \set Staff.instrumentName = "Corni in F"
  \set Staff.midiInstrument = "english horn"
  \clef treble
  \key c \major
  \time 3/2
- \override Staff.AccidentalPlacement   #'padding = #0.5
- << { <c' c''>1.\fermata } \\
- { \override DynamicLineSpanner   #'padding = #2.5 s2\f s4 s4\> s4 s4\! } >>
+ \moreAccidentalPadding
+ <c' c''>1.\fermata-\hideF_\forteSforzato
  R1. R1. R1. R1. R1. R1. R1. <c' c''>1.\ff
  <g g'>2\staccato <g g'>2\staccato r4 r8 <g g'>8
  << { d''2\staccato } \\ { d''2 } >> <g g'>2\staccato r2 R1. R1. R1.
@@ -20,10 +19,10 @@
 
  \time 3/4 R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. \clef bass
  << { R2. R2. d4\rest d4\rest c4 ~ c2. ~ c4 d4\rest d4\rest R2. R2. } \\
- { c,4\rest c,4\rest c,4\p ~ c,2. ~ c,4 c,4\rest
- c,4 ~ c,2. ~ c,4 c,4\rest c,4 ~ c,2. ~ c,4 c,4\rest c,4\rest } >>
+ { c,4\rest c,4\rest \hairpinPastBarline c,4\p\< ~ c,2.\!\> ~ c,4\! c,4\rest
+ \hairpinPastBarline c,4\< ~ c,2.\!\> ~ c,4\! c,4\rest \hairpinPastBarline c,4\< ~ c,2.\> ~ c,4\! c,4\rest c,4\rest } >>
  \clef treble r4 <g g'>\p r r <g g'> r r <g g'> r r <g g'> r
- \cresc r4 <g g'> r r <g g'> r r <g g'> r r <g g'> r r <g g'> r r <g g'> r 
+ r4 <g g'>\cresc r r <g g'> r r <g g'> r r <g g'> r r <g g'> r r <g g'> r 
  r4 <g g'> r r <g g'> r r <g g'> r r <g g'> r r <g g'> r r4 <g g'>
  <g g'>4\ff ~ <g g'>2. ~ <g g'>2. ~ <g g'>4 <g g'> <g g'> <g g'> r4
  <g g'>4\ff ~ <g g'>2. ~ <g g'>2. ~ <g g'>4 <g g'> <g g'>
@@ -40,10 +39,10 @@
  <c' c''>4\staccato r r R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2.
  R2. R2. R2. R2. R2. R2. <g g'>4\p <g g'>4 r r <g g'>4 r r <g g'>4 r r <g g'>4 r r <g g'>4 r
  r4 <g g'>4 r r <g g'>4 r r r \clef bass
- \override DynamicLineSpanner   #'padding = #2.0
- <c, c>4\< ~ <c, c>2.\!\> ~ <c, c>4\! r r R2. r4 r <c, c>4\< ~ <c, c>2.\!\> ~ <c, c>4\! r4 r
+ \spaceSpannerE
+ \hairpinPastBarline <c, c>4\< ~ <c, c>2.\!\> ~ <c, c>4\! r r R2. r4 r \hairpinPastBarline <c, c>4\< ~ <c, c>2.\!\> ~ <c, c>4\! r4 r
  \clef treble r4 <g g'>4\p r r <g g'>4 r r <g g'>4 r r <g g'>4 r
- r4 \cresc <g g'> r r <g g'> r r <g g'> r r <g g'> r r <g g'> r r <g g'> r
+ r4 <g g'>\cresc r r <g g'> r r <g g'> r r <g g'> r r <g g'> r r <g g'> r
  r4 <g g'> r r <g g'> r r <g g'> r r <g g'> r r <g g'> r r <g g'>
  <g g'>4\ff ~ <g g'>2. ~ <g g'>2. ~ <g g'>4 <g g'> <g g'> <g g'> r
  <g g'>4\ff ~ <g g'>2. ~ <g g'>2. ~ <g g'>4 <g g'> <g g'> <c' c''> r r R2. R2. R2. R2. R2.
@@ -65,8 +64,8 @@
  <g g'>4 <g g'> r r4 r r8 r^\fermata
  R2. R2. R2. R2. R2. R2. R2. R2.^\fermataMarkup \bar "||"
 
- \time 4/4 <g g'>1\pp <g g'>1 <g g'>1 <g g'>1 <g g'>1_\markup { \italic \large "cresc." } <g g'>1
- <g g'>1 ~ <g g'>4_\markup { \italic \large "cresc." } <g' g''>2 <g' g''>4
+ \time 4/4 <g g'>1\pp <g g'>1 <g g'>1 <g g'>1 <g g'>1_\txtCresc <g g'>1
+ <g g'>1 ~ <g g'>4_\txtCresc <g' g''>2 <g' g''>4
  <c'' e''>2\ff ~ <c'' e''>8( <g' d''>) <e' c''>\staccato <g' d''>\staccato
  <c'' e''>2\sf ~ <c'' e''>8( <g' d''>) <e' c''>\staccato <g' d''>\staccato
  <c'' e''>8\sf( <g' d''>) <e' c''>\staccato <g' d''>\staccato
@@ -84,7 +83,7 @@
  << { c''4. } \\ { c''4.\sf } >> r8 r2 << { d''4. } \\ { d''4.\sf } >> r8 r2
  << { c''4. } \\ { c''4.\sf } >> r8 r2 << { d''4. } \\ { d''4.\sf } >> r8 r2
  << { c''4. } \\ { c''4.\sf } >> r8 r2 << { d''4. } \\ { d''4.\sf } >> r8 r2
- << { c''4. } \\ { c''4._\markup { \italic \large "cresc." } } >> r8 << { c''8 } \\ { c''8 } >> r8 r4
+ << { c''4. } \\ { c''4._\txtCresc } >> r8 << { c''8 } \\ { c''8 } >> r8 r4
  << { d''4. } \\ { d''4.\sf } >> r8 << { d''8 } \\ { d''8 } >> r8 r4
  << { c''8[ c''] } \\ { c''8\ff[ c''] } >> r4 << { c''8[ c''] } \\ { c''8[ c''] } >> r4
  << { d''8[ d''] } \\ { d''8[ d''] } >> r4 << { d''8[ d''] } \\ { d''8[ d''] } >> r4

--- a/ftp/BeethovenLv/O84/Egmont/Egmont-lys/defs.ily
+++ b/ftp/BeethovenLv/O84/Egmont/Egmont-lys/defs.ily
@@ -1,0 +1,72 @@
+\version "2.18.2"
+
+%---Definitions
+
+softPageBreak = {
+ %\allowPageTurn 
+}
+
+hardPageBreak = {
+  \pageBreak
+}
+
+preventBreak = {
+  \noBreak
+}
+
+hideF = \tweak #'stencil ##f \f
+hideFF = \tweak #'stencil ##f \ff
+hideP = \tweak #'stencil ##f \p
+hidePP = \tweak #'stencil ##f \pp
+hidePPP = \tweak #'stencil ##f \ppp
+hideMF = \tweak #'stencil ##f \mf
+
+moreAccidentalPadding = \override Staff.AccidentalPlacement #'right-padding = #0.15
+
+hideMetronomeMark = \override Score.MetronomeMark.transparent = ##t
+
+hairpinPastBarline = \once \override Hairpin.to-barline = ##f
+hairpinNarrow = {
+  \once \override Hairpin.height = 0.45
+  \once \override Hairpin.padding = 0.0
+}
+
+doubleSlursOn = \set doubleSlurs = ##t
+doubleSlursOff = \set doubleSlurs = ##f
+
+aDue = \markup \tiny "a 2."
+forteSforzato = \markup { \concat { \dynamic "f " \raise #0.6 \huge \musicglyph #"scripts.sforzato" }}
+pDolce = \markup { \dynamic p \italic \larger dolce }
+pCresc = \markup { \dynamic p \italic \larger \whiteout cresc. }
+txtCresc = \markup \italic \larger "cresc."
+dolce = \markup \italic \larger \whiteout "dolce"
+txtMarcato = \markup \italic \large "marcato"
+txtPizz = \markup \italic \large "pizz."
+txtArco = \markup \italic \large "arco"
+upFermata = \markup{ \concat { \hspace #1 \musicglyph #"scripts.ufermata" } }
+downFermata = \markup{ \musicglyph #'"scripts.dfermata" }
+sostNonTropo = \markup { \large \bold { \hspace #-4.0 "Sostenuto ma non troppo" } }
+flautoPiccolo = \markup { \whiteout "Flauto piccolo." }
+allegro = \markup { \large \bold "Allegro" }
+
+insideSlur = \once \override Slur.outside-staff-priority = #500
+hideTupletNumber = \temporary \override TupletNumber.transparent = ##t
+hideTupletBracket = \temporary \override TupletBracket.bracket-visibility = ##f
+
+posDynamicTxtA = \once \override DynamicText.extra-offset = #'(0.8 . -0.5)
+posDynamicTxtB = \once \override DynamicText.extra-offset = #'(1.6 . -0.2)
+posDynamicTxtC = \once \override DynamicText.extra-offset = #'(-1.5 . 6.7)
+posDynamicTxtD = \once \override DynamicText.extra-offset = #'(2 . -2)
+
+shapeSlurA = \shape #'(( 0 . 2) (0 . 0) (0 . 0) (0 . 2)) Slur
+shapeSlurB = \shape #'(( 0 . 1.3) (0 . 1.3) (0 . 1.3) (0 . 1.3)) Slur
+shapeSlurC = \shape #'(( 0 . -1.3) (0 . -0.5) (0 . 0) (0 . 0)) Slur
+
+spaceSpannerA = \temporary \override DynamicLineSpanner.padding = #2.5
+spaceSpannerB = \temporary \override DynamicLineSpanner.padding = #1.9
+spaceSpannerC = \temporary \override DynamicLineSpanner.padding = #1.0
+spaceSpannerD = \temporary \override DynamicLineSpanner.padding = #1.5
+spaceSpannerE = \temporary \override DynamicLineSpanner.padding = #2.0
+spaceSpannerF = \temporary \override DynamicLineSpanner.padding = #3.0
+
+spaceTextScrA = \temporary \override TextScript.padding = #1.5

--- a/ftp/BeethovenLv/O84/Egmont/Egmont-lys/fagotti.ly
+++ b/ftp/BeethovenLv/O84/Egmont/Egmont-lys/fagotti.ly
@@ -1,52 +1,52 @@
-\version "2.4.0"
+\version "2.18.2"
+
+\include "defs.ily"
 
  fagotti =  {
- \set Staff.instrument = "Faggotti"
+ \set Staff.instrumentName = "Faggotti"
  \set Staff.midiInstrument = "bassoon"
  \clef bass
  \key f \minor
  \time 3/2
- \override Staff.AccidentalPlacement   #'padding = #0.5
- << { <f, f>1.\fermata } \\
- { \override DynamicLineSpanner   #'padding = #1.5 s2\f s4 s4\> s4 s4\! } >>
+ \moreAccidentalPadding
+ <f, f>1.\fermata_\forteSforzato-\hideF
  R1. R1. R1. R1.
- << { r2 r4 \once \override Slur   #'attachment = #'(stem . stem)
+ << { r2 r4 \shapeSlurB
  c'4^\p( b aes') aes'2. f'4\rest a2\rest  } \\
  { r2 r2 r4 b\p b2( c'4) b,4\rest b,2\rest } >>
  << { a2\rest c'4\rest
- \once \override Slur   #'attachment = #'(stem . stem)
+ \shapeSlurB
  des'2( c'4) } \\
  { b,2\rest b,4\rest\p g2. } \\
- { s2 s8 s8\< s4 s8\!\> s4 s8\! } >> <f, f>1.\ff
+ { s2-\hideP s8 s8\< s4 s8\!\> s4 s8\! } >> <f, f>1.\ff
  <f, f>2\staccato <f, f>2\staccato r4 r8  <f, f>8
  <ees, ees>2\staccato <aes, aes>2\staccato r2
- << { r2 r4 des'^\p( c' des') des'( ges' f' ees' des' des') des'2( c' ees'4 ges') } \\
+ << { r2 r4 \shapeSlurB des'^\p( c' des') des'( ges' f' ees' des' des') des'2( c' ees'4 ges') } \\
  { r2 r2 r4 bes\p( aes2.)\< aes4\!( bes\> g!)\! aes1 aes2 } >>
  <des' f'>4 r4 <aes des'>2\pp\staccato <aes des'>\staccato
  r2 <aes des'>2\staccato <aes des'>\staccato
  r2 <ges ees'>2\staccato <ges ees'>\staccato
  << { e'4\rest
- \override Slur   #'attachment = #'(stem . stem)
- ees'4( f'8 ees' des' c') c'4 d'4\rest } \\ { r2 a2 a } >>
+ ees'4( f'8 ees' des' c') c'4 d'4\rest } \\ { d2\rest a2 a } >>
  r2 <bes des'>2 <bes des'>  r2 <e e'>2 <e e'>  r2 <e c'>2 <e c'> R1. R1. R1. \bar "||"
 
  \time 3/4 R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2.
- r4 r4 << { f,4( bes,2.) f,4 } \\
- { \override DynamicLineSpanner   #'padding = #1.5 s4\p\< s4\!\> s4 s4\! f,4 } >>
- r4 <f, aes>4\<( <bes, bes>2.\!\> <f, aes>4\!) r4
- << { f,4( bes,2.) f,4 } \\ { s4\< s4\!\> s4 s4\! f,4 } >> r4 r4
+ r4 r4 << { f,4(-\hideP bes,2.) f,4 } \\
+ { \spaceSpannerD \hairpinPastBarline s4\p\< s4\!\> s4 s4\! f,4 } >>
+ r4 \hairpinPastBarline <f, aes>4\<( <bes, bes>2.\!\> <f, aes>4\!) r4
+ << { \shapeSlurB f,4( bes,2.) f,4 } \\ { \hairpinPastBarline f,4-\hideP\< bes,2.\!\> f,4\! } >> r4 r4
  R2. R2. R2. R2. R2. R2. R2. R2.
- r4 \cresc <e' g'> r4 r <e' g'> r r <e' g'> r r <e' g'> r
- r4 <e' g'> r r <e' g'> r r <e' g'> r r <e' g'>\!
- << { f,4\ff ~ f,2. ~ f,2. ~ f,4 f,4( aes, c) } \\ { f,4 ~ f,2. ~ f,2. ~ f,4 f,4( aes, c) } >>
+ << { \oneVoice r4 <e' g'>\cresc r4 r <e' g'> r r <e' g'> r r <e' g'> r
+ r4 <e' g'> r r <e' g'> r r <e' g'> r r <e' g'>
+ \voiceOne f,4\ff ~ f,2. ~ f,2. ~ f,4 f,4( aes, c) } \\ { s2.*7 s2 \voiceTwo f,4-\hideFF ~ f,2. ~ f,2. ~ f,4 f,4( aes, c) } >>
  r4 <c, c>4\ff ~ <c, c>2. ~ <c, c>2. ~ <c, c>4 <c, c> <c, c>
  <f, f>4 r r <g bes> r r <aes c'> r r <bes des'> <bes des'> <bes c'>
  <aes c'> r r <g bes> r r <aes c'> r <f aes> <f aes> <f aes> <fes aes>
  <ees g>2.\sf <aes c'>\sf <aes bes>\sf <g bes>\sf <g bes>\sf <aes c'>\sf <aes bes>\sf
  <g bes>4 r r R2. R2.
- <ees bes>2._\markup { \italic \large "p dolce" }( <aes c'>2.) R2. R2.
- <ees bes>2._\markup { \italic \large "p dolce" }( <aes c'>2.) R2. R2.
- <cis e>2._\markup { \italic \large "p cresc." }( <d fis>4 <e gis> <fis a>)
+ <ees bes>2._\pDolce-\hideP( <aes c'>2.) R2. R2.
+ <ees bes>2._\pDolce( <aes c'>2.) R2. R2.
+ <cis e>2._\pCresc( <d fis>4 <e gis> <fis a>)
  <cis e>2.( <d fis>4 <e gis> <fis a>) <cis e>2. <d! f!>2. ~ <d f>2.\f <ees! g!>2.\ff
  << { aes!4 } \\ { aes!4 } >> <aes c'>4 \tieDown <aes c'>4\sf( ~ <aes des'>) <aes des'>
  \slurDown \tieUp <aes des'>4\sf( ~ <bes des'>) <bes des'>
@@ -61,30 +61,30 @@
  { aes,4\staccato d,\rest d,\rest R2. R2. R2. R2. R2. R2. b,,4\rest b,,\rest f,4\f\staccato } >>
  << { bes,2.^\fp ~ bes,2. ~ bes,2. ~ bes,2. a,2. ~ a,2. ~ a,2. ~ a,2 f,4\staccato
  bes,2.^\fp ~ bes,2. ~ bes,2. ~ bes,2 b,4 ~ b,2. ~ b,2 r4 } \\
- { bes,4\staccato e,\rest e,\rest R2. R2. R2. R2. R2. R2. e,4\rest e,\rest f,4\f
+ { bes,4\staccato e,\rest e,\rest R2. R2. R2. R2. R2. R2. d,4\rest d,\rest f,4\f
  bes,4\staccato e,\rest e,\rest R2. R2. R2. R2. R2. } >> R2. R2. R2. R2. R2. R2. R2.
  <g d'>2.\pp <g d'>2. <g d'>2. ~ <g d'>2.
- <c, c>2.\pp\staccato <c, c>2.\staccato \cresc <c, c>2. ~ <c, c>2. ~ <c, c>2. ~ <c, c>2
+ <c, c>2.\pp\staccato <c, c>2.\staccato-\hidePP <c, c>2.\cresc ~ <c, c>2. ~ <c, c>2. ~ <c, c>2
  <f, f>4\sfp <f, f>4 <f, f>4 r r <f, f> r r <f, f> r
  r4 <g bes> r r <g bes> r r <g bes> r r <g bes> r r <f aes> r R2.
- r4 r << { f4( bes2. f4) } \\ { f4\<( bes2.\!\> f4\!) } >> r4 r R2. << { f,4 } \\ { f,4\p } >> r4 r
+ r4 r << { \shapeSlurB f4( bes2.)( f4) } \\ { \hairpinPastBarline f4-\hideP\<( bes2.\!\>)( f4\!) } >> r4 r R2. << { f,4 } \\ { f,4\p } >> r4 r
  R2. R2. R2. R2. R2. R2. R2. R2.
  << { s2. s2. s2. s2. s2. s2. s2. s2 f,4 ~ f,2. ~ f,2. ~ f,4 f,( aes, c) } \\
- { r4 \cresc <e' g'> r r <e' g'> r r <e' g'> r r <e' g'> r
+ { r4-\hideP <e' g'>\cresc r r <e' g'> r r <e' g'> r r <e' g'> r
  r <e' g'> r r <e' g'> r r <e' g'> r r <e' g'> f,4\ff  ~ f,2. ~ f,2. ~ f,4 f, aes, c } >>
  r4 <c, c>4\ff ~ <c, c>2. ~ <c, c>2. ~ <c, c>4 <c, c> <c, c> <f, f> r
  << { f,4 bes,2 bes,4 f,4 } \\ { f,4\f bes,2\sf bes,4 f,4 } >> r4
- <f c'>4\f( <bes des'>2) <bes des'>4 <f c'>4 r
+ \doubleSlursOn <f c'>4\f( <bes des'>2) \doubleSlursOff <bes des'>4 <f c'>4 r
  << { f,4 bes,2 bes,4 f,4 } \\ { f,4 bes,2\sf bes,4 f,4 } >> r4 <des des'>4\ff <des des'>4 r r
- <des des'>4 r r <des des'>4 r r <ges bes>4 <ees ges>4 aes <des f>4 r r
+ <des des'>4 r r <des des'>4 r r <ges bes>4 <ees ges>4 <<{ aes } \\ { aes }>> <des f>4 r r
  <des des'>4 r r <des des'>4 r r <g! bes>4 <g bes>4 <aes c'>4 <bes des'>2. ~ <bes des'>2.
  <aes c'>2.\sf <aes des'>2.\sf <g bes>2.\sf <aes c'>2.\sf
  <ees ges>2.\sf <des f>2.\sf <g bes>2.\sf <aes c'>4 r r
- R2. R2. << { c'2.( des'2.) } \\ { aes2._\markup { \italic \large "p dolce" }( des'2.) } >>
- R2. R2. << { c'2.( des'2.) } \\ { aes2._\markup { \italic \large "p dolce" }( des'2.) } >>
- R2. R2. \slurUp <fis a>2._\markup { \italic \large "p cresc." }( <g b>4 <a cis'> <b d'>)
+ R2. R2. << { c'2.-\hideP( des'2.) } \\ { aes2._\pDolce-\hideP( des'2.) } >>
+ R2. R2. << { c'2.( des'2.) } \\ { aes2._\pDolce( des'2.) } >>
+ R2. R2. \slurUp <fis a>2._\pCresc( <g b>4 <a cis'> <b d'>)
  <fis a>2.( <g b>4 <a cis'> <b d'>) <fis a>2. <f! aes!>2.
- <ees ges>2.\f <ees c'>2.\ff <f des'>4 <f des'> <f des'>4\sf( <bes des'>) <ges bes>
+ <ees ges>2.\f <ees c'>2.\ff <f des'>4 <f des'> \doubleSlursOn <f des'>4\sf( <bes des'>) \doubleSlursOff <ges bes>
  <ges bes>4\sf ~ <ges bes> <ges bes> <ges bes>\sf( <ges c'>) <ges c'> <ees aes>
  <des f>2.\f ~ <des f>2. <des f>2. ~ <des f>2. <des f>2. ~ <des f>2 <des' f'>4
  <ees' ges'>2\sf <c' ees'>4\staccato <ees' ges'>2\sf <c' ees'>4\staccato
@@ -96,11 +96,11 @@
  R2. R2. R2. R2. <bes des'>4\ff <bes des'> r8 <bes des'> <bes des'>4 <bes des'> r8 <bes des'>
  << { a4 a } \\ { a4 a } >> r8 << { a8 a4 a } \\ { a8 a4 a } >> r4
  R2. R2. R2. R2. R2. R2. R2. r4 r r8 r^\fermata
- f2.\pp ~ f2. <des des'>2.^\ppp ~ <des des'>2. ~ <bes, des'>2. ~ <bes, des'>2.
+ f2.\ppp ~ f2. <des des'>2.^\ppp ~ <des des'>2. ~ <bes, des'>2. ~ <bes, des'>2.
  <c c'>2. ~ <c c'>2.^\fermata \bar "||"
 
- \key f\major \times 4/4 R1 R1 R1 R1
- <e g>2_\markup { \italic \large "cresc." } <e g>2 <f a> <f a> <e g> <f a>
+ \key f\major \time 4/4 R1 R1 R1 R1
+ <e g>2_\txtCresc <e g>2 <f a> <f a> <e g> <f a>
  <g bes>8( <fis a>) <g bes>\staccato <a c'>\staccato
  <bes d'>\staccato <c' e'>\staccato <d' f'!>\staccato <e' g'>\staccato
  <f' a'>2\ff ~ <f' a'>8( <c' g'>) <a f'>\staccato <c' g'>\staccato
@@ -117,15 +117,15 @@
  <f' a'>8\sf( <c' g'>) <a f'>\staccato <c' g'>\staccato
  <f' a'>8\sf( <c' g'>) <a f'>\staccato <c' g'>\staccato
  << { a'8 g' f' e' f' e' d' cis' d' c'! bes a bes g c' c' } \\ { f'8 d8\rest f4 d2 bes,4 g, c c } >>
- << { \once \override Slur   #'attachment = #'(stem . stem) f'4( ees' d' fis') } \\
+ << { f'4( ees' d' fis') } \\
  { f'4\sf ees' d' fis' } >>
- \clef tenor << { \once \override Slur   #'attachment = #'(stem . stem) g'( des' c' e'!) } \\
+ \clef tenor << { \shapeSlurB g'( des' c' e'!) } \\
  { g'\sf des' c' e'! } >>
  f'!4\sf( ees' d'! fis') g'\sf( des' c' e'!) f'!4\sf( ees' d'! fis') g'\sf( des' c' e'!)
- r8 \cresc a16( bes) c'8\staccato r r
- \set tupletSpannerDuration = #(ly:make-moment 1 4) \times 2/3 { a16[ bes c'] }
+ r8-\hideF a16(\cresc bes) c'8\staccato r r
+ \tupletSpan 4 \tuplet 3/2 { a16[ bes c'] }
  d'8\staccato r
- r8 g16([ a]) bes8\staccato r r \times 2/3 { g16[ a bes] } c'8[ c']
+ r8 g16([ a]) bes8\staccato r r \tuplet 3/2 { g16[ a bes] } c'8[ c']
  \clef bass <f f'>4\ff( <ees ees'> <d d'> <fis fis'>)
  << { g'4( des' c' e'!) } \\ { g4\sf bes2 g4 } >>
  << { f!2 } \\ { f!2 } >> <e g>2 <f a> <g bes> <gis b>4 <a c'>2. ~ <a c'>1

--- a/ftp/BeethovenLv/O84/Egmont/Egmont-lys/flautoone.ly
+++ b/ftp/BeethovenLv/O84/Egmont/Egmont-lys/flautoone.ly
@@ -1,95 +1,132 @@
-\version "2.4.0"
+\version "2.18.2"
+
+\include "defs.ily"
 
  flautoone =  {
- \set Staff.instrument = "Flauto I"
+ \set Staff.instrumentName = "Flauto I"
  \set Staff.midiInstrument = "flute"
  \clef treble
  \key f \minor
  \time 3/2
- \override Staff.AccidentalPlacement   #'padding = #0.5
- << { f'''1.\fermata^\markup { \large \bold "Sostenuto ma non troppo" } } \\
- { s2\f s4 s4\> s4 s4\! } >> R1. R1. R1. R1. R1. R1. R1. f'''1.\ff
+ \moreAccidentalPadding
+ f'''1.-\hideF_\forteSforzato^\upFermata^\sostNonTropo
+ R1. R1. R1. 
+ R1. R1. R1. R1. f'''1.\ff
+ \softPageBreak
  aes''2\staccato aes''2\staccato r4 r8 aes''8 bes''2\staccato c'''2\staccato r2 R1.
+ \preventBreak
  r4\p ees'''4\<( des'''! c'''\!\> des''' bes''\!) aes''2( ges''2. ees''4)
  des''4 r4 r2 r2 R1. r4 ees'''4\pp( f'''8 ees''' des''' c''') c'''4 r4
+ \softPageBreak
  r4 ees'''4( f'''8 ees''' des''' c''') c'''4 r4
- r4 des'''4( ees'''8 des''' c''' bes'') bes''4 r4 R1. R1. R1. R1. R1. \bar "||"
+ r4 des'''4( ees'''8 des''' c''' bes'') bes''4 r4 R1. R1. R1. R1. R1.
+  \bar "||"
+  \hardPageBreak
 
  \tempo 4 = 168
- \override Score.MetronomeMark   #'transparent = ##t
- \time 3/4 R2.^\markup { \large \bold "Allegro" }
+ \hideMetronomeMark
+ \time 3/4 R2.^\allegro
  R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2.
- r4 r4 f'''4\<( ees'''2\!\> des'''4\! c''') r4 r4 R2. c'''4\p r4 r4 R2. R2. R2. R2.
- R2. R2. R2. R2. r4 \cresc des''' r r des''' r r des''' r r des''' r
+ \softPageBreak
+ r4 r4 \hairpinPastBarline f'''4\<( ees'''2\!\> des'''4\! c''') r4 r4 R2. c'''4\p r4 r4 R2. R2. R2. R2.
+ R2. R2. R2. R2.
+ \softPageBreak
+ r4 des'''\cresc r r des''' r r des''' r r des''' r
  r des''' r r des''' r r des''' r r4 c'''4
- f'''4\ff ~ f'''2. ~ f'''2. ~ f'''4 f''' f''' e''' r e'''4\ff ~ e'''2. ~ e'''2. ~ e'''4
+ f'''4\ff ~ f'''2. ~ f'''2. ~ f'''4 f''' f'''
+ \softPageBreak
+ e''' r e'''4\ff ~ e'''2. ~ e'''2. ~ e'''4
  e''' e''' f''' r r f''' r r f''' r r g''' g''' g''' f''' r r f''' r r
  f''' r f''' aes''' aes''' aes'''
+ \softPageBreak
  g'''2.\sf aes'''2.\sf aes'''2.\sf g'''4 ees''' ees''' ees'''2.\sf ees'''2.\sf f'''2.\sf
- ees'''4 r r R2. R2. R2. ees'''4_\markup { \italic \large "p dolce" }( c''' aes''')
- R2. R2. R2. ees'''4_\markup { \italic \large "p dolce" }( c''' aes''') R2. R2.
- e'''2._\markup { \italic \large "p cresc." }( fis'''4 gis''' a''')
+ ees'''4 r r R2. R2. R2. ees'''4_\pDolce-\hideP( c''' aes''')
+ R2. R2. R2. 
+ \softPageBreak ees'''4_\pDolce( c''' aes''')
+ R2. R2.
+ e'''2._\pCresc( fis'''4 gis''' a''')
  e'''2.( fis'''4 gis''' a''') e'''2. f'''!2. ~ f'''2.\f ees'''!2.\ff
- ees'''4 c''' aes'''\sf ~ aes''' f''' f'''\sf ~ f''' des''' des'''\sf ~ des''' ees''' ees'''
+ ees'''4 c''' aes'''\sf ~ aes''' f''' f'''\sf ~
+ \softPageBreak
+ f''' des''' des'''\sf ~ des''' ees''' ees'''
  aes''4\f r r R2. c'''4 r r R2. ees'''4 r r r ees''' ees'''
- ees'''2.\sf ees'''2.\sf ees'''2.\sf ees'''2.\sf ees'''2.\sf ees'''2\sf g'''4\staccato
+ ees'''2.\sf ees'''2.\sf ees'''2.\sf ees'''2.\sf
+ \softPageBreak
+ ees'''2.\sf ees'''2\sf g'''4\staccato
  aes'''4\staccato r r R2. R2. r4 r
- c'''4_\markup { \italic \large "dolce" }( ees''' des''' bes'' g'') r r R2.
+ c'''4_\dolce( ees''' des''' bes'' g'') r r R2.
  r4 r ees'''\f\staccato ees'''\staccato r r R2. R2.
- r4 r ees'''_\markup { \italic \large "dolce" }( f''' ees''' c''' a'') r r R2.
+ r4 r ees'''_\dolce( f''' ees''' c''' 
+ \softPageBreak
+ a'') r r R2.
  r4 r f'''\f\staccato f'''\staccato r r R2. R2.
- r4 r des'''_\markup { \italic \large "dolce" }( f''' ees''' c''' a'') r r R2.
+ r4 r des'''!_\dolce( f''' ees''' c''' a'') r r R2.
  r4 r f'''\f\staccato f'''\staccato r r R2. R2.
- r4 r f'''\p( g''' f''') r R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2.
- c'''2.\pp\staccato c'''2.\staccato \cresc c'''2. ~ c'''2. ~ c'''2. ~ c'''2 c'''4\sfp
- c'''4 c''' r r c''' r r c''' r r c''' r r c''' r r c''' r r c''' r r c''' r R2.
- r4 c'''\<( f''' ees'''2\!\> des'''4\! c''') r r R2. c'''4\p r r R2. R2. R2. R2.
- R2. R2. R2. R2. r4 \cresc des'''4 r r des''' r r des''' r r des''' r
- r des''' r r des''' r r des''' r r c''' f'''4\ff ~ f'''2. ~ f'''2. ~ f'''4 f''' f'''
+ r4 r f'''\p( 
+ \softPageBreak
+ g''' f''') r R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2.
+ \softPageBreak
+ R2.
+ c'''2.\pp\staccato c'''2.\staccato c'''2.\cresc ~ c'''2. ~ c'''2. ~ c'''2 c'''4\sfp
+ c'''4 c''' r r c''' r r c''' r r c''' r r c''' r
+ \softPageBreak
+ r c''' r \softPageBreak r c''' r r c''' r R2.
+ r4 \hairpinPastBarline c'''\<( f''' ees'''2\!\> des'''4\! c''') r r R2. c'''4\p r r R2. R2. R2. R2. \softPageBreak
+ R2. R2. R2. R2. r4 des'''4\cresc r r des''' r r des''' r r des''' r
+ r des''' r r des''' r r des''' r r c''' f'''4\ff ~ \softPageBreak f'''2. ~ f'''2. ~ f'''4 f''' f'''
  e'''4 r e'''\ff ~ e'''2. ~ e'''2. ~ e'''4 e'''\staccato e'''\staccato
- f'''4\staccato r r R2. r4 r f'''4\f( ees'''!2 des'''4) c'''4 r r R2.
+ f'''4\staccato r r R2. r4 r f'''4\f( ees'''!2 des'''4) c'''4 r r \softPageBreak R2.
  r4 r f'''4\ff des'''4 r r des''' r r des''' r r des''' ges''' ees'''
  f'''4 r r des''' r r des''' r r des''' ees''' ees''' ees'''2. ~ ees'''2.
- ees'''2.\sf f'''2.\sf ees'''2.\sf ees'''2.\sf ees'''2.\sf f'''2.\sf ees'''2.\sf ees'''4 r r
- R2. R2. R2. f'''4_\markup { \italic \large "p dolce" }( des''' aes''')
- R2. R2. R2. f'''4_\markup { \italic \large "p dolce" }( des''' aes''')
- R2. R2. d'''2._\markup { \italic \large "p cresc." } ~ d'''2. ~ d'''2. ~ d'''2. ~ d'''2. f'''2.
- ges'''2.\f ges'''2.\ff f'''4 des''' des'''\sf ~ des''' bes'' bes''\sf ~ bes'' ees'''
+ ees'''2.\sf \softPageBreak f'''2.\sf ees'''2.\sf ees'''2.\sf ees'''2.\sf f'''2.\sf ees'''2.\sf ees'''4 r r
+ R2. R2. R2. f'''4_\pDolce-\hideP( des''' aes''')
+ R2. R2. R2. f'''4_\pDolce( des''' aes''')
+ R2. \softPageBreak R2. d'''2._\pCresc ~ d'''2. ~ d'''2. ~ d'''2. ~ d'''2. f'''2.
+ ges'''2.\f ges'''2.\ff f'''4 des''' des'''\sf ~ des''' bes'' bes''\sf ~ \softPageBreak bes'' ees'''
  ees'''4\sf ~ ees''' ees''' c''' des'''\f r r R2. f'''4 r r R2. aes'''4 r r r aes''' aes'''
- aes'''2\sf c'''4\staccato aes'''2\sf c'''4\staccato aes'''2\sf des'''4\staccato
+ aes'''2\sf c'''4\staccato aes'''2\sf c'''4\staccato aes'''2\sf des'''4\staccato \softPageBreak
  aes'''2\sf c'''4\staccato aes'''2\sf des'''4\staccato aes'''2\sf c'''4\staccato des'''4 r r
- R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2.
+ R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. \softPageBreak R2. R2. R2. R2.
  c'''4\ff c''' r8 c''' c'''4 c''' r8 c''' c'''4 c''' r r4 r r8 r^\fermata
  R2. R2. R2. R2. R2. R2. R2. R2.^\fermataMarkup \bar "||"
+ \hardPageBreak
 
  \tempo 4 = 152
- \override Score.MetronomeMark   #'transparent = ##t
+ \hideMetronomeMark
  \key f \major
- \time 4/4 R1^\markup { \large \bold "Allegro con brio" } R1 R1 R1 R1 R1 R1
- c'''2\p ~ c'''4.
- \set tupletSpannerDuration = #(ly:make-moment 1 4) \times 2/3 { c'''16[ d''' e'''] }
+ \time 4/4 R1^\markup { \large \bold "Allegro con brio" } R1 R1 R1 R1 R1 \softPageBreak R1
+ c'''2_\txtCresc ~ c'''4.
+ \tupletSpan 4 \tuplet 3/2 { c'''16[ d''' e'''] }
  f'''2\ff ~ f'''8( e''') c'''\staccato e'''\staccato
  f'''2\sf ~ f'''8( e''') c'''\staccato e'''\staccato
- f'''8\sf( e''') c'''\staccato e'''\staccato f'''8\sf( e''') c'''\staccato e'''\staccato
+ f'''8\sf( e''') c'''\staccato e'''\staccato f'''8\sf( e''') c'''\staccato e'''\staccato \softPageBreak
  f'''8\sf( e''') c'''\staccato e'''\staccato f'''8\sf( e''') c'''\staccato e'''\staccato
  f'''8 g'' f'' e'' f'' e'' d'' cis'' d'' c'''! bes'' a'' bes'' g'' c''' c'''
  f'''2\sf ~ f'''8( e''') c'''\staccato e'''\staccato
  f'''2\sf ~ f'''8( e''') c'''\staccato e'''\staccato
+ \softPageBreak
  f'''8\sf( e''') c'''\staccato e'''\staccato f'''8\sf( e''') c'''\staccato e'''\staccato
  f'''8\sf( e''') c'''\staccato e'''\staccato f'''8\sf( e''') c'''\staccato e'''\staccato
  f'''8 g'' f'' e'' f'' e'' d'' cis'' d'' c'''! bes'' a'' bes'' g'' c''' c'''
- f''4 r r2 R1 R1 R1 R1 R1
- r8 \cresc a''16( bes'') c'''8\staccato r r
- \set tupletSpannerDuration = #(ly:make-moment 1 4) \times 2/3 { a''16[ bes'' c'''] }
+ f''4 r r2 R1
+ \softPageBreak
+ R1 R1 R1 R1
+ r8 a''16-\hideP(\cresc bes'') c'''8\staccato r r
+ \tupletSpan 4 \tuplet 3/2 { a''16[ bes'' c'''] }
  d'''8\staccato r
- r8 g''16([ a'']) bes''8\staccato r r \times 2/3 { g''16[ a'' bes''] } c'''8[ c''']
+ r8 g''16([ a'']) bes''8\staccato r r \tuplet 3/2 { g''16[ a'' bes''] } c'''8[ c'''] \softPageBreak
  f'''4\sf( ees''' d''' fis''') g'''\sf( des''' c''' e'''!) f'''!2 c''' c''' c'''
- c'''4 c'''2. ~ c'''1 bes''4 g''' g''' g''' g''' g''' g''' g'''
+ c'''4 c'''2. ~ c'''1 bes''4 g''' g''' g''' 
+ \softPageBreak
+ g''' g''' g''' g'''
  f'''4. c'''8 c'''4. c'''8 c'''4. c'''8 c'''4. c'''8 c'''4 c'''2. ~ c'''1 ~ c'''4
  g'''4 g''' g''' g''' g''' g''' g'''
+ \softPageBreak
  f'''2 f'''\sf ~ f'''1 ~ f'''2 a'''2\sf ~ a'''1 ~ a'''2 f'''
  e'''2.\sf e'''4 f'''2 f''' e'''2.\sf e'''4 f'''2 f'''
- e'''2.\sf e'''4 e'''2.\sf e'''4 e'''2.\sf e'''4
+ e'''2.\sf e'''4 e'''2.\sf e'''4
+ \softPageBreak
+ e'''2.\sf e'''4
  f'''8\ff f'' g'' a'' bes'' a'' bes'' c''' d''' c''' d''' e''' f''' e''' f''' g'''
  a'''4 r r2 a'''4 r r2 a'''4 r r2 f'''4 r f''' r f''' r r2 \bar "|."
 }

--- a/ftp/BeethovenLv/O84/Egmont/Egmont-lys/flautotwo.ly
+++ b/ftp/BeethovenLv/O84/Egmont/Egmont-lys/flautotwo.ly
@@ -1,26 +1,28 @@
-\version "2.4.0"
+\version "2.18.2"
+
+\include "defs.ily"
 
  flautotwo =  {
- \set Staff.instrument = "Flauto II"
+ \set Staff.instrumentName = "Flauto II"
  \set Staff.midiInstrument = "flute"
  \clef treble
  \key f \minor
  \time 3/2
- \override Staff.AccidentalPlacement   #'padding = #0.5
- << { f''1.\fermata } \\ { s2\f s4 s4\> s4 s4\! } >>
+ \moreAccidentalPadding
+ f''1.-\hideF_\forteSforzato\fermata
  R1. R1. R1. R1. R1. R1. R1. f''1.\ff
  f''2\staccato  f''2\staccato r4 r8 f''8 g''2\staccato aes''2\staccato r2
  R1. R1. R1. R1. R1. R1. R1. R1. R1. R1. R1. R1. R1. \bar "||"
 
  \time 3/4 R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2.
  R2. R2. R2. R2. R2. R2. aes''4\p r4 r4 R2. R2. R2. R2. R2. R2. R2. R2.
- r4 \cresc e'' r r e'' r r e'' r r e'' r r e'' r r e'' r r e'' r r e''
+ r4 e''\cresc r r e'' r r e'' r r e'' r r e'' r r e'' r r e'' r r e''
  c'''4\ff ~ c'''2. ~ c'''2. ~ c'''4 c''' c''' c''' r c'''4\ff ~ c'''2. ~ c'''2. ~ c'''4
  c'''4 c''' c''' r r f'' r r f'' r r f''' f''' e''' f''' r r f'' r r f'' r c'''
  des'''4 des''' d'''
  ees'''2.\sf ees'''2.\sf f'''2.\sf ees'''4 bes'' bes'' bes''2.\sf c'''2.\sf d'''2.\sf
  ees'''4 r4 r R2. R2. R2. R2. R2. R2. R2. R2. R2. R2.
- cis'''2._\markup { \italic \large "p cresc." }( d'''4 e''' fis''')
+ cis'''2._\pCresc( d'''4 e''' fis''')
  cis'''2.( d'''4 e''' fis''') cis'''2. d'''2. ~ d'''2.\f des'''!2.\ff
  c'''!4 aes'' c'''\sf( f''') des''' des'''\sf ~ des'''
  bes''4 bes''\sf ~ bes'' bes'' bes''
@@ -31,36 +33,27 @@
  R2. R2. R2. R2. R2. R2. r4 r c'''4\f\staccato des'''\staccato r r
  R2. R2. R2. R2. R2. R2. r4 r c'''4\f\staccato des'''\staccato r r R2. R2. R2.
  R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2.
- R2. R2. R2. R2. R2. R2. R2. R2. R2. r4 r f''\< ~ f''2.\!\> ~ f''4\! r4 r R2. aes''4\p r r
+ R2. R2. R2. R2. R2. R2. R2. R2. R2. r4 r \hairpinPastBarline f''\< ~ f''2.\!\> ~ f''4\! r4 r R2. aes''4\p r r
  R2. R2. R2. R2. R2. R2. R2. R2.
- r4 \cresc e'' r r e'' r r e'' r r e'' r r e'' r r e'' r r e'' r r e'' c'''\ff ~
+ r4 e''\cresc r r e'' r r e'' r r e'' r r e'' r r e'' r r e'' r r e'' c'''\ff ~
  c'''2. ~ c'''2. ~ c'''4 c''' c''' c''' r c'''4\ff ~ c'''2. ~ c'''2. ~
  c'''4 c'''\staccato c'''\staccato c'''4 r r R2. R2. R2. R2. R2. r4 r des'''4\ff
  des'' r r des'' r r des'' r r bes'' des''' c''' des''' r r
  des''4 r r des'' r r g''! bes'' c''' des'''2. ~ des'''2.
  c'''2.\sf des'''2.\sf des'''2.\sf c'''2.\sf c'''2.\sf des'''2.\sf des'''2.\sf c'''4 r r
- R2. R2. R2. des'''4_\markup { \italic \large "p dolce" }( aes'' f'')
- R2. R2. R2. des'''4_\markup { \italic \large "p dolce" }( aes'' f'')
- R2. R2. d''2._\markup { \italic \large "p cresc." } ~ d''2. ~ d''2. ~ d''2. ~ d''2. bes''2.
+ R2. R2. R2. des'''4_\pDolce-\hideP( aes'' f'')
+ R2. R2. R2. des'''4_\pDolce( aes'' f'')
+ R2. R2. d''2._\pCresc ~ d''2. ~ d''2. ~ d''2. ~ d''2. bes''!2.
  bes''2.\f ees'''2.\ff des'''4 r r R2. r4 bes''4 bes''4\sf( c''') c''' ees''
  f''\f r r R2. des'''4 r r R2. f'''4 r r r f''' f'''
  c'''2.\sf c'''2.\sf des'''2.\sf c'''2.\sf des'''2.\sf c'''2.\sf des'''4 r r
  R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2.
  c'''4\ff c''' r8 c''' c'''4 c''' r8 c''' c'''4 c''' r r4 r r8 r^\fermata
- R2. R2.^\markup { "Flauto piccolo." }
+ R2. R2.^\flautoPiccolo
  R2. R2. R2. R2. R2. R2.^\fermataMarkup \bar "||"
 
  \key f \major \time 4/4 R1 R1 R1 R1 R1 R1
- c''\p^\markup { \musicglyph #"scripts-trill"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" }^\markup { "Flauto piccolo." } ~ c''2.( d''16 e'' f'' g'')
+ c''\p^\markup { "Flauto piccolo." }\startTrillSpan ~ c''2.(\stopTrillSpan d''16 e'' f'' g'')
  a''2\ff ~ a''8( g'') f''\staccato g''\staccato a''2\sf ~ a''8( g'') f''\staccato g''\staccato
  a''8\sf( g'') f''\staccato g''\staccato a''8\sf( g'') f''\staccato g''\staccato
  a''8\sf( g'') f''\staccato g''\staccato a''8\sf( g'') f''\staccato g''\staccato
@@ -71,9 +64,9 @@
  a''8 g'' f'' e'' f'' e'' d'' cis'' d'' c'''! bes'' a'' bes'' g'' c''' c'''
  f''4 r r2 R1 R1 R1
  r8 a''16( bes'' c'''4) r8
- \set tupletSpannerDuration = #(ly:make-moment 1 4) \times 2/3 { a''16[ bes'' c'''] } d'''4
- r8 g''16( a'' bes''4) r8 \times 2/3 { g''16[ a'' bes''] } c'''4
- \cresc a''8 bes'' c''' cis''' d''' c''' bes'' a'' bes'' a'' g'' a'' bes'' c''' d''' e'''
+ \tupletSpan 4 \tuplet 3/2 { a''16[ bes'' c'''] } d'''4
+ r8 g''16( a'' bes''4) r8 \tuplet 3/2 { g''16[ a'' bes''] } c'''4
+ a''8-\hideMF\cresc bes'' c''' cis''' d''' c''' bes'' a'' bes'' a'' g'' a'' bes'' c''' d''' e'''
  f'''4\sf( ees''' d''' fis''') g'''\sf( des''' c''' e'''!) f''!2 g'' a'' bes'' b''4 c'''2. ~ c'''1
  bes''!8 g''16( a'') bes''4 r8 g''16( a'') bes''4
  r8 g''16( a'') bes''4 r8 g''16( a'') bes''8\staccato e''\staccato
@@ -84,9 +77,9 @@
  f''2.\sf c''8 c'' f''4\staccato c''\staccato a'\staccato c''\staccato
  f''2 a''4 a''8 a'' c'''2.\sf c''4 f''2 a''4 a''8 a'' c'''2.\sf c''4
  f''2 a''4 a''8 a'' c'''2.\sf c''4 c'''2.\sf c''4 c'''2.\sf c''4 c'''1\ff ~ c'''1
- f'''4 r8 \times 2/3 { c'''16([ d''' e'''] } f'''4) r4
- r4 r8 \times 2/3 { c'''16([ d''' e'''] } f'''4) r4
- r4 r8 \times 2/3 { c'''16([ d''' e'''] } f'''4) r4
- r4 r8 \times 2/3 { c'''16([ d''' e'''] } f'''4) r8 \times 2/3 { c'''16([ d''' e'''] } f'''4) r4 r2
+ f'''4 r8 \tuplet 3/2 { c'''16([ d''' e'''] } f'''4) r4
+ r4 r8 \tuplet 3/2 { c'''16([ d''' e'''] } f'''4) r4
+ r4 r8 \tuplet 3/2 { c'''16([ d''' e'''] } f'''4) r4
+ r4 r8 \tuplet 3/2 { c'''16([ d''' e'''] } f'''4) r8 \tuplet 3/2 { c'''16([ d''' e'''] } f'''4) r4 r2
  \bar "|."
 }

--- a/ftp/BeethovenLv/O84/Egmont/Egmont-lys/oboi.ly
+++ b/ftp/BeethovenLv/O84/Egmont/Egmont-lys/oboi.ly
@@ -1,22 +1,23 @@
-\version "2.4.0"
+\version "2.18.2"
+
+\include "defs.ily"
 
  oboi =  {
- \set Staff.instrument = "Oboi"
+ \set Staff.instrumentName = "Oboi"
  \set Staff.midiInstrument = "oboe"
  \clef treble
  \key f \minor
  \time 3/2
- \override Staff.AccidentalPlacement   #'padding = #0.5
- << { <f' f''>1.\fermata } \\ { s2\f s4 s4\> s4 s4\! } >> R1. R1. R1.
+ \moreAccidentalPadding
+ <f' f''>1.\fermata_\forteSforzato-\hideF
+ R1. R1. R1.
  r2 r4^\p \stemUp \slurUp c''4( b' aes'' g'') f''2 ~ f''2 f''4
- \once \override Slur   #'attachment = #'(stem . stem)
  f''2( ees''4) r4 r2 R1. <f' f''>1.\ff
  \stemDown <f'' aes''>2\staccato <f'' aes''>2\staccato r4 r8 <f'' aes''>8\staccato
  <g'' bes''>2\staccato <aes'' c'''>2\staccato r2
- << { r2 r2 r4 \stemUp des''!\p ~ des'' r4 r4
- \override Slur   #'attachment = #'(stem . stem)
+ << { r2 r2 r4 \stemUp des''!^\p ~ des'' r4 r4
  ges''( f'' bes') r4
- \override Slur   #'attachment = #'(stem . stem) f''4( ees''2. c''4)
+ f''4( ees''2. c''4)
  des''4 r4 r2 r2 } \\ { R1. R1. R1. R1. } >>
  R1. R1. R1. R1.
  << { g''4\rest bes''4\pp( c'''8 bes'' aes'' g'') g''4 g''4\rest
@@ -26,12 +27,12 @@
  R1. R1. \bar "||"
 
  \time 3/4 R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2.
- r4 r4 f''4\<( ees''2\!\> des''4\! c'') r4 r4 R2. c''4\p r4 r4
+ r4 r4 \hairpinPastBarline f''4\<( ees''2\!\> des''4\! c'') r4 r4 R2. c''4\p r4 r4
  r4 <g' e''> r4 r4 <aes' f''> r4 r4 <e'' g''> r4 r4 <f'' aes''> r4
- r4 \cresc <g'' bes''> r r <g'' bes''> r r <g'' bes''> r r <g'' bes''> r
+ r4 <g'' bes''>\cresc r r <g'' bes''> r r <g'' bes''> r r <g'' bes''> r
  r4 <g'' bes''> r r <g'' bes''> r r <g'' bes''> r r <g'' bes''> r
  r4 <g'' bes''> r r <g'' bes''> r r <g'' bes''> r r <g'' bes''>
- <c'' c'''>\ff( <f'' aes''>2.) ~ <f'' aes''>2. ~
+ \doubleSlursOn <c'' c'''>\ff( <f'' aes''>2.) ~ \doubleSlursOff <f'' aes''>2. ~
  <f'' aes''>4 <f'' aes''> <f'' aes''> <e'' g''> r
  <g'' bes''>4\ff ~ <g'' bes''>2. ~ <g'' bes''>2. ~ <g'' bes''>4 <g'' bes''> <g'' bes''>
  <f'' aes''>4 r r <g'' bes''> r r <aes'' c'''> r r <bes'' des'''> <bes'' des'''> <bes'' c'''>
@@ -39,9 +40,9 @@
  <des'' bes''> <des'' bes''> <d'' bes''>
  <ees'' g''>2.\sf <ees'' aes''>2.\sf <f'' aes''>2.\sf <ees'' g''>4 <ees'' g''>4 <ees'' g''>4
  <ees'' g''>2.\sf <ees'' aes''>2.\sf <f'' aes''>2.\sf <ees'' g''>4 r r R2. R2. R2.
- <aes'' c'''>4_\markup { \italic \large "p dolce" }( <ees'' aes''>4 <c'' ees''>4) R2. R2. R2.
- <aes'' c'''>4_\markup { \italic \large "p dolce" }( <ees'' aes''>4 <c'' ees''>4) R2. R2.
- <cis'' e''>2._\markup { \italic \large "p cresc." }( <d'' fis''>4 <e'' gis''> <fis'' a''>)
+ <aes'' c'''>4_\pDolce-\hideP( <ees'' aes''>4 <c'' ees''>4) R2. R2. R2.
+ <aes'' c'''>4_\pDolce( <ees'' aes''>4 <c'' ees''>4) R2. R2.
+ <cis'' e''>2._\pCresc( <d'' fis''>4 <e'' gis''> <fis'' a''>)
  <cis'' e''>2.( <d'' fis''>4 <e'' gis''> <fis'' a''>) <cis'' e''>2.
  <d'' f''!>2. ~ <d'' f''>2.\f <ees''! bes''!>2.\ff <ees'' aes''!>4 r r r r <aes' aes''>\sf
  <bes' bes''>4 <bes' bes''> <bes' bes''>\sf ~ <bes' bes''> <des'' bes''> <des'' bes''>
@@ -49,43 +50,44 @@
  <bes'' des'''>2.\sf <bes'' des'''>2.\sf <aes'' c'''>2.\sf
  <bes'' des'''>2.\sf <aes'' c'''>2.\sf <bes'' des'''>2.\sf
  <aes'' c'''>4\staccato r r R2. R2. R2. R2.
- << { f''4\rest f''\rest g''_\markup { \italic \large "dolce" }( bes'' g'') f''4\rest }
+ << { f''4\rest f''\rest g''_\dolce( bes'' g'') f''4\rest }
  \\ { R2. R2. } >> r4 r <ees'' g''>\f\staccato <ees'' aes''>\staccato r r R2. R2. R2. R2.
  << { f''4\rest f''\rest a''_\markup { \italic \large "dolce" }( c''' a'') f''4\rest }
  \\ { R2. R2. } >> r4 r <f'' a''>4\f\staccato <f'' bes''>\staccato r r R2. R2. R2. R2.
- << { f''4\rest f''\rest a''_\markup { \italic \large "dolce" }( c''' a'') f''4\rest }
+ << { f''4\rest f''\rest a''_\dolce( c''' a'') f''4\rest }
  \\ { R2. R2. } >> r4 r <f'' a''>4\f\staccato <f'' bes''>\staccato r r R2. R2.
- << { f''4\rest f''\rest f''_\markup { \italic \large "dolce" }( g'' f'') f''4\rest }
+ << { f''4\rest f''\rest f''_\dolce( g'' f'') f''4\rest }
  \\ { R2. R2. } >>
- r4 r << { \tieNeutral \stemDown <ees'' g''>4\p ~ <ees'' g''>2. ~ <ees'' g''>2. ~ <ees'' g''>2
- <ees'' c'''>4( <d'' b''>) } \\ { s4\< s2. s2 s4\! s4\> s2 s4\! } >> r4
+ r4 r << { \tieNeutral \stemDown \once \hide DynamicText <ees'' g''>4\p ~ <ees'' g''>2. ~ <ees'' g''>2. ~ <ees'' g''>2
+ <ees'' c'''>4( <d'' b''>) } \\ { s8..\p s32\< s2. s2 s4\! s4\> s2 s16 s8.\! } >> r4
  <b' g''>4\< ~ <b' g''>2. ~ <b' g''>2. ~ <b' g''>2 <f'' d'''>4\!
  << { g''2.\staccato\pp g''2.\staccato g''2. ~ g''2. e''2.\pp\staccato e''2.\staccato
  e''2. ~ e''2. ~ e''2. ~ e''2 f''4 }
- \\ { R2. R2. R2. R2. R2. R2. \cresc R2. R2. R2. f'4\rest f'\rest f''\sfp } >>
+ \\ { R2. R2. R2. R2. R2. R2. R2.-\hidePPP\cresc
+      R2. R2. f'4\rest f'\rest f''\sfp } >>
  <f'' aes''>4 <f'' aes''>4 r r <f'' aes''>4 r r <f'' aes''>4 r r <g'' bes''>4 r
  r4 <e'' g''>4 r r <e'' g''>4 r r <e'' g''>4 r r <f'' aes''>4 r R2.
- r4 r f''4\<( ees''2\!\> des''4\! c'') r r R2. c''4\p r r
+ r4 r \hairpinPastBarline f''4\<( ees''2\!\> des''4\! c'') r r R2. c''4\p r r
  r4 <g' e''>4\p r r <aes' f''>4 r r <e'' g''>4 r r <f'' aes''> r
- r4 \cresc <g'' bes''> r r <g'' bes''> r r <g'' bes''> r r <g'' bes''> r
+ r4 <g'' bes''>\cresc r r <g'' bes''> r r <g'' bes''> r r <g'' bes''> r
  r4 <g'' bes''> r r <g'' bes''> r r <g'' bes''> r r <g'' bes''> r
  r4 <g'' bes''> r r <g'' bes''> r r <g'' bes''> r r <g'' bes''>
- <c'' c'''>\ff( <f'' aes''>2.) ~ <f'' aes''>2. ~ <f'' aes''>4 <f'' aes''> <f'' aes''>
+ \doubleSlursOn <c'' c'''>\ff( <f'' aes''>2.) ~ \doubleSlursOff <f'' aes''>2. ~ <f'' aes''>4 <f'' aes''> <f'' aes''>
  <e'' g''>4 r <g'' bes''>4\ff ~ <g'' bes''>2. ~ <g'' bes''>2. ~ <g'' bes''>4
  <g'' bes''>4\staccato <g'' bes''>4\staccato <f'' aes''>4 r r R2.
- r4 r <f'' aes''>4\f( <f'' bes''>2.) <f'' aes''>4 r r R2. r4 r <f'' aes''>4\ff
+ r4 r \doubleSlursOn <f'' aes''>4\f( <f'' bes''>2.) \doubleSlursOff <f'' aes''>4 r r R2. r4 r <f'' aes''>4\ff
  <des'' f''>4 r r <ees'' ges''> r r <f'' aes''> r r <ges'' bes''> <ges'' bes''> <ges'' c'''>
  <f'' aes''>4 r r <ees'' ges''> r r <f'' aes''> r r <g''! bes''> <g'' bes''> <aes'' c'''>
  <des'' bes''>2. ~ <des'' bes''>2. << { aes''2. } \\ { c''2\sf ees''4 } >>
  <f'' aes''>2.\sf <g'' bes''>2.\sf <ees'' aes''>2.\sf <ges'' aes''>2.\sf
- <f'' aes''>2.\sf <g'' bes''>2.\sf <ees'' aes''>4 r r
- R2. R2. R2. << { \override Slur   #'attachment = #'(stem . stem)
- aes''4_\markup { \italic \large "p dolce" }( f'' des'') } \\ { R2. } >>
- R2. R2. R2. << { \override Slur   #'attachment = #'(stem . stem)
- aes''4_\markup { \italic \large "p dolce" }( f'' des'') } \\ { R2. } >>
- R2. R2. <fis'' a''>2._\markup { \italic \large "p cresc." }( <g'' b''>4 <a'' cis'''> <b'' d'''>)
+ <f'' aes''>2.\sf <g''! bes''>2.\sf <ees'' aes''>4 r r
+ R2. R2. R2. << { 
+ aes''4_\pDolce-\hideP( f'' des'') } \\ { R2. } >>
+ R2. R2. R2. << { 
+ aes''4_\pDolce( f'' des'') } \\ { R2. } >>
+ R2. R2. <fis'' a''>2._\pCresc( <g'' b''>4 <a'' cis'''> <b'' d'''>)
  <fis'' a''>2.( <g'' b''>4 <a'' cis'''> <b'' d'''>) <fis'' a''>2. <f''! aes''!>2.
- <ees''! ges''>2.\f <ees'' ges''>2.\ff <des''! f''>4 <des'' f''>4 <des'' f''>4\sf( <des'' bes''>4)
+ <ees''! ges''>2.\f <ees'' ges''>2.\ff <des''! f''>4 <des'' f''>4 \doubleSlursOn <des'' f''>4\sf( <des'' bes''>4) \doubleSlursOff
  <des'' ges''>4 <des'' ges''>4\sf( <ees'' ges''>4) <ees'' ges''>4 <ees'' ges''>\sf ~ <ees'' ges''>
  <ees'' ges''>4 <ees'' ges''> <des'' f''>\f r r R2. <des'' f''>4 r r R2.
  <f'' aes''>4 r r r <f'' aes''> <f'' aes''>
@@ -95,11 +97,11 @@
  <c'' aes''>4\ff <c'' aes''> r8 <c'' aes''> <c'' aes''>4 <c'' aes''> r8 <c'' aes''>
  <c'' g''>4 <c'' g''> r r4 r r8 r^\fermata
  R2. R2. R2. R2. << { des''2.^\ppp ~ des''2. c''2. ~ c''2.^\fermata } \\
- { R2. R2. R2. R2._\fermata }>> \bar "||"
+ { R2. R2. R2. R2._\downFermata }>> \bar "||"
 
  \key f \major \time 4/4
  << { c''1\pp c'' } \\ { R1 R1 } >> <b' d''>1\pp <b' d''>1
- <c'' e''>2_\markup { \italic \large "cresc." } <c'' e''>2 <c'' f''> <c'' f''> <e'' g''> <f'' a''>
+ <c'' e''>2_\txtCresc <c'' e''>2 <c'' f''> <c'' f''> <e'' g''> <f'' a''>
  <g'' bes''>8( <fis'' a''>) <g'' bes''>\staccato <a'' c'''>\staccato
  <bes'' d'''>\staccato <c'' e''>\staccato <d'' f''!>\staccato <e'' g''>\staccato
  <f'' a''>2\ff ~ <f'' a''>8( <e'' g''>) <c'' f''>\staccato <e'' g''>\staccato
@@ -118,10 +120,10 @@
  <f'' a''>8\sf( <e'' g''>) <c'' f''>\staccato <e'' g''>\staccato
  << { a''8 g'' f'' e'' f'' e'' d'' cis'' d'' c'''! bes'' a'' bes'' g'' c''' c''' f''4 } \\
  { f''8 g'' f'' e'' f'' e'' d'' cis'' d'' c''! bes' a' bes' g' c'' c'' f'4 } >> r4 r2 R1 R1 R1 R1 R1
- r8 \cresc a''16( bes'') c'''8\staccato r r
- \set tupletSpannerDuration = #(ly:make-moment 1 4) \times 2/3 { a''16[ bes'' c'''] }
+ r8 a''16(-\hideMF\cresc^\aDue bes'') c'''8\staccato r r
+ \tupletSpan 4 \tuplet 3/2 { a''16[ bes'' c'''] }
  d'''8\staccato r
- r8 g''16([ a'']) bes''8\staccato r r \times 2/3 { g''16[ a'' bes''] } c'''8[ c''']
+ r8 g''16([ a'']) bes''8\staccato r r \tuplet 3/2 { g''16[ a'' bes''] } c'''8[ c''']
  f''4\ff( ees'' d'' fis'') g''\sf( des'' c'' e''!) f''!2 g'' a'' bes''
  <b' b''>4 <c'' c'''>2. ~ <c'' c'''>1 <g'' bes''!>4 <g'' bes''> <g'' bes''> <g'' bes''>
  <g'' bes''>4 <g'' bes''> <g'' bes''> <g'' bes''>

--- a/ftp/BeethovenLv/O84/Egmont/Egmont-lys/timpani.ly
+++ b/ftp/BeethovenLv/O84/Egmont/Egmont-lys/timpani.ly
@@ -1,20 +1,23 @@
-\version "2.4.0"
+\version "2.18.2"
+
+\include "defs.ily"
 
  timpani =  {
- \set Staff.instrument = "Timpani F.C."
+ \set Staff.instrumentName = "Timpani F.C."
  \set Staff.midiInstrument = "timpani"
  \clef bass
  \key c \major
  \time 3/2
+ \moreAccidentalPadding
  r1\fermata s2 R1. R1. R1. R1. R1. R1. R1. R1.
  R1. R1. R1. R1. R1. R1. R1. r2 c\pp c r2 c c R1. R1. R1. R1. R1. R1. \bar "||"
 
  \time 3/4 R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2.
  R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2.
  r4 r4 f,4\ff
- \set tupletSpannerDuration = #(ly:make-moment 1 4)
- \times 2/3 { f,8[ f, f,] f,[ f, f,] f,[ f, f,] } f,4 r4 r4 r4 f,4 f, c r c\ff
- \times 2/3 { c8[ c c] c[ c c] c[ c c] } c4 r r r c c f,4 r r f, r r f, r r f, f, f,
+ \tupletSpan 4
+ \tuplet 3/2 { f,8 f, f, \hideTupletNumber f, f, f, f, f, f, } f,4 r4 r4 r4 f,4 f, c r c\ff
+ \tuplet 3/2 { c8[ c c] c[ c c] c[ c c] } c4 r r r c c f,4 r r f, r r f, r r f, f, f,
  f,4 r r f, r r f, r f, f, f, r
  R2. c4 r r R2. R2. R2. c4 r r R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2.
  R2. R2. R2. R2. R2. R2. R2. R2. c4\ff r r f,4 r r f,4 r r R2.
@@ -24,9 +27,9 @@
  R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2.
  R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2.
  R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. r4 r f,\ff
- \set tupletSpannerDuration = #(ly:make-moment 1 4)
- \times 2/3 { f,8[ f, f,] f,[ f, f,] f,[ f, f,] } f,4 r r r f, f,
- c4 r c\ff \times 2/3 { c8[ c c] c[ c c] c[ c c] } c4 r r r c c f, r r
+ \tupletSpan 4
+ \tuplet 3/2 { f,8[ f, f,] f,[ f, f,] f,[ f, f,] } f,4 r r r f, f,
+ c4 r c\ff \tuplet 3/2 { c8[ c c] c[ c c] c[ c c] } c4 r r r c c f, r r
  R2. R2. R2. R2. R2. r4 r f,4\ff f, r r R2. f,4 r r R2. f,4 r r R2. f,4 r r r r c R2. R2.
  c4 r r f, r r R2. c4 r r c r r f, r r R2. c4 r r
  R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2.
@@ -35,124 +38,18 @@
  R2. R2. R2. R2. R2. R2. R2. R2. c4\ff c r8 c c4 c r8 c c4 c r r4 r r8 r^\fermata
  R2. R2. R2. R2. R2. R2. R2. R2.^\fermataMarkup \bar "||"
 
- \time 4/4 c1\pp^\markup { \musicglyph #"scripts-trill"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall"} ~ c1 ~ c1 ~ c1 ~
- c1^\markup { \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall"} ~ c1 ~ c1 ~ c1
+ \time 4/4 c1\pp \startTrillSpan ~ c1 ~ c1 ~ c1 ~
+ c1_\txtCresc ~ c1 ~ c1 ~ c1*15/16 s1*1/16\stopTrillSpan
  f,4\ff r r2 f,4\sf r r2 f,4\sf r f,\sf r f,\sf r f,\sf r
  f,4 r f, f, f, r c r
  f,2\sf\trill f,8 r r4 f,2\sf\trill f,8 r r4
  f,16\sf f, f, f, r4 f,16\sf f, f, f, r4 f,16\sf f, f, f, r4 f,16\sf f, f, f, r4
  f,4 r f, r f, r c r f, r r2 R1 R1 R1 R1 R1 R1 R1
- f,4\ff f, f,8 r r4 r2 c4 c f, r c r c r c r c1^\markup { \musicglyph #"scripts-trill"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall" } ~ c1
+ f,4\ff f, f,8 r r4 r2 c4 c f, r c r c r c r c1 \startTrillSpan ~ c1*15/16 s1*1/16\stopTrillSpan
  c4 r c r c r c r f,4 r8 c c4 r8 c c4 r8 c c4 r8 c
- c4 c2.^\markup { \musicglyph #"scripts-trill"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall" } ~ c1 c4 c c c c c c c
+ c4 c2.\startTrillSpan ~ c1*15/16 s1*1/16\stopTrillSpan c4 c c c c c c c
  f,2^\trill f,4 r R1 f,2^\trill f,4 r R1
  f,4 r f, r c\sf r r c f, r f, r c\sf r r c f,4 r f, r c\sf r r c c\sf r r c c\sf r r c
- f,1\ff^\markup { \musicglyph #"scripts-trill"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" } ~
- f,1^\markup { \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall"
- \musicglyph #"scripts-prall" \musicglyph #"scripts-prall" }
+ f,1\ff ~ \startTrillSpan f,1*15/16 s1*1/16 \stopTrillSpan
  f,4 r r2 f,4 r r2 f,4 r r2 f,4 r f, r f, r r2 \bar "|."
 }

--- a/ftp/BeethovenLv/O84/Egmont/Egmont-lys/trombe.ly
+++ b/ftp/BeethovenLv/O84/Egmont/Egmont-lys/trombe.ly
@@ -1,17 +1,18 @@
-\version "2.4.0"
+\version "2.18.2"
+
+\include "defs.ily"
 
  trombe =  {
- \set Staff.instrument = "Trombe in F"
+ \set Staff.instrumentName = "Trombe in F"
  \set Staff.midiInstrument = "english horn"
  \clef treble
  \key c \major
  \time 3/2
- \override Staff.AccidentalPlacement   #'padding = #0.5
- << { <c' c''>1.\fermata } \\
- { \override DynamicLineSpanner   #'padding = #2.5 s2\f s4 s4\> s4 s4\! } >>
+ \moreAccidentalPadding
+ <c' c''>1.\fermata-\forteSforzato-\hideF
  R1. R1. R1. R1. R1. R1. R1. <c' c''>1.\ff
  << { c'2\staccato c'\staccato } \\ { c'2 c'2 } >> r2 r2 << { g'2 } \\ { g'2 } >> r2
- R1. R1. R1. R1. R1. << { R1. R1. } \\ { r2 g2\pp g r2 g2 g } >>
+ R1. R1. R1. R1. R1. << { R1. R1. } \\ { \posDynamicTxtD r2\pp g2_. g_. r2 g2 g } >>
  R1. R1. R1. R1. R1. R1. \bar "||"
 
  \time 3/4 R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2.
@@ -43,7 +44,7 @@
  <g g'>4\ff <g g'> r8 <g g'> <g g'>4 <g g'> r8 <g g'> <g g'>4 <g g'> r r4 r r8 r^\fermata
  R2. R2. R2. R2. R2. R2. R2. R2.^\fermataMarkup \bar "||"
 
- \time 4/4 R1 R1 R1 R1 R1 R1 R1 <g g'>1\p
+ \time 4/4 R1 R1 R1 R1 R1 R1 R1 <g g'>1-\hideP_\pCresc
  << { c''2 ~ c''8( g') e'\staccato g'\staccato c''2 ~ c''8( g') e'\staccato g'\staccato
  c''8( g') e'\staccato g'\staccato c''( g') e'\staccato g'\staccato
  c''8( g') e'\staccato g'\staccato c''( g') e'\staccato g'\staccato } \\
@@ -60,12 +61,12 @@
  <c'' d''>4 <c'' d''>8 <c'' d''> <g' d''>4 <g' d''>8 <g' d''> <c' c''>4 r r2 R1
  R1 R1 R1 R1 R1 R1
  <c' c''>4\ff <c' c''> <c' c''>8 r r4 r2 <g g'>4 <g g'> <c' c''>4 r <g g'> r <g g'> r <g g'> r
- <g g'>8 <g g'>16 <g g'> <g g'>8 <g g'> <g g'> <g g'> <g g'> <g g'>
- <g g'>8 <g g'> <g g'> <g g'> <g g'> <g g'> <g g'> <g g'>
+ <g g'>8 <g g'>16 <g g'> <g g'>8 <g g'> <g g'>[ <g g'>] <g g'> <g g'>
+ <g g'>8[ <g g'>] <g g'> <g g'> <g g'>[ <g g'>] <g g'> <g g'>
  <g g'>4 <g g'> <g g'> <g g'> <g g'> <g g'> <g g'> <g g'>
  <c' c''>4 r <g g'> r <g g'> r <g g'> r
- <g g'>8 <g g'>16 <g g'> <g g'>8 <g g'> <g g'> <g g'> <g g'> <g g'>
- <g g'>8 <g g'> <g g'> <g g'> <g g'> <g g'> <g g'> <g g'>
+ <g g'>8 <g g'>16 <g g'> <g g'>8 <g g'> <g g'>[ <g g'>] <g g'> <g g'>
+ <g g'>8[ <g g'>] <g g'> <g g'> <g g'>[ <g g'>] <g g'> <g g'>
  <g g'>4 <g g'> <g g'> <g g'> <g g'> <g g'> <g g'> <g g'>
  <c' c''>2. <g g'>4 <c' c''>4\staccato <g g'>4\staccato
  << { e'4\staccato } \\ { e'4 } >> <g g'>4\staccato

--- a/ftp/BeethovenLv/O84/Egmont/Egmont-lys/viola.ly
+++ b/ftp/BeethovenLv/O84/Egmont/Egmont-lys/viola.ly
@@ -1,19 +1,20 @@
-\version "2.4.0"
+\version "2.18.2"
+
+\include "defs.ily"
 
  viola =  {
- \set Staff.instrument = "Viola"
+ \set Staff.instrumentName = "Viola"
  \set Staff.midiInstrument = "viola"
  \clef alto
  \key f \minor
  \time 3/2
- \override Staff.AccidentalPlacement   #'padding = #0.5
- << { f1.\fermata } \\ { s2\f s4 s4\> s4 s4\! } >>
- <c f>2\staccato_"marcato" <c f>\staccato r4 r8 <c f>8
+ \moreAccidentalPadding
+ f1.\fermata_\forteSforzato-\hideF
+ <c f>2\staccato_\txtMarcato <c f>\staccato r4 r8 <c f>8
  ees2\staccato ees2\staccato r4 r8 c8 g2\staccato g2\staccato r4 r8 d8\p
  c4 r4 r2 r2 R1. R1.
- << { r2 r4 des'!2( c'4) } \\
- { \override DynamicLineSpanner   #'padding = #3.0
- s4 s4 s4\< s4\! s4\> s8 s8\! } >> f1.\ff
+ << { r2 r4 \stemDown des'!2( c'4) \stemNeutral } \\
+ { \spaceSpannerF s4 s4 s4\< s4\! s4\> s8 s8\! } >> f1.\ff
  c2\staccato c2\staccato r4 r8 c8 ees2\staccato ees2\staccato r2 R1. R1.
  r2 r2 <ees ges>2\p
  f16\pp <f aes> <f aes> <f aes> <f aes> <f aes> <f aes> <f aes> <f aes>2:16 <f aes>2:16
@@ -27,14 +28,14 @@
  << { bes4 } \\ { <e g>4 } >> r4 r2 r4 r8 << { bes8 } \\ { <e g>8 } >>
  << { bes4 } \\ { <e g>4 } >> r4 r2 r2 \bar "||"
 
- \time 3/4 R2. R2. R2. r4 r4 f'8\sfp f' f' f' f' f' f' f' f' f' f' f' f' f'
+ \time 3/4 R2. R2. R2. r4 r4 f'8\sfp f'-\hideP f' f' f' f' f' f' f' f' f' f' f' f'
  f' f' f' f' f' f' g'[ g' g' g'] e'\sfp[ e'] e'2.:8 e'2.:8 e'2.:8 e'8 e' f' f'
- << { f4 ~ f4. f8\staccato[ f\staccato g\staccato] } \\ { s4\< s4\!\> s4 s8 s8\! } >>
- aes4( f) << { f4 ~ f4. f8\staccato[ f\staccato g\staccato] } \\ { s4\< s4\!\> s4 s8 s8\! } >>
- aes4( f) << { f4 ~ f4. f8\staccato[ f\staccato g\staccato] } \\ { s4\< s4\!\> s4 s8 s8\! } >>
+ \hairpinPastBarline f4\< ~ f4.\> f8_\staccato f_\staccato g_\staccato\!
+ aes4( f) \hairpinPastBarline f4\< ~ f4.\> f8\staccato f\staccato g\staccato\!
+ aes4( f) \hairpinPastBarline f4\< ~ f4.\> f8\staccato f\staccato g\staccato\!
  aes4 r8 f'8\staccato[ f'\staccato c'\staccato]
  c'4 r8 e'8[ e' f'] f'8 c' c'2 c'8 c' c'2 c'8 c' c'2
- \cresc <c bes>2. ~ <c bes>2. ~ <c bes>2. ~ <c bes>2.
+ <c bes>2.\cresc ~ <c bes>2. ~ <c bes>2. ~ <c bes>2.
  <c bes>2. ~ <c bes>2. ~ <c bes>2. ~ <c bes>2.
  <c bes>2. ~ <c bes>2. ~ <c bes>2. ~ <c bes>4 r4 c8\ff([ des]
  c8 des c des c des) c( des c des c des) c( des c des c des)
@@ -45,10 +46,10 @@
  ees2\sf( des8 ees) c2\sf( ees8 aes) d2\sf( f8 bes) bes4 r r
  aes4\ff\staccato aes4\staccato r8 aes8 aes4 aes r R2. R2.
  aes4\ff aes r8 aes aes4 aes r R2. R2. aes4\ff aes r8 aes aes4 aes r
- \override TextScript   #'padding = #1.5
- a2._\markup { \italic \large "p cresc." } ~ a2. ~ a2. ~ a2. ~ a2. ~ a2. aes!2.\f g2.\ff
- \set tupletSpannerDuration = #(ly:make-moment 1 4)
- \times 2/3 { c8[ c c] c[ c c] c\sf[ c c] f[ f f] f[ f f] f\sf[ f f]
+ \once \override TextScript.padding = #1.5
+ a2._\pCresc-\hideP ~ a2. ~ a2. ~ a2. ~ a2. ~ a2. aes!2.\f g2.\ff
+ \tupletSpan 4
+ \tuplet 3/2 { c8[ c c] c[ c c] c\sf[ c c] f[ f f] f[ f f] f\sf[ f f]
  des8[ des des] des[ des des] des\sf[ des des] des[ des des] des[ des des] des[ des des] }
  c4\f r r R2. aes4 r r R2. aes4 r r R2. <bes des'>2.:8\sf <bes des'>2.:8\sf
  <aes c'>8\sf <aes c'> <aes c'> <aes c'> <c' ees'> <c' ees'> <bes des'>2.:8\sf
@@ -56,25 +57,25 @@
  \stemUp aes'8\fp[ <ees aes>] <ees aes>[ <ees aes> <ees aes> <ees aes>]
  <ees aes>2.:8 <ees aes>2.:8 <ees aes>2.:8 <ees g>2.:8 <ees g>2.:8 <ees g>2.:8
  <ees g>8[ <ees g> <ees g> <ees g>] \stemDown ees'4\f\staccato
- \stemUp aes8 <ees aes>\p[ <ees aes> <ees aes> <ees aes> <ees aes>]
+ \stemUp aes8\noBeam <ees aes>\p <ees aes>[ <ees aes> <ees aes> <ees aes>]
  <ees aes>2.:8 <ees aes>2.:8 <ees aes>8[ <ees aes> <ees aes> <ees aes>] ges[ ges]
  f2.:8 f2.:8 f2.:8 f8 f f f \stemDown f'4\f\staccato
- \stemUp bes8\staccato <f bes>\p[ <f bes> <f bes> <f bes> <f bes>]
+ \stemUp bes8\staccato <f bes>\p <f bes>[ <f bes> <f bes> <f bes>]
  <f bes>2.:8 <f bes>2.:8 <f bes>2.:8 f2.:8 f2.:8 f2.:8 f8[ f f f] \stemDown f'4\f\staccato
- \stemUp <f bes>8\staccato <f bes>\p[ <f bes> <f bes> <f bes> <f bes>] <f bes>2.:8 <f bes>2.:8
+ \stemUp <f bes>8\staccato <f bes>\p <f bes>[ <f bes> <f bes> <f bes>] <f bes>2.:8 <f bes>2.:8
  <f bes>8[ <f bes> <f bes> <f bes>] <f b>[ <f b>] <f b>2.:8 <f b>8[ <f b> <f b> <f b>]
- \override DynamicLineSpanner   #'padding = #2.5
+ \spaceSpannerA
  g8\p\<([ aes] g[ aes g aes g aes]) g( aes g aes g aes\!) g\>( aes g aes g aes\!)
  g8\<( aes g aes g aes) g( aes g aes g aes) g( aes g aes g aes) g( aes g aes) g4\!
  R2. R2. R2. R2. r8 bes8\pp([ c' bes aes g]) r bes([ c' bes aes g])
- r8 \cresc bes([ c' bes aes g]) c'([ bes aes g c' bes]) aes([ g c' bes aes g]) c'([ bes aes g])
+ r8 \spaceSpannerB bes([\cresc c' bes aes g]) c'([ bes aes g c' bes]) aes([ g c' bes aes g]) c'([ bes aes g])
  \stemDown f'8\sfp[ f'] f' f' f' f' f' f' f' f' f' f' f' f' f' f' f' f' f' f' g'[ g' g' g']
  e'8\sfp[ e'] e' e' e' e' e' e' e' e' e' e' e' e' e' e' e' e' e' e' e'[ e' f' f']
- \stemUp f4\< ~ f4.\!\> f8\staccato[ f\staccato g\staccato\!] aes4( f) f4\< ~ f2.\!\> ~ f4\! r
- f4\< ~ f4.\!\> f8\staccato[ f\staccato g\staccato\!] aes4 r8
+ \stemUp \hairpinPastBarline f4\< ~ f4.\!\> f8\staccato[ f\staccato g\staccato\!] aes4( f) \hairpinPastBarline f4\< ~ f2.\!\> ~ f4\! r
+ \hairpinPastBarline f4\< ~ f4.\> f8\staccato f\staccato g\staccato\! aes4 r8
  \stemDown f'8\staccato[ f'\staccato c'\staccato] c'4 r8 e'[ e' f'] f'[ c'] c'2
  c'8[ c'] c'2 c'8[ c'] c'2
- \cresc \stemUp <c bes>2. ~ <c bes>2. ~ <c bes>2. ~ <c bes>2.
+ \stemUp <c bes>2.\cresc ~ <c bes>2. ~ <c bes>2. ~ <c bes>2.
  <c bes>2. ~ <c bes>2. ~ <c bes>2. ~ <c bes>2.
  <c bes>2. ~ <c bes>2. ~ <c bes>2. ~ <c bes>4 r4 c8\ff([ des] c[ des c des c des])
  c8( des c des c des) c( des c des c des) c( des c des c des) c( des c des c des)
@@ -83,16 +84,16 @@
  f4 ~ f4. f8\staccato[ f\staccato g\staccato] aes4( f)
  f4 ~ f4. f8\staccato[ f\staccato g\staccato] aes4( f) r4
  f4 r8 f8\staccato[ ees\staccato des\staccato] ges4 r8 ges[ f ees] aes4 r8 aes[ ges f]
- bes4 ges aes f r8 f[ ees des] ges4 r8 ges[ f ees] aes4 r8 aes[ ges f]
- \stemDown des'4 des' c' \stemUp bes8[ g] g[ g g g] \stemDown ees' ees' ees' ees' ees' ees'
+ bes4 ges aes f r8 f[ ees des!] ges4 r8 ges[ f ees] aes4 r8 aes[ ges f]
+ \stemDown des'4 des' c' \stemUp bes8[ g!] g[ g g g] \stemDown ees' ees' ees' ees' ees' ees'
  \stemUp aes2\sf( \stemDown c'8 ees') \stemUp f2\sf( aes8 des') ees2\sf( g8 bes)
  ees2\sf( aes8 c') c2\sf( ees8 ges) des2\sf( f8 aes) des2\sf( ees8 des) c4 r r
  f4\ff\staccato f4\staccato r8 f ges4 ges r R2. R2. f4\ff f4 r8 f ges4 ges r R2. R2.
  \stemDown des'4\ff des' r8 des' des'4 des' r
- \stemUp <d d'>2.\p ~ <d d'>2. ~ <d d'>2. ~ <d d'>2. ~ <d d'>2. ~ <d d'>2.
- \set tupletSpannerDuration = #(ly:make-moment 1 4)
- \stemDown \times 2/3 { ges'8\f[ ges' ges'] ges'[ ges' ges'] ges'[ ges' ges']
- <aes ges'>8\ff[ <aes ges'> <aes ges'>] <aes ges'>[ <aes ges'> <aes ges'>]
+ \stemUp <d d'>2.-\hideP_\pCresc ~ <d d'>2. ~ <d d'>2. ~ <d d'>2. ~ <d d'>2. ~ <d d'>2.
+ \tupletSpan 4
+ \stemDown \tuplet 3/2 { ges'8\f[ ges' ges'] ges'[ ges' ges'] ges'[ ges' ges']
+ \hideTupletNumber <aes ges'>8\ff[ <aes ges'> <aes ges'>] <aes ges'>[ <aes ges'> <aes ges'>]
  <aes ges'>8[ <aes ges'> <aes ges'>] f'[ f' f'] \stemUp f[ f f] f\sf[ f f]
  bes8[ bes bes] bes8[ bes bes] bes8\sf[ bes bes] ges[ ges ges] ges[ ges ges] ges\sf[ ges ges]
  <ees ges>8[ <ees ges> <ees ges>] <ees ges>[ <ees ges> <ees ges>] <ees ges>[ <ees ges> <ees ges>] }
@@ -101,21 +102,21 @@
  <ges aes>2.:8 <ges aes>2.:8 <f aes>2.:8 <ges aes>2.:8 <f aes>2.:8 <ges aes>2.:8 <f aes>4 } \\
  { des8\f[ des] des[ des des des] des des des des des des des2.:8 des2.:8 des2.:8 des2.:8
  ees2.\sf ees2.\sf des2.\sf ees2.\sf des2.\sf ees2.\sf des4 } >> r4 r R2. R2. R2.
- des'4\p\staccato des'4\staccato r des'4\staccato des'4\staccato r ees'4 ees' r c' c' r R2. R2. R2. R2.
+ \stemNeutral des'4\p\staccato des'4\staccato r des'4\staccato des'4\staccato r ees'4 ees' r c' c' r R2. R2. R2. R2.
  \stemUp bes4\p\staccato bes\staccato r bes4 bes r bes bes r g! g r
  <f aes>4\ff <f aes> r8 <f aes> <f aes>4 <f aes> r8 <f aes> g4 g r r4 r r8 r^\fermata
  R2. R2. R2. R2. R2. R2. R2. R2.^\fermataMarkup \bar "||"
 
  \key f \major \time 4/4
  \stemDown e'16\pp e' e' e' e' e' e' e' e'2:16 e'2:16 e'2:16 aes'2:16 aes'2:16 aes'2:16 aes'2:16
- g'16_\markup { \italic \large "cresc." } g' g' g' e' e' e' e' g' g' g' g' e' e' e' e'
+ g'16_\txtCresc g' g' g' e' e' e' e' g' g' g' g' e' e' e' e'
  a'!16 a' a' a' f' f' f' f' a' a' a' a' f' f' f' f'
  \stemUp c'8( b) c'\staccato c'\staccato c'( b) c'\staccato c'\staccato
  \stemDown g'16 c'' c'' c'' c'' c'' c'' c'' c'' c'' c'' c'' c'' c'' c'' c''
  c''2:16\ff c''2:16 c''2:16\sf c''2:16 c''2:16\sf c''2:16\sf c''2:16\sf c''2:16\sf
  c''8 g'16[ g'] f' f' e' e' f' f' e' e' d' d' cis' cis'
  d'16 d' c'! c' \stemUp bes bes a a bes bes g g \stemDown c' c' c' c'
- g'16 c'' c'' c'' c'' c'' c'' c'' c'' c'' c'' c'' c'' c'' c'' c''
+ f'16\sf c'' c'' c'' c'' c'' c'' c'' c'' c'' c'' c'' c'' c'' c'' c''
  c''2:16\sf c''2:16 c''2:16\sf c''2:16\sf c''2:16\sf c''2:16\sf
  c''8 g'16[ g'] f' f' e' e' f' f' e' e' d' d' cis' cis'
  d'16 d' c'! c' \stemUp bes bes a a bes bes g g \stemDown c' c' c' c'
@@ -124,14 +125,14 @@
  f'!4\sf( ees' d' fis') g'\sf( des' c' e'!)
  \stemUp f4\sf( ees d fis) g\sf( des c <c c'>)
  a8\ff a bes c' d' c' bes a bes\sf c des bes e g g c'
- f2_\markup { \italic \large "marcato" } e f g gis4 a2. ~ a1
- \set tupletSpannerDuration = #(ly:make-moment 1 4)
- \times 2/3 { <g! bes>8[ <g e'> <g e'>] <g e'>[ <g e'> <g e'>]
+ f2_\txtMarcato e f g gis4 a2. ~ a1
+ \tupletSpan 4
+ \tuplet 3/2 { <g! bes>8[ <g e'> <g e'>] <g e'>[ <g e'> <g e'>]
  <g e'>8[ <g e'> <g e'>] <g e'>[ <g e'> <g e'>]
  <g e'>8[ <g e'> <g e'>] <g e'>[ <g e'> <g e'>] 
  <g e'>8[ <g e'> <g e'>] <g e'>[ <g e'> <g e'>] }
  f4. f8 e4. e8 f4. f8 g4. g8 gis4 a2. ~ a1
- \times 2/3 { <g! e'>8[ <g e'> <g e'>] <g e'>[ <g e'> <g e'>]
+ \tuplet 3/2 { <g! e'>8[ <g e'> <g e'>] <g e'>[ <g e'> <g e'>]
  <g e'>8[ <g e'> <g e'>] <g e'>[ <g e'> <g e'>]
  <g e'>8[ <g e'> <g e'>] <g e'>[ <g e'> <g e'>] 
  <g e'>8[ <g e'> <g e'>] <g e'>[ <g e'> <g e'>] }

--- a/ftp/BeethovenLv/O84/Egmont/Egmont-lys/violinoone.ly
+++ b/ftp/BeethovenLv/O84/Egmont/Egmont-lys/violinoone.ly
@@ -1,20 +1,21 @@
-\version "2.4.0"
+\version "2.18.2"
+
+\include "defs.ily"
 
  violinoone =  {
- \set Staff.instrument = "Violino I"
+ \set Staff.instrumentName = "Violino I"
  \set Staff.midiInstrument = "violin"
  \clef treble
  \key f \minor
  \time 3/2
- \override Staff.AccidentalPlacement   #'padding = #0.5
- << { f'1.\fermata } \\ { s2\f s4 s4\> s4 s4\! } >>
- aes2\staccato_"marcato" aes2\staccato r4 r8 aes
+ \moreAccidentalPadding
+ f'1.\fermata-\forteSforzato-\hideF
+ aes2\staccato_\txtMarcato aes2\staccato r4 r8 aes
  bes2\staccato c'\staccato r4 r8
  c' d'2\staccato ees'\staccato r4 r8 b8\p c'4 r4 r2 r2
  R1. r2 r4 c'4\p( b aes')
- << { \override Slur   #'attachment = #'(stem . stem) g'4( f'2 ~ f'2 e'4) } \\
- { \override DynamicLineSpanner   #'padding = #2.0
- s4 s4 s4\< s4\! s4\> s8 s8\! } >> f'1.\ff
+ << { g'4_( f'2_~ f'2 e'4) } \\
+ { \spaceSpannerE s4 s4 s4\< s4\! s4\> s8 s8\! } >> f'1.\ff
  aes2\staccato aes2\staccato r4 r8 aes8 bes2\staccato c'\staccato r2 R1. R1.
  r2 r2 c'2\p des'4\pp aes''4( bes''8 aes'' ges'' f'') f''4 r4
  r4 aes''4( bes''8 aes'' ges'' f'') f''4 r4 r4 ees''4( f''8 ees'' des'' c'') c''4 r4
@@ -23,22 +24,22 @@
  R1. R1. r4 bes'4\pp( c'' bes' aes' g') \bar "||"
 
  \time 3/4
- r8 \cresc \stemUp bes'([ c'' bes' aes' g'] c'' bes' aes' g' c'' bes')
+ r8 \stemUp bes'([\cresc c'' bes' aes' g'] c'' bes' aes' g' c'' bes')
  aes'( g' c'' bes' aes' g') c''( bes' aes' g') \stemDown c''4\sfp ~
- c''2. ~ c''2. ~ c''4 c''4( f''4) ~ f''4( e'') c''4\sfp ~
+ c''2.-\hideP ~ c''2. ~ c''4 c''4( f''4) ~ f''4( e'') c''4\sfp ~
  c''2. ~ c''2. ~ c''4 c''4( e'' g'' f'')
- f''4\<( ees''!2\!\> des''4\! c''4) r4 r4 R2. r4 r4 f''4\<( ees''2\!\> des''4\! c''4) r8
+ \hairpinPastBarline f''4\<( ees''!2\!\> des''4\! c''4) r4 r4 R2. r4 r4 \hairpinPastBarline f''4\<( ees''2\!\> des''4\! c''4) r8
  f''8\staccato[ f''\staccato e''\staccato]
  e''4 r8 g''8[ g'' f''] f''4 r8 aes''[ aes'' g''] g''4 r8 bes''[ bes'' aes'']
  aes''4 r8 c'''8[ c''' bes'']
- bes''4 r8 \cresc bes''8[ c''' des'''] des'''4 r8 g''[ aes'' bes'']
+ bes''4 r8 bes''8[\cresc c''' des'''] des'''4 r8 g''[ aes'' bes'']
  bes''4 r8 e''8[ f'' g''] g''4 r8 g''8[ aes'' bes''] bes''4 r8 bes''8[ c''' des''']
  des'''4 r8 g''[ aes'' bes''] bes''4 r8 e''[ f'' g'']
  g''4 r8 g''8[ aes'' bes''] bes''4 r8 bes''[ c''' des''']
  des'''4 r8 bes''[ c''' des'''] des'''4 r8 bes''[ c''' des'''] des'''4 r
  c'''4\ff( des''' c''') aes''\staccato f''\staccato des''\staccato c''\staccato
  \stemDown aes'2( f'4) e'4 r4
- \stemUp c'''4\ff( des''' c''') bes''\staccato g''\staccato e''\staccato des''\staccato
+ \stemNeutral c'''4\ff( des''' c''') bes''\staccato g''\staccato e''\staccato des''\staccato
  c''2( \stemUp bes'8 g') f'4 r8 \stemDown f''\staccato[ g''\staccato aes''\staccato] bes''4 r8
  g''[ aes'' bes''] c'''4 r8 aes''[ bes'' c'''] des'''4 des''' e''' f'''4 r8 f''[ g'' aes'']
  bes''4 r8 g''[ aes'' bes''] c'''4 r8 aes''[ bes'' c'''] des'''4 des''' d'''
@@ -47,8 +48,8 @@
  ees'4\ff\staccato ees'4\staccato r8 ees' f'4 f' r R2. R2.
  ees'4\ff ees'4 r8 ees' f'4 f' r R2. R2. ees'4\ff ees'4 r8 ees' fes'4 fes' r
  R2. R2. R2. R2. R2. R2.
- \set tupletSpannerDuration = #(ly:make-moment 1 4)
- \stemDown \times 2/3 { bes''!8\f[ bes'' bes''] bes''[ bes'' bes''] bes''[ bes'' bes'']
+ \tupletSpan 4
+ \stemDown \tuplet 3/2 { bes''!8\f[ bes'' bes''] bes''[ bes'' bes''] bes''[ bes'' bes'']
  ees'''8\ff[ ees''' ees'''] ees'''[ ees''' ees'''] ees'''[ ees''' ees''']
  ees'''8[ ees''' ees'''] c'''[ c''' c'''] aes''[ aes'' aes'']
  aes''8[ aes'' aes''] f''[ f'' f''] f''\sf[ f'' f'']
@@ -62,23 +63,23 @@
  \stemUp <ees' c'' aes''>8\fp[ ees'] ees'[ ees' ees' ees'] ees'2.:8 ees'2.:8 ees'2.:8
  <des' ees'>2.:8 <des' ees'>2.:8 <bes ees'>2.:8
  <bes ees'>8 <bes ees'> <bes ees'> <bes ees'> <ees' bes' g''>4\f\staccato
- <ees' c'' aes''>8 ees'\p[ ees' ees' ees' ees'] ees'2.:8 ees'2.:8 ees'2.:8
+ <ees' c'' aes''>8\noBeam ees'\p ees'[ ees' ees' ees'] ees'2.:8 ees'2.:8 ees'2.:8
  f'2.:8 f'2.:8 f'2.:8 f'8 f' f' f' \stemDown <f' c'' a''>4\f\staccato
  <f' des'' bes''>8\staccato \stemUp f'8\p[ f' f' f' f']
  f'2.:8 f'2.:8 f'2.:8 f'2.:8 f'2.:8 f'2.:8 f'8[ f' f' f'] \stemDown <f' c'' a''>4\f\staccato
  <f' des'' bes''>8\staccato \stemUp f'8\p[ f' f' f' f'] f'2.:8 f'2.:8 f'2.:8 f'2.:8
  f'8[ f' f' f'] r4 R2. R2. R2. R2.
- \stemDown b'4 r8 b'8[ b' c''] d''4 r8 d''8[ ees'' f''] f''4 r8 d''8[ ees'' f'']
+ \stemDown b'4 r8 b'8[\< b' c''] d''4 r8 d''8[ ees'' f''] f''4 r8 d''8[ ees'' f''\!]
  f''8 \stemUp f'8\pp([ g' f' ees' d']) r8 f'([ g' f' ees' d']) r f'([ g' f' ees' d'])
  g'8([ f' ees' d'] g'4)
- r8 bes'\pp([ c'' bes' aes' g']) r8 bes'([ c'' bes' aes' g']) r \cresc bes'([ c'' bes' aes' g'])
+ r8 bes'\pp([ c'' bes' aes' g']) r8 bes'([ c'' bes' aes' g']) r bes'([\cresc c'' bes' aes' g'])
  c''8( bes' aes' g' c'' bes') aes'( g' c'' bes' aes' g') c''( bes' aes' g')
  \stemDown c''4\sfp ~ c''2. ~ c''2. ~ c''4 c''( f'') ~ f''( e'')
- c''\sfp ~ c''2. ~ c''2. ~ c''4 c''4( e'' g'' f'') f''\<( ees''2\!\> des''4\! c'') r f''4\< ~ f''4.
- f''8\staccato\!\>[ f''\staccato g''\staccato\!] aes''4( f'') f''\<( ees''2\!\> des''4\! c'')
+ c''\sfp ~ c''2. ~ c''2. ~ c''4 c''4( e'' g'' f'') \hairpinPastBarline f''\<( ees''!2\!\> des''4\! c'') r f''4\< ~ f''4.
+ f''8\staccato\!\>[ f''\staccato g''\staccato\!] aes''4( f'') \hairpinPastBarline f''\<( ees''2\!\> des''4\! c'')
  r8 f''8\staccato[ f''\staccato e''\staccato] e''4 r8 g''8[ g'' f'']
  f''4 r8 aes''[ aes'' g''] g''4 r8 bes''8[ bes'' aes''] aes''4 r8 c'''8[ c''' bes'']
- bes''4 r8 \cresc bes''[ c''' des'''] des'''4 r8 g''[ aes'' bes'']
+ bes''4 r8 bes''[\cresc c''' des'''] des'''4 r8 g''[ aes'' bes'']
  bes''4 r8 e''8[ f'' g''] g''4 r8 g''[ aes'' bes'']
  bes''4 r8 bes''[ c''' des'''] des'''4 r8 g''[ aes'' bes'']
  bes''4 r8 e''8[ f'' g''] g''4 r8 g''[ aes'' bes'']
@@ -99,8 +100,8 @@
  aes'4\ff\staccato aes'4\staccato r8 aes' bes'4 bes' r R2. R2.
  aes'4\ff aes' r8 aes' bes'4 bes' r R2. R2.
  aes'4\ff aes' r8 aes' \stemDown beses'4 beses' r R2. R2. R2. R2. R2. R2.
- \set tupletSpannerDuration = #(ly:make-moment 1 4)
- \stemDown \times 2/3 { bes''8\f[ bes'' bes''] bes''[ bes'' bes''] bes''[ bes'' bes'']
+ \tupletSpan 4
+ \stemDown \tuplet 3/2 { bes''!8\f[ bes'' bes''] bes''[ bes'' bes''] bes''[ bes'' bes'']
  c'''8\ff[ c''' c'''] c'''[ c''' c'''] c'''[ c''' c''']
  des'''8[ des''' des'''] des'''[ des''' des'''] des'''\sf[ des''' des''']
  des'''8[ des''' des'''] bes''[ bes'' bes''] bes''\sf[ bes'' bes'']
@@ -120,7 +121,7 @@
  \key f \major \time 4/4
  \stemDown c''4\pp ~ c''16( b' c'' d'' e''8) r8 r4 c''4 ~ c''16( b' c'' d'' e''8) r8 r4
  d''4 ~ d''16( cis'' d'' e'' f''8) r8 r4 d''4 ~ d''16( cis'' d'' e'' f''8) r8 r4
- e''16_\markup { \italic \large "cresc." }( d'' e'' f'' g''8) r8 e''16( d'' e'' f'' g''8) r8
+ e''16_\txtCresc( d'' e'' f'' g''8) r8 e''16( d'' e'' f'' g''8) r8
  f''16( e'' f'' g'' a''8) r8  f''16( e'' f'' g'' a''8) r8
  g''16( fis'' g'' a'' bes''8) r a''16( g'' a'' bes'' c'''8) r
  bes''16 bes'' a'' a'' bes'' bes'' c''' c''' d''' d''' e''' e''' f'''! f''' g''' g'''
@@ -138,20 +139,20 @@
  d'''16 d''' c'''! c''' bes'' bes'' a'' a'' bes'' bes'' g'' g'' c''' c''' c''' c'''
  f''4 r r2 R1
 
- r8 a''16( bes'') c'''8\staccato c'''\staccato c'''\staccato[
- \set tupletSpannerDuration = #(ly:make-moment 1 4) \times 2/3 { a''16[ bes'' c'''] }
+ r8 a''16( bes'') c'''8\staccato c'''\staccato c'''\staccato
+ \tupletSpan 4 \tuplet 3/2 { a''16 bes'' c''' }
+ d'''8\staccato c'''\staccato
+ bes''8\staccato g''16( a'') bes''8\staccato bes''\staccato bes''\staccato
+ \tuplet 3/2 { g''16 a'' bes'' } c'''8\staccato bes''\staccato
+ a''8\staccato a''16( bes'') c'''8\staccato c'''\staccato c'''\staccato
+ \tupletSpan 4 \tuplet 3/2 { a''16 bes'' c''' }
  d'''8\staccato[ c'''\staccato]
- bes''8\staccato[ g''16( a'']) bes''8\staccato bes''\staccato bes''\staccato[
- \times 2/3 { g''16[ a'' bes''] } c'''8\staccato[ bes''\staccato]
- a''8\staccato a''16( bes'') c'''8\staccato c'''\staccato c'''\staccato[
- \set tupletSpannerDuration = #(ly:make-moment 1 4) \times 2/3 { a''16[ bes'' c'''] }
- d'''8\staccato[ c'''\staccato]
- bes''8\staccato[ g''16( a'']) bes''8\staccato bes''\staccato bes''\staccato[
- \times 2/3 { g''16[ a'' bes''] } c'''8\staccato[ bes''\staccato]
- \cresc a''16 a'' bes'' bes'' c''' c''' cis''' cis''' d''' d''' c''' c''' bes'' bes'' a'' a''
+ bes''8\staccato[ g''16( a'']) bes''8\staccato bes''\staccato bes''\staccato
+ \tuplet 3/2 { g''16 a'' bes'' } c'''8\staccato bes''\staccato
+ a''16-\hideF\cresc a'' bes'' bes'' c''' c''' cis''' cis''' d''' d''' c''' c''' bes'' bes'' a'' a''
  bes''16 bes'' a'' a'' g'' g'' a'' a'' bes'' bes'' c''' c''' d''' d''' e''' e'''
- \set tupletSpannerDuration = #(ly:make-moment 1 4)
- \times 2/3 { f'''8\ff[ f''' f'''] ees'''[ ees''' ees'''] d'''[ d''' d'''] fis'''[ fis''' fis''']
+ \tupletSpan 4 \hideTupletNumber
+ \tuplet 3/2 { f'''8\ff[ f''' f'''] ees'''[ ees''' ees'''] d'''[ d''' d'''] fis'''[ fis''' fis''']
  g'''8\sf[ g''' g'''] des'''[ des''' des'''] c'''[ c''' c'''] e'''![ e''' e''']
  f'''!8[ f''' f'''] f'''[ f''' f'''] g'''[ g''' g'''] g'''[ g''' g''']
  a'''8[ a''' a'''] a'''[ a''' a'''] bes'''[ bes''' bes'''] bes'''[ bes''' bes''']
@@ -168,15 +169,18 @@
  f''[ f''' f'''] f'''[ f''' f'''] f'''\sf[ f''' f'''] f'''[ f''' f''']
  f'''[ f''' f'''] f'''[ f''' f'''] f'''[ f''' f'''] f'''[ f''' f''']
  a'''\sf[ a''' a'''] a'''[ a''' a'''] a'''\sf[ a''' a'''] a'''[ a''' a''']
- a'''[ a''' a'''] a'''[ a''' a'''] a'''[ a''' a'''] a'''[ a''' a''']
- a'''[ a''' a'''] a'''[ a''' a'''] a'''[ a''' a'''] a'''[ a''' a''']
- g'''[ g''' g'''] g'''[ g''' g'''] g'''[ g''' g'''] g'''[ g''' g''']
- a'''[ a''' a'''] a'''[ a''' a'''] a'''[ a''' a'''] a'''[ a''' a''']
- g'''[ g''' g'''] g'''[ g''' g'''] g'''[ g''' g'''] g'''[ g''' g''']
- a'''[ a''' a'''] a'''[ a''' a'''] a'''[ a''' a'''] a'''[ a''' a''']
- g'''[ g''' g'''] g'''[ g''' g'''] g'''[ g''' g'''] g'''[ g''' g''']
- g'''[ g''' g'''] g'''[ g''' g'''] g'''[ g''' g'''] g'''[ g''' g''']
- g'''[ g''' g'''] g'''[ g''' g'''] g'''[ g''' g'''] g'''[ g''' g'''] }
+ }
+ \tupletSpan \default \hideTupletBracket
+ \tuplet 3/2 {
+ a'''2.:8 a''': 
+ a'''2.:8 a''': 
+ g'''2.:8\sf g''':
+ a'''2.:8 a''':
+ g'''2.:8\sf g''':
+ a'''2.:8 a''':
+ g'''2.:8\sf g''':
+ g'''2.:8\sf g''':
+ g'''2.:8\sf g''': } \tupletSpan 4
  f'''16\ff f''' f'' f'' g'' g'' a'' a'' bes'' bes'' a'' a'' bes'' bes'' c''' c'''
  d'''16 d''' c''' c''' d''' d''' e''' e''' f''' f''' e''' e''' f''' f''' g''' g'''
  a'''4 r r2 <f' c'' a''>4 r r2 <f' c'' a''>4 r r2

--- a/ftp/BeethovenLv/O84/Egmont/Egmont-lys/violinotwo.ly
+++ b/ftp/BeethovenLv/O84/Egmont/Egmont-lys/violinotwo.ly
@@ -1,21 +1,22 @@
-\version "2.4.0"
+\version "2.18.2"
+
+\include "defs.ily"
 
  violinotwo =  {
- \set Staff.instrument = "Violino II"
+ \set Staff.instrumentName = "Violino II"
  \set Staff.midiInstrument = "violin"
  \clef treble
  \key f \minor
  \time 3/2
- \override Staff.AccidentalPlacement   #'padding = #0.5
- << { f'1.\fermata } \\ { s2\f s4 s4\> s4 s4\! } >>
- aes2\staccato_"marcato" aes2\staccato r4 r8 aes
+ \moreAccidentalPadding
+ f'1.\fermata_\forteSforzato
+ aes2\staccato_\txtMarcato aes2\staccato r4 r8 aes
  g2\staccato aes\staccato r4 r8 c' b2\staccato c'\staccato r4 r8 g\p g4 r4 r2 r2
  R1. R1.
- << { r4 aes4\p( g b2.) } \\
- { \override DynamicLineSpanner   #'padding = #3.0
- s4 s4 s4\< s4\! s4\> s8 s8\! } >> f'1.\ff
+ << { r4 aes4\p_( g b2.) } \\
+ { \spaceSpannerF s4 s4. s8\< s2\> s8 s8\! } >> f'1.\ff
  aes2\staccato aes2\staccato r4 r8 aes8 g2\staccato aes2\staccato r2 R1. R1. r2 r2 aes2\p
- aes16 des' des' des' des' des' des' des' des'2:16 des'2:16
+ aes16\pp des' des' des' des' des' des' des' des'2:16 des'2:16
  des'16 des' des' des' des' des' des' des' des'2:16 des'2:16
  ees'2:16 ees'2:16 ees'2:16
  ees'16 ees'16 ees'16 ees'16 ees'16 ees'16 ees'16 ees'16  ees'2:16 ees'2:16
@@ -23,15 +24,16 @@
  <c' g'>2:16 <c' g'>2:16 <c' g'>2:16
  <c' g'>4 r4 r2 r4 r8 <c' g'>8 <c' g'>4 r4 r2 r4 r8 <c' g'>8 <c' g'>4 r4 r2 r2 \bar "||"
 
- \time 3/4 R2. R2. R2. r4 r4 aes'8\sfp aes'8
+ \time 3/4 R2. R2. R2. r4 r4 aes'8\sfp aes'8-\hideP
  aes'8 aes' aes' aes' aes' aes' aes' aes' aes' aes' aes' aes'
  aes'[ aes' aes' aes'] b'[ b'] c''8[ c'' c'' c''] <g' bes'!>\sfp[ <g' bes'>]
- <g' bes'>2.:8 <g' bes'>2.:8<g' bes'>2.:8 bes'8 bes' aes' aes'
- << { f'4 ~ f'2. ~ f'4 } \\ { s4\< s4\!\> s4 s4\! s4 } >> r4 r4 R2.
- r4 r4 << { f'4 ~ f'2. ~ f'4 } \\ { s4\< s4\!\> s4 s4\! s4 } >> r8
+ <g' bes'>2.:8 <g' bes'>2.:8<g' bes'>2.:8 bes'8 bes' aes' aes' \hairpinPastBarline f'4_~\< f'2._~\> 
+ f'4\! r4 r4 R2.
+ r4 r4 \hairpinPastBarline f'4\< ~ f'2.\> ~
+ f'4\! r8
  aes'8\staccato[ aes'\staccato g'\staccato] g'4 r8 bes'[ bes' aes']
  aes'4 r8 f''8[ f'' e''] e''4 r8 g''8[ g'' f''] f''4 r8 aes''8[ aes'' g'']
- g''4 r8 \cresc bes'[ c'' des''] des''4 r8 g'[ aes' bes'] bes'4 r8 e'[ f' g']
+ g''4 r8 bes'[\cresc c'' des''] des''4 r8 g'[ aes' bes'] bes'4 r8 e'[ f' g']
  g'4 r8 g'[ aes' bes'] bes'4 r8 bes'[ c'' des''] des''4 r8 g'[ aes' bes']
  bes'4 r8 e'[ f' g'] g'4 r8 g'[ aes' bes'] bes'4 r8 bes'[ c'' des'']
  des''4 r8 bes'[ c'' des''] des''4 r8 bes'[ c'' des''] des''4 r4
@@ -45,8 +47,8 @@
  c'4\ff\staccato c'4\staccato r8 c' des'4 des' r R2. R2.
  c'4\ff c' r8 c' des'4 des' r R2. R2. c'4\ff c'4 r8 c' des'4 des' r
  R2. R2. R2. R2. R2. R2.
- \set tupletSpannerDuration = #(ly:make-moment 1 4)
- \times 2/3 { bes'!8\f[ bes' bes'] bes'[ bes' bes'] bes'[ bes' bes']
+ \tupletSpan 4
+ \tuplet 3/2 { bes'!8\f[ bes' bes'] bes'[ bes' bes'] bes'[ bes' bes']
  <ees' ees''>8\ff[ <ees' ees''> <ees' ees''>]  <ees' ees''>[ <ees' ees''> <ees' ees''>]
  <ees' ees''>[ <ees' ees''> <ees' ees''>]
  ees''8[ ees'' ees''] c''[ c'' c''] aes'[ aes' aes']
@@ -59,12 +61,12 @@
  <des'' bes''>2.:8\sf <c'' aes''>2.:8\sf <des'' bes''>2.:8\sf
  \stemUp <c'' aes''>8\fp[ c'] c'[ c' c' c'] c'2.:8 c'2.:8 c'2.:8 bes2.:8 bes2.:8 des'2.:8
  des'8 des' des' des' <bes g'>4\f\staccato
- <c' aes'>8\staccato c'\p[ c' c' c' c'] c'2.:8 c'2.:8 c'2.:8
+ <c' aes'>8\staccato\noBeam c'\p c'[ c' c' c'] c'2.:8 c'2.:8 c'2.:8
  <c' ees'>2.:8 <c' ees'>2.:8 <c' ees'>2.:8
  <c' ees'>8 <c' ees'> <c' ees'> <c' ees'> <c' a'>4\f\staccato
- bes'8\staccato des'\p[ des' des' des' des'] des'2.:8 des'2.:8 des'2.:8
+ bes'8\staccato des'\p des'[ des' des' des'] des'2.:8 des'2.:8 des'2.:8
  <c' ees'>2.:8 <c' ees'>2.:8 <c' ees'>2.:8 <c' ees'>8[ <c' ees'> <c' ees'> <c' ees'>]
- <c' a'>4\f\staccato bes'8\staccato des'\p[ des' des' des' des'] des'2.:8 des'2.:8
+ <c' a'>4\f\staccato bes'8\staccato des'\p des'[ des' des' des'] des'2.:8 des'2.:8
  des'8[ des' des' des'] d'[ d'] d'2.:8 d'8[ d' d' d']
  c'\p\<[ c'] c'4 r8 c'[ c' d'] ees'4 r8 ees'[ ees' f'\!] g'4\> r8 g'8[ g' aes'\!]
  b4 r8 b8[ b c'] d'4 r r R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. R2. r4 r aes'8\sfp aes'
@@ -74,12 +76,12 @@
  <g' bes'>8 <g' bes'> <g' bes'> <g' bes'> <g' bes'> <g' bes'>
  <g' bes'>8 <g' bes'> <g' bes'> <g' bes'> <g' bes'> <g' bes'>
  bes'8[ bes' aes' aes']
- \override DynamicLineSpanner   #'padding = #2.0
- f'4\< ~ f'2.\!\> ~ f'4\! r f'4\< ~ f'4.\!\>
- f'8\staccato[ f'\staccato g'\staccato\!] aes'4( f') f'4\< ~ f'2.\!\> ~ f'4\! r8
+ \spaceSpannerE
+ \hairpinPastBarline f'4\< ~ f'2.\!\> ~ f'4\! r \hairpinPastBarline f'4\< ~ f'4.\!\>
+ f'8\staccato[ f'\staccato g'\staccato\!] aes'4( f') \hairpinPastBarline f'4\< ~ f'2.\!\> ~ f'4\! r8
  aes'8\staccato[ aes'\staccato g'\staccato] g'4 r8 bes'8[ bes' aes'] aes'4 r8
  \stemDown f''8[ f'' e''] e''4 r8 g''[ g'' f''] f''4 r8 aes''[ aes'' g'']
- g''4 r8 \stemDown bes'[ c'' des''] des''4 r8 \stemUp g'[ aes' bes']
+ g''4 r8 \stemDown bes'[\cresc c'' des''] des''4 r8 \stemUp g'[ aes' bes']
  \stemDown bes'4 r8 \stemUp e'[ f' g'] g'4 r8 g'[ aes' bes']
  \stemDown bes'4 r8 bes'[ c'' des''] des''4 r8 \stemUp g'[ aes' bes']
  \stemDown bes'4 r8 \stemUp e'[ f' g'] g'4 r8 g'[ aes' bes']
@@ -100,8 +102,8 @@
  des'4\ff\staccato des'4\staccato r8 des' des'4 des'4 r R2. R2.
  des'4\ff des'4 r8 des' des'4 des'4 r R2. R2.
  f'4\ff f' r8 f' ges'4 ges' r R2. R2. R2. R2. R2. R2.
- \set tupletSpannerDuration = #(ly:make-moment 1 4)
- \stemDown \times 2/3 { bes'8\f[ bes' bes'] bes'[ bes' bes'] bes'[ bes' bes']
+ \tupletSpan 4
+ \stemDown \tuplet 3/2 { bes'8\f[ bes' bes'] bes'[ bes' bes'] bes'[ bes' bes']
  c''8\ff[ c'' c''] c''[ c'' c''] c''[ c'' c'']
  des''8[ des'' des''] des''[ des'' des''] des''\sf[ des'' des'']
  des''8[ des'' des''] bes'[ bes' bes'] bes'\sf[ bes' bes']
@@ -121,7 +123,7 @@
  \key f \major \time 4/4
  \stemUp g'16\pp g' g' g' g' g' g' g' g'2:16 g'2:16 g'2:16
  <f' b'>2:16 <f' b'>2:16 <f' b'>2:16 <f' b'>2:16
- bes'!16_\markup { \italic \large "cresc." } bes' bes' bes' g' g' g' g' bes' bes' bes' bes' g' g' g' g'
+ bes'!16_\txtCresc bes' bes' bes' g' g' g' g' bes' bes' bes' bes' g' g' g' g'
  \stemDown c''16 c'' c'' c'' \stemUp a' a' a' a' \stemDown c'' c'' c'' c'' \stemUp a' a' a' a'
  \stemDown e''16( dis'' e'' f'') e''8 g'' f''16( e'' f'' g'') a''8 f''
  g''16 g'' fis'' fis'' g'' g'' a'' a'' bes'' bes'' c''' c''' d''' d''' e''' e'''
@@ -138,16 +140,16 @@
  f'''8 g''16[ g''] f'' f'' e'' e'' f'' f'' e'' e'' d'' d'' cis'' cis''
  d''16 d'' c''! c'' \stemUp bes' bes' a' a' bes' bes' g' g' \stemDown c'' c'' c'' c'' f''4 r r2 R1
  R1 R1
- r8 a'16( bes') c''8\staccato c''\staccato c''\staccato[
- \set tupletSpannerDuration = #(ly:make-moment 1 4) \times 2/3 { a'16[ bes' c''] }
+ r8 a'16( bes') c''8\staccato c''\staccato c''\staccato
+ \tupletSpan 4 \tuplet 3/2 { a'16 bes' c'' }
  d''8\staccato[ c''\staccato]
- bes'8\staccato[ g'16( a']) bes'8\staccato bes'\staccato bes'\staccato[
- \times 2/3 { g'16[ a' bes'] } c''8\staccato[ bes'\staccato]
- \cresc \stemUp a'16 a' bes' bes' \stemDown c'' c'' cis'' cis'' d'' d'' c'' c'' \stemUp bes' bes' a' a'
+ bes'8\staccato[ g'16( a']) bes'8\staccato bes'\staccato bes'\staccato
+ \tuplet 3/2 { g'16 a' bes' } c''8\staccato[ bes'\staccato]-\hideMF
+ \stemUp a'16\cresc a' bes' bes' \stemDown c'' c'' cis'' cis'' d'' d'' c'' c'' \stemUp bes' bes' a' a'
  bes'16 bes' a' a' g' g' a' a' \stemDown bes' bes' c'' c'' d'' d'' e'' e''
- \set tupletSpannerDuration = #(ly:make-moment 1 4)
- \times 2/3 { f''8\ff[ f'' f''] ees''[ ees'' ees''] d''[ d'' d''] fis''[ fis'' fis'']
- g''8\sf[ g'' g''] des''[ des'' des''] c''[ c'' c''] e''![ e'' e'']
+ \tupletSpan 4
+ \tuplet 3/2 { f''8\ff[ f'' f''] ees''[ ees'' ees''] d''[ d'' d''] fis''[ fis'' fis'']
+ \hideTupletNumber g''8\sf[ g'' g''] des''[ des'' des''] c''[ c'' c''] e''![ e'' e'']
  f''!8[ f'' f''] f''[ f'' f''] g''[ g'' g''] g''[ g'' g'']
  a''8[ a'' a''] a''[ a'' a''] bes''[ bes'' bes''] bes''[ bes'' bes'']
  b''8[ b'' b''] c'''[ c''' c'''] c'''[ c''' c'''] c'''[ c''' c''']
@@ -164,24 +166,19 @@
  a''[ a'' a''] a''[ a'' a''] a''[ a'' a''] a''[ a'' a'']
  a''\sf[ f''' f'''] <a'' f'''>[ <a'' f'''> <a'' f'''>]
  <a'' f'''>\sf[ <a'' f'''> <a'' f'''>] <a'' f'''>[ <a'' f'''> <a'' f'''>]
- <a'' f'''>[ <a'' f'''> <a'' f'''>] <a'' f'''>[ <a'' f'''> <a'' f'''>]
- <a'' f'''>[ <a'' f'''> <a'' f'''>] <a'' f'''>[ <a'' f'''> <a'' f'''>]
- <a'' f'''>[ <a'' f'''> <a'' f'''>] <a'' f'''>[ <a'' f'''> <a'' f'''>]
- <a'' f'''>[ <a'' f'''> <a'' f'''>] <a'' f'''>[ <a'' f'''> <a'' f'''>]
- <g'' e'''>\sf[ <g'' e'''> <g'' e'''>] <g'' e'''>[ <g'' e'''> <g'' e'''>]
- <g'' e'''>[ <g'' e'''> <g'' e'''>] <g'' e'''>[ <g'' e'''> <g'' e'''>]
- <a'' f'''>[ <a'' f'''> <a'' f'''>] <a'' f'''>[ <a'' f'''> <a'' f'''>]
- <a'' f'''>[ <a'' f'''> <a'' f'''>] <a'' f'''>[ <a'' f'''> <a'' f'''>]
- <g'' e'''>\sf[ <g'' e'''> <g'' e'''>] <g'' e'''>[ <g'' e'''> <g'' e'''>]
- <g'' e'''>[ <g'' e'''> <g'' e'''>] <g'' e'''>[ <g'' e'''> <g'' e'''>]
- <a'' f'''>[ <a'' f'''> <a'' f'''>] <a'' f'''>[ <a'' f'''> <a'' f'''>]
- <a'' f'''>[ <a'' f'''> <a'' f'''>] <a'' f'''>[ <a'' f'''> <a'' f'''>]
- <g'' e'''>\sf[ <g'' e'''> <g'' e'''>] <g'' e'''>[ <g'' e'''> <g'' e'''>]
- <g'' e'''>[ <g'' e'''> <g'' e'''>] <g'' e'''>[ <g'' e'''> <g'' e'''>]
- <g'' e'''>\sf[ <g'' e'''> <g'' e'''>] <g'' e'''>[ <g'' e'''> <g'' e'''>]
- <g'' e'''>[ <g'' e'''> <g'' e'''>] <g'' e'''>[ <g'' e'''> <g'' e'''>]
- <g'' e'''>\sf[ <g'' e'''> <g'' e'''>] <g'' e'''>[ <g'' e'''> <g'' e'''>]
- <g'' e'''>[ <g'' e'''> <g'' e'''>] <g'' e'''>[ <g'' e'''> <g'' e'''>] }
+ }
+ \tupletSpan \default \hideTupletBracket
+ \tuplet 3/2 {
+ <a'' f'''>2.:8 <a'' f'''>:
+ <a'' f'''>2.:8 <a'' f'''>:
+ <g'' e'''>2.:8\sf <g'' e'''>:
+ <a'' f'''>2.:8 <a'' f'''>:
+ <g'' e'''>2.:8\sf <g'' e'''>:
+ <a'' f'''>2.:8 <a'' f'''>:
+ <g'' e'''>2.:8\sf <g'' e'''>:
+ <g'' e'''>2.:8\sf <g'' e'''>:
+ <g'' e'''>2.:8\sf <g'' e'''>: }
+ \tupletSpan 4
  <a'' f'''>8\ff f''16[ f''] g'' g'' a'' a'' bes'' bes'' a'' a'' bes'' bes'' c''' c'''
  d''' d''' c''' c''' d''' d''' e''' e''' f''' f''' e''' e''' f''' f''' g''' g'''
  a'''4 r r2 <f' c'' a''>4 r r2 <f' c'' a''>4 r r2

--- a/ftp/BeethovenLv/O84/Egmont/Egmont-lys/violoncello.ly
+++ b/ftp/BeethovenLv/O84/Egmont/Egmont-lys/violoncello.ly
@@ -1,35 +1,36 @@
-\version "2.4.0"
+\version "2.18.2"
+
+\include "defs.ily"
 
  violoncello =  {
- \set Staff.instrument = "Violoncello"
+ \set Staff.instrumentName = "Violoncello"
  \set Staff.midiInstrument = "cello"
  \clef bass
  \key f \minor
  \time 3/2
- \override Staff.AccidentalPlacement   #'padding = #0.5
- << {  f,1.\fermata } \\
- { \override DynamicLineSpanner   #'padding = #2.0 s2\f s4 s4\> s4 s4\! } >>
- f,2\staccato_"marcato" f,2\staccato r4 r8 f,8
+ \moreAccidentalPadding
+ f,1.\fermata-\hideF_\forteSforzato
+ f,2\staccato_\txtMarcato f,2\staccato r4 r8 f,8
  ees,2\staccato aes,2\staccato r4 r8 aes,8 g,2\staccato g,2\staccato r4 r8 g8\p
  c4 r4 r2 r2 R1. R1.
- << { r2 c1 } \\ { s4 s4\< s4\!\> s4\! s2 } >> f,1.\ff
+ << { r2 c1 } \\ { s4. s8\< s4\> s8 s4.\! s4 } >> f,1.\ff
  f,2\staccato f,2\staccato r4 r8 f,8 ees,2\staccato aes,2\staccato r2 R1. R1.
  r2 r2 aes,2\p des4\pp\staccato r4 r2 r4 r8 des8 des2\staccato des2\staccato r4 r8 des8
  c2\staccato c2\staccato r4 r8 c8 a,2 a,2 r4 r8 a,8 bes,2 bes,2 r4 r8 bes,8
  g,2 g,2 r4 r8 g,8 e,2 c2 r4 r8 c8 c4 r4 r2 r4 r8 c8 c4 bes4\p( c'8 bes aes g) g4 r4
  r4 bes4\pp( c' bes aes g) \bar "||"
 
- \time 3/4 r8 \cresc bes8([ c' bes aes g] c' bes aes g c' bes)
+ \time 3/4 r8 bes8([\cresc c' bes aes g] c' bes aes g c' bes)
  aes( g c' bes aes g) c'8( bes aes g)
- c'4\sfp( des' c' aes f des c aes, f, des, c,) r4 c'\sfp( des' c' bes g e des c bes, g,8) e,
+ c'4\sfp( des'-\hideP c' aes f des c aes, f, des, c,) r4 c'\sfp( des' c' bes g e des c bes, g,8) e,
  c,4( f,) << { \stemDown f4 ~ f4. f8\staccato[ f\staccato g\staccato] } \\
- { s4\< s4\!\> s4 s8 s8\! } >> aes4( f)
+ { \hairpinPastBarline s4-\hideP\< s4\!\> s4 s8 s8\! } >> aes4( f)
  << { \stemDown f4 ~ f4. f8\staccato[ f\staccato g\staccato] } \\
- { s4\< s4\!\> s4 s8 s8\! } >> aes4( f)
+ { \hairpinPastBarline s4-\hideP\< s4\!\> s4 s8 s8\! } >> aes4( f)
  << { \stemDown f4 ~ f4. f8\staccato[ f\staccato g\staccato] } \\
- { s4\< s4\!\> s4 s8 s8\! } >> aes8 c8 c2 c8 c c2 c8 c c2 c8 c c2 c8 c c2
- \cresc << { c2.( bes,2.)( g,2.) } \\ { \stemUp c,2. ~ c,2. ~ c,2. } >> e,2.
- << { c2.( bes,2.)( g,2.) } \\ { \stemUp c,2. ~ c,2. ~ c,2. } >> e,2.
+ { \hairpinPastBarline s4\<-\hideP s4\!\> s4 s8 s8\! } >> aes8 c8 c2 c8 c c2 c8 c c2 c8 c c2 c8 c c2
+ \doubleSlursOn <c c,>2.(\cresc <bes, c,>2.)( <g, c,>2.)  e,2.
+ <c c,>2.( <bes, c,>2.)( <g, c,>2.)  e,2. \doubleSlursOff
  c,8 c, c,2 c,8 c, c,2 c,8 c, c,2 c,4 r4 c,8\ff([ des,8]
  c,8 des, c, des, c, des,) c,( des, c, des, c, des,) c,( des, c, des, c, des,)
  c,8( des, c, des, c, des,) c,( des, c, des, c, des,) c,( des, c, des, c, des,)
@@ -39,8 +40,7 @@
  aes,4\ff\staccato aes,4\staccato r8 aes,8 des4 des r R2. R2.
  aes,4\ff aes,4 r8 aes,8 des4 des r R2. R2.
  aes,4\ff aes,4 r8 aes,8 des4 des r
- \override TextScript   #'padding = #1.5
- a,2._\markup { \italic \large "p cresc." } ~ a,2. ~ a,2. ~ a,2. ~ a,2. ~ a,2.
+ \spaceTextScrA a,2._\pCresc-\hideP ~ a,2. ~ a,2. ~ a,2. ~ a,2. ~ a,2.
  aes,!2.\f g,2.\ff aes,2.\sf des2.\sf bes,2.\sf ees2.\sf
  aes,8\f aes, aes, aes, aes, aes, aes, aes, aes, aes, aes, aes,
  aes, aes, aes, aes, aes, aes, aes, aes, aes, aes, aes, aes,
@@ -51,14 +51,14 @@
  bes,4\staccato r r R2. R2. R2. a,4\p r r R2. f,4 r r r r f4\f\staccato
  bes,4\staccato r r R2. R2. r4 r g,\p R2. r4 r g4\p\<( aes g ees c aes, g,\! ees,\> ees c\!)
  g,4\< r g( aes g f d b, g f d b,\!) R2. R2. R2. R2. R2. R2. R2.
- r4 r c'8([ bes] \cresc aes[ g c' bes aes g]) c'([ bes aes g])
+ r4 r c'8([ bes] aes[-\hidePP\cresc g c' bes aes g]) c'([ bes aes g])
  c'4\sfp( des' c' aes f des c aes, f, des, c,) r c'\sfp( des' c' bes g e des c bes, g,8 e,)
- c,4( f,) f4\< ~ f4.\! f8\staccato\>[ f\staccato g\staccato\!] aes4( f)
- f4\< ~ f2.\!\> ~ f4\! r f4\< ~ f4.\! f8\staccato\>[ f\staccato g\staccato\!] aes8 c c2
+ c,4( f,) \hairpinPastBarline f4\< ~ f4.\! f8\staccato\>[ f\staccato g\staccato\!] aes4( f)
+ \hairpinPastBarline f4\< ~ f2.\!\> ~ f4\! r \hairpinPastBarline f4\< ~ f4.\! f8\staccato\>[ f\staccato g\staccato\!] aes8 c c2
  c8 c c2 c8 c c2 c8 c c2 c8 c c2
- \slurUp  \override DynamicLineSpanner   #'padding = #2.0
- \cresc <c, c>2.( ~ <c, bes,>2.)( ~ <c, g,>2.) e,2.
- <c, c>2.( ~ <c, bes,>2.)( ~ <c, g,>2.) e,2. c,8 c, c,2 c,8 c, c,2 c,8 c, c,2
+ \slurUp  \spaceSpannerE
+ \doubleSlursOn <c, c>2.(\cresc <c, bes,>2.)( <c, g,>2.) e,2.
+ <c, c>2.( <c, bes,>2.)( <c, g,>2.) \doubleSlursOff e,2. c,8 c, c,2 c,8 c, c,2 c,8 c, c,2
  c,4 r \slurDown c,8\ff([ des,] c,[ des, c, des, c, des,]) c,( des, c, des, c, des,)
  c,8( des, c, des, c, des,) c,( des, c, des, c, des,) c,( des, c, des, c, des,)
  c,8( des, c, des, c, des,) c,([ des, c, des,]) c,4 f, f,
@@ -67,22 +67,22 @@
  f4 ~ f4. f8\staccato[ f\staccato g\staccato] aes4( f4) r
  des8 des des2 des8 des des2 des8 des des2 des4 des des
  des8 des des2 des8 des des2 des8 des des2 bes,4 bes, aes,
- g,8[ ees] ees[ ees ees ees] ees ees ees ees ees ees
+ g,!8[ ees] ees[ ees ees ees] ees ees ees ees ees ees
  aes,2.\sf aes,2.\sf aes,2.\sf aes,2.\sf aes,2.\sf aes,2.\sf aes,2.\sf aes,4 r r
- des4\ff\staccato des4\staccato r8 des ges,4 ges, r R2. R2.
- des4\ff des4 r8 des ges,4 ges, r R2. R2. des4\ff des4 r8 des ges,4 ges, r
- d2.\p ~ d2. ~ d2. ~ d2. ~ d2. ~ d2. ees2.\f aes,2.\ff des2.\sf ges,2.\sf ees,2.\sf aes,2.\sf
- des8\sf des des des des des des des des des des des des2.:8 des2.:8 des2.:8 des2.:8
+ \stemUp des4\ff\staccato des4\staccato r8 des \stemNeutral ges,4 ges, r R2. R2.
+ \stemUp des4\ff des4 r8 des \stemNeutral ges,4 ges, r R2. R2. \stemUp des4\ff des4 r8 des \stemNeutral ges,4 ges, r
+ d2._\pCresc-\hideP ~ d2. ~ d2. ~ d2. ~ d2. ~ d2. ees2.\f aes,2.\ff des!2.\sf ges,2.\sf ees,2.\sf aes,2.\sf
+ des8\f des des des des des des des des des des des des2.:8 des2.:8 des2.:8 des2.:8
  des2.:8\sf des2.:8\sf des2.:8\sf des2.:8\sf des2.:8\sf des2.:8\sf des4 r r R2. R2. R2.
  des'4\p\staccato des'4\staccato r des'4\staccato des'4\staccato r c'4 c' r a a r R2. R2. R2. R2.
  bes4\p\staccato bes4\staccato r bes bes r g g r e e r
  f,4\ff f, r8 f, f,4 f, r8 f, e,4 e, r r4 r r8 r^\fermata
  R2. R2. R2. R2. R2. R2. R2. R2.^\fermataMarkup \bar "||"
 
- \key f \major \times 4/4
+ \key f \major \time 4/4
  \slurDown c8\pp( b,) c\staccato c\staccato c c c c c( b,) c\staccato c\staccato c c c c
  c8( b,) c\staccato c\staccato c c c c c( b,) c\staccato c\staccato c c c c
- c8_\markup { \italic \large "cresc." }( b,) c\staccato c\staccato c( b,) c\staccato c\staccato
+ c8_\txtCresc( b,) c\staccato c\staccato c( b,) c\staccato c\staccato
  c8( b,) c\staccato c\staccato c( b,) c\staccato c\staccato
  c8( b,) c\staccato c\staccato c( b,) c\staccato c\staccato c8 c' c' c' c' c' c' c'
  f2\ff ~ f8( c) a,\staccato c\staccato f2\sf ~ f8( c) a,\staccato c\staccato
@@ -96,7 +96,7 @@
  f'!4\sf( ees' d' fis') g'\sf( des' c' e'!)
  \clef bass \slurDown f,4\sf( ees, d, fis,) g,\sf( des, c, bes,)
  g,8\ff g, bes, c d c bes, a, bes,\sf a, bes, g, c c, c c
- f,2_\markup { \italic \large "marcato" } e, f, g, gis,4 a,2. ~ a,1
+ f,2_\txtMarcato e, f, g, gis,4 a,2. ~ a,1
  <c, c>4 <c, c> <c, c> <c, c> <c, c> <c, c> <c, c> <c, c>
  f,4. f,8 e,4. e,8 f,4. f,8 g,4. g,8 gis,4 a,2. ~ a,1
  <c, c>4 <c, c> <c, c> <c, c> <c, c> <c, c> <c, c> <c, c>


### PR DESCRIPTION
update to 2.18.2
update articulation commands, add courtesy accidentals
correct and update dynamics
Bars 124 & 132 violins and viola: correct beaming
Bars 150-152 violin 1: add hairpin crescendo
Bar 181 violin 2: add crescendo
Bar 247 viola and cello: sforzando->forte
Bar 294 flute 1: p -> cresc.
Bar 332-340 violins: change to repeats
Bar 301 viola: first note g->f, add sforzando
Bars 319-320, 325-326: correct beaming
(Javier Ruiz-Alma)

Close #632