### PR TITLE
Use existing variable for FTP area link

### DIFF
--- a/cgibin/make-table.cgi
+++ b/cgibin/make-table.cgi
@@ -259,7 +259,8 @@ until (eof CACHE) {
 
    print "<td><a href=\"";
    print "$baseref$midrif$musicnm/$pngfile\">Preview image</a></td>\n";
-   print "<td><a href=\"ftp://ibiblio.org/pub/multimedia/mutopia/$midrif$musicnm/\">Appropriate FTP area</a></td>\n</tr><tr>\n";
+   print "<td><a href=\"";
+   print "$baseref$midrif$musicnm/\">Appropriate FTP area</a></td>\n</tr><tr>\n";
 
    # Several ps/pdf files in a zip, or just one?
    if ($a4psfile =~ /\.zip$/) {


### PR DESCRIPTION
There was already a variable assigned to the appropriate ftp area so the code has been modified to use that variable instead of hard-coding the ibiblio link.

Close #649 