### PR TITLE
Add website link to piece-info pages

### DIFF
--- a/cgibin/piece-info.cgi
+++ b/cgibin/piece-info.cgi
@@ -417,6 +417,13 @@ elsif ($maintaineremail ne "") { print "<td>$maintaineremail</td>\n"; }
 if ($maintainerweb ne "") { print "<td><a href=\"$maintainerweb\">$maintainerweb</a></td>\n"; }
 print "</tr>\n</table>\n\n";
 
+# Tagline
+print "<br /><br />\n\n"
+print "<table align=\"center\" border=\"0\" width=\"90%\" bgcolor=\"#fefefe\" ";
+print "cellpadding=\"5\" cellspacing=\"0\">\n";
+print "<tr>\n<td align=\"center\">Free music from <a href=\"http://www.mutopiaproject.org\">Mutopia Project</a></td>\n";
+print "</tr>\n</table>\n\n";
+
 # Finish
 print "</center></body>\n</html>\n";
 


### PR DESCRIPTION
Adds a short footer with link to mutopiaproject.org.

Objective:
Give visitors that follow external links to specific pieces in Mutopia...
http://www.mutopiaproject.org/cgibin/piece-info.cgi?id=xxxx
...an indication of the publisher of the page, as well as a path to visit the main portal page.