### PR TITLE
Use a join to concatenate search terms

### DIFF
--- a/cgibin/make-table.cgi
+++ b/cgibin/make-table.cgi
@@ -119,11 +119,16 @@ until (eof CACHE) {
   if ($FORM{searchingfor} ne "")
   {
     @searchlist = split(/ /, $FORM{searchingfor});
+    my $keywords = join('|',
+                        $title,$composer,$opus,$lyricist,$instrument,
+                        $date,$style,$metre,$arranger,$source,$copyright,
+                        $id, $maintainer,$mainteremail,$maintainterweb,
+                        $extrainfo,$lilypondversion,$collections);
     foreach $searchitem (@searchlist)
     {
-      if (!((uc($title . $composer . $opus . $lyricist . $instrument . $date . $style . $metre . $arranger . $source . $copyright . $id . $maintainer . $maintaineremail . $maintainerweb . $extrainfo . $lilypondversion . $collections)) =~ $searchitem))
-      {
+      if (!(uc($keywords) =~ $searchitem)) {
         $go = 0;
+        last;               # logical AND so stop on failure
       }
     }
   }


### PR DESCRIPTION
The search terms are now concatenated in a way that it would be trivial to change the separator character. I chose the bar character (``|``).

Close #659 