### PR TITLE
Fix link references to cgi routines

### DIFF
--- a/Mutopia_HTMLGen.pm
+++ b/Mutopia_HTMLGen.pm
@@ -310,8 +310,8 @@ sub LATEST_ADDITIONS_RSS($) {
     
         $xml .= "<item>\n";
         $xml .= "<title>" . $piece->{composer} . ": " . $piece->{title} . "</title>\n";
-        $xml .= "<link>http://www.mutopiaproject.org/cgibin/piece-info.cgi?id=" . $id . "</link>\n";
-        $xml .= "<guid>http://www.mutopiaproject.org/cgibin/piece-info.cgi?id=" . $id . "</guid>\n";
+        $xml .= "<link>cgibin/piece-info.cgi?id=" . $id . "</link>\n";
+        $xml .= "<guid>cgibin/piece-info.cgi?id=" . $id . "</guid>\n";
         $xml .= "<description>" . $piece->{title} . ", ";
         if ($piece->{composer} !~ /^(Anonymous|Traditional)$/) {
             $xml .= "by ";


### PR DESCRIPTION
Links to cgibin routines should be relative to DocumentRoot . This particular edit will make these 2 lines match the rest of the html code created in this module.