### PR TITLE
Update Brandenburg Concerto BWV 1050

### DIFF
--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello-score.ly
@@ -1,20 +1,14 @@
 \version "2.18.0"
-\include "header.ly"
+
 \include "cello.ly"
 
 #(set-global-staff-size 18)
 
-\score
-{
-  \header
-  {
+\score {
+  \header {
     instrument = "Cello"
   }
-  %
   \cello
   \midi {}
-  \layout
-  {
-  }
-
+  \layout {}
 }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello-score.ly
@@ -1,4 +1,4 @@
-\version "2.4.0"
+\version "2.18.0"
 \include "header.ly"
 \include "cello.ly"
 

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello-score.ly
@@ -4,17 +4,17 @@
 
 #(set-global-staff-size 18)
 
-\score 
+\score
 {
-	\header
-	{
-		instrument = "Cello"
-	}
-	% 
-	\cello
-	\midi {}
- 	\layout 
-	{
-	}
+  \header
+  {
+    instrument = "Cello"
+  }
+  %
+  \cello
+  \midi {}
+  \layout
+  {
+  }
 
 }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello-score.ly
@@ -1,13 +1,11 @@
 \version "2.18.0"
-
 \include "cello.ly"
 
-#(set-global-staff-size 18)
+\header {
+  instrument = "Violoncello"
+}
 
 \score {
-  \header {
-    instrument = "Cello"
-  }
   \cello
   \midi {}
   \layout {}

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello.ly
@@ -6,73 +6,73 @@ cello = \relative c {
   \key d \major
   \time 2/4
 
-  R2 * 28 |
+  R2*28 |
   \repeat unfold 2 {
-   r4 fis,8 r |
-  g r a r |
-  b r cis r |
-  d r e r |
+    r4 fis,8 r |
+    g r a r |
+    b r cis r |
+    d r e r |
 
-  % --Bar 33-- %
-  fis r fis r |
-  g r a r |
-  b r a r |
-  b r cis r |
-  d r r4 |
-  R2 |
-  r8 r16 a d8. a16 |
-  \tuplet 3/2 { b8( a) g fis( g) a | }
-  \hide TupletNumber
+    % --Bar 33-- %
+    fis r fis r |
+    g r a r |
+    b r a r |
+    b r cis r |
+    d r r4 |
+    R2 |
+    r8 r16 a d8. a16 |
+    \tuplet 3/2 { b8( a) g fis( g) a | }
+    \hide TupletNumber
 
-  % --Bar 41-- %
-  d, r e r |
-  fis r fis, r |
-  g r a r |
-  b r cis r |
-  d r e r |
-  fis r g r |
+    % --Bar 41-- %
+    d, r e r |
+    fis r fis, r |
+    g r a r |
+    b r cis r |
+    d r e r |
+    fis r g r |
 
-  % --Bar 47-- %
-  a r b r |
-  cis8. \noBeam a16 d8. a16 |
-  \tuplet 3/2 {
-    b8( a) g fis( g) a |
-    d,( fis) e d( e) fis |
-  }
-  g r a r |
-  b r b, r |
-  r4 b'8 r |
+    % --Bar 47-- %
+    a r b r |
+    cis8. \noBeam a16 d8. a16 |
+    \tuplet 3/2 {
+      b8( a) g fis( g) a |
+      d,( fis) e d( e) fis |
+    }
+    g r a r |
+    b r b, r |
+    r4 b'8 r |
 
-  % --Bar 54-- %
-  fis r fis, r |
-  r4 fis'8 r |
-  gis r gis, r |
-  r4 gis'8 r |
-  a r fis r |
-  b, r e r |
-  a, r d r |
+    % --Bar 54-- %
+    fis r fis, r |
+    r4 fis'8 r |
+    gis r gis, r |
+    r4 gis'8 r |
+    a r fis r |
+    b, r e r |
+    a, r d r |
 
-  % --Bar 61-- %
-  g,4 r |
-  r8 r16 a d8. a16 |
-  \tuplet 3/2 { b8( a) g } a8. a16 |
-  d,8 r fis r |
-  g r c r |
-  b8. \noBeam g'16 d'8. a16 |
-  \tuplet 3/2 { b8( a) g fis( gis) a } |
-  % --Bar 68-- %
-  gis r gis, r |
-  r4 gis'8 r |
-  gis r gis, r |
-  r4 gis'8 r |
-  a r r r16 fis |
-  b8 r r r16 g |
-  cis8 r r r16 a |
-  d8 r fis, r |
+    % --Bar 61-- %
+    g,4 r |
+    r8 r16 a d8. a16 |
+    \tuplet 3/2 { b8( a) g } a8. a16 |
+    d,8 r fis r |
+    g r c r |
+    b8. \noBeam g'16 d'8. a16 |
+    \tuplet 3/2 { b8( a) g fis( gis) a } |
+    % --Bar 68-- %
+    gis r gis, r |
+    r4 gis'8 r |
+    gis r gis, r |
+    r4 gis'8 r |
+    a r r r16 fis |
+    b8 r r r16 g |
+    cis8 r r r16 a |
+    d8 r fis, r |
 
-  % --Bar 76-- %
-  g r a r |
-  \tuplet 3/2 { b( a) g } a8. a,16 |
+    % --Bar 76-- %
+    g r a r |
+    \tuplet 3/2 { b( a) g } a8. a,16 |
   }
   \alternative {
     {
@@ -153,11 +153,7 @@ cello = \relative c {
       b8 r r4 |
       a8 r r4 |
       gis8 r fis r |
-      cis'8 r r4 |
-      cis'8 r r4 |
-      cis,8 r r4 |
-      cis'8 r r4 |
-      cis,8 r r4 |
+      \repeat unfold 5 { cis'8 r r4 | }
 
       % --Bar 203 -- %
       cis'8 r cis, r |
@@ -195,11 +191,7 @@ cello = \relative c {
       fis8. e16 fis8. fis,16 |
       b4 r |
       d r |
-      %234
-      %244
-      %251
-      %261
-      R2 * 27 |
+      R2*27 |
     }
     {
       d2\fermata \bar "|."

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello.ly
@@ -6,11 +6,9 @@ cello = \relative c {
   \key d \major
   \time 2/4
 
-  % --Bar 1-- %
-  R2*28 |
-
-  % --Bar 29-- %
-  r4 fis,8 r |
+  R2 * 28 |
+  \repeat unfold 2 {
+   r4 fis,8 r |
   g r a r |
   b r cis r |
   d r e r |
@@ -42,7 +40,7 @@ cello = \relative c {
     d,( fis) e d( e) fis |
   }
   g r a r |
-  b r g, r |
+  b r b, r |
   r4 b'8 r |
 
   % --Bar 54-- %
@@ -61,8 +59,7 @@ cello = \relative c {
   d,8 r fis r |
   g r c r |
   b8. \noBeam g'16 d'8. a16 |
-  \tuplet 3/2 { b8( a) g fis( gis) a | }
-
+  \tuplet 3/2 { b8( a) g fis( gis) a } |
   % --Bar 68-- %
   gis r gis, r |
   r4 gis'8 r |
@@ -70,199 +67,146 @@ cello = \relative c {
   r4 gis'8 r |
   a r r r16 fis |
   b8 r r r16 g |
-  cis 8 r r r16 a |
+  cis8 r r r16 a |
   d8 r fis, r |
 
   % --Bar 76-- %
   g r a r |
   \tuplet 3/2 { b( a) g } a8. a,16 |
-  \tuplet 3/2 { d8( fis) e d( e fis) } |
-  b, r r4 |
-  \repeat unfold 6 { b8 r r4 | }
-
-  % --Bar 86 -- %
-  r8 r16 fis' \tuplet 3/2 {
-    b8( d) cis |
-    d( cis) b ais( g) cis |
   }
-  fis,4 ~ \tuplet 3/2 {
-    fis8 g e |
-    d( cis b)
-  } r4 |
-  \repeat unfold 6 { b8 r r4 | }
+  \alternative {
+    {
+      \tuplet 3/2 { d8( fis) e d( e fis) } |
+      b, r r4 |
+      \repeat unfold 6 { b8 r r4 | }
 
-  % --Bar 96 -- %
-  r8 r16 fis' \tuplet 3/2 {
-    b8( a) gis |
-    a( gis) fis eis( fis) gis |
+      % --Bar 86 -- %
+      r8 r16 fis' \tuplet 3/2 {
+        b8( d) cis |
+        d( cis) b ais( g) cis |
+      }
+      fis,4 ~ \tuplet 3/2 {
+        fis8 g e |
+        d( cis b)
+      } r4 |
+      \repeat unfold 6 { b8 r r4 | }
+
+      % --Bar 96 -- %
+      r8 r16 fis' \tuplet 3/2 {
+        b8( a) gis |
+        a( gis) fis eis( fis) gis |
+      }
+      cis,4 ~ \tuplet 3/2 {
+        cis8 d b |
+        a( gis fis)
+      } r4 |
+      \repeat unfold 7 { fis8 r r4 | }
+
+      % --Bar 107 -- %
+      R2*21 |
+
+      % --Bar 128 -- %
+      r4 a8_\forteB r |
+      b r cis r |
+      d r dis r |
+      e r fis r |
+      g r gis r |
+      a r b r |
+      cis r cis, r |
+
+      % --Bar 135 -- %
+      d r e r |
+      fis r fis, r |
+      gis r gis' r |
+      a r a, r |
+      b r b' r |
+      cis r cis, r |
+      d r d' r |
+      d r cis r |
+
+      % --Bar 143 -- %
+      d r e r |
+      \tuplet 3/2 { fis( e) d cis( dis) e | }
+      dis4 r8 b |
+      e8. d!16 cis8. fis,16 |
+      e8. d16 e8. e,16 |
+      a8_\pianoB r a' r |
+      \repeat unfold 6 { a, r a' r | }
+
+      % --Bar 155 -- %
+      a, r r4 |
+      R2 * 22 |
+
+      % --Bar 178 -- %
+      r4 b |
+      e, r |
+      r a |
+      d, r |
+      R2 * 10 |
+
+      % --Bar 192 -- %
+      r4 r8 a' |
+      d r r4 |
+      cis8 r r4 |
+
+      % --Bar 195 -- %
+      b8 r r4 |
+      a8 r r4 |
+      gis8 r fis r |
+      cis'8 r r4 |
+      cis'8 r r4 |
+      cis,8 r r4 |
+      cis'8 r r4 |
+      cis,8 r r4 |
+
+      % --Bar 203 -- %
+      cis'8 r cis, r |
+      fis8 r r4 |
+      fis8 r fis, r |
+      g8 r r4 |
+      a8 r b r |
+      e,8 r r4 |
+      a8 r d r |
+      b r g r |
+
+
+      % --Bar 211 -- %
+      e r a r |
+      d, r g r |
+      d' r c r |
+      b2 ~ |
+      b8. \noBeam fis'16 b8. fis16 |
+      g8. fis16 g8. e16 |
+      fis2 ~ |
+      fis2 ~ |
+
+      % --Bar 219 -- %
+      \repeat unfold 3 { fis2 ~ | }
+      % --Bar 222 -- %
+      fis8. \noBeam b,16 fis'8. a,16 |
+      %should beam down
+      \tuplet 3/2 { b8( a) g ais( b) cis | }
+      fis,4 ~ \tuplet 3/2 { fis8 fis' e | }
+      d r r4 |
+
+      % --Bar 226 -- %
+      R2*4 |
+      r8 r16 g d8. e16 |
+      fis8. e16 fis8. fis,16 |
+      b4 r |
+      d r |
+      %234
+      %244
+      %251
+      %261
+      R2 * 27 |
+    }
+    {
+      d2\fermata \bar "|."
+    }
   }
-  cis,4 ~ \tuplet 3/2 {
-    cis8 d b |
-    a( gis fis)
-  } r4 |
-  \repeat unfold 7 { fis8 r r4 | }
-
-  % --Bar 107 -- %
-  R2*21 |
-
-  % --Bar 128 -- %
-  r4 a8_\forteB r |
-  b r cis r |
-  d r dis r |
-  e r fis r |
-  g r gis r |
-  a r b r |
-  cis r cis, r |
-
-  % --Bar 135 -- %
-  d r e r |
-  fis r fis, r |
-  gis r gis' r |
-  a r a, r |
-  b r b' r |
-  cis r cis, r |
-  d r d' r |
-  d r cis r |
-
-  % --Bar 143 -- %
-  d r e r |
-  \tuplet 3/2 { fis( e) d cis( dis) e | }
-  dis4 r8 b |
-  e8. d!16 cis8. fis,16 |
-  e8. d16 e8. e,16 |
-  a8_\pianoB r a' r |
-  \repeat unfold 6 { a, r a' r | }
-
-  % --Bar 155 -- %
-  a, r r4 |
-  R2 * 22 |
-
-  % --Bar 178 -- %
-  r4 b |
-  e, r |
-  r a |
-  d, r |
-  R2 * 10 |
-
-  % --Bar 192 -- %
-  r4 r8 a' |
-  d r r4 |
-  cis8 r r4 |
-
-  % --Bar 195 -- %
-  b8 r r4 |
-  a8 r r4 |
-  gis8 r fis r |
-  cis'8 r r4 |
-  cis'8 r r4 |
-  cis,8 r r4 |
-  cis'8 r r4 |
-  cis,8 r r4 |
-
-  % --Bar 203 -- %
-  cis'8 r cis, r |
-  fis8 r r4 |
-  fis8 r fis, r |
-  g8 r r4 |
-  a8 r b r |
-  e,8 r r4 |
-  a8 r d r |
-  b r g r |
 
 
-  % --Bar 211 -- %
-  e r a r |
-  d, r g r |
-  d' r c r |
-  b2 ~ |
-  b8. \noBeam fis'16 b8. fis16 |
-  g8. fis16 g8. e16 |
-  fis2 ~ |
-  fis2 ~ |
 
-  % --Bar 219 -- %
-  \repeat unfold 3 { fis2 ~ | }
-  % --Bar 222 -- %
-  fis8. \noBeam b,16 fis'8. a,16 |
-  %should beam down
-  \tuplet 3/2 { b8( a) g ais( b) cis | }
-  fis,4 ~ \tuplet 3/2 { fis8 fis' e | }
-  d r r4 |
-
-  % --Bar 226 -- %
-  R2*4 |
-  r8 r16 g d8. e16 |
-  fis8. e16 fis8. fis,16 |
-  b4 r |
-  d r |
-  %234
-  %244
-  %251
-  %261
-  R2 * 27 |
-  r4 fis,8 r |
-  g r a r |
-  b r cis r |
-  d r e r |
-  fis r fis r |
-  g r a r |
-
-  % --Bar 267 -- %
-  b r a r |
-  b r cis r |
-  d r r4 |
-  R2 |
-  r8 r16 a d8. a16 |
-  \tuplet 3/2 { b8( a) g fis( a) b | }
-  d, r e r |
-  fis r fis, r |
-
-  % --Bar 275 -- %
-  g r a r |
-  b r cis r |
-  d r e r |
-  fis r g r |
-  a r b r |
-
-  % --Bar 280 -- %
-  cis8. \noBeam a16 d8. a16 |
-  \tuplet 3/2 {
-    b8( a) g fis( g) a |
-    d,( fis) e d( e) fis |
-  }
-  g r a r |
-  b r b, r |
-  r4 b'8 r |
-  fis r fis, r |
-  r4 fis'8 r |
-
-  % --Bar 288 -- %
-  gis r gis, r |
-  r4 gis'8 r |
-  a r fis r |
-  b, r e r |
-  a, r d r |
-  g,4 r |
-
-  % --Bar 294 -- %
-  r8 r16 a d8. a16 |
-  \tuplet 3/2 { b8( a) fis } a8. a16 |
-  d,8 r fis r |
-  g r c r |
-  b8. \noBeam g'16 d'8. a16 |
-  \tuplet 3/2 { b8( a) g fis( gis) a } |
-  gis r gis, r |
-  r4 gis'8 r |
-
-  % --Bar 302 -- %
-  gis r gis, r |
-  r4 gis'8 r |
-  a r r r16 fis |
-  b8 r r r16 g |
-  cis8 r r r16 a |
-  d8 r fis, r |
-  g r a r |
-  \tuplet 3/2 { b( a) g } a8. a,16 |
-  d2\fermata \bar "|."
 }
 

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello.ly
@@ -10,151 +10,150 @@ cello = \relative c {
   R2*28 |
   \repeat unfold 2 {
     r4 fis,8 r |
-    g r a r |
-    b r cis r |
-    d r e r |
+    g8 r a r |
+    b8 r cis r |
+    d8 r e r |
 
     % --Bar 33-- %
-    fis r fis r |
-    g r a r |
-    b r a r |
-    b r cis r |
-    d r r4 |
+    fis8 r fis r |
+    g8 r a r |
+    b8 r a r |
+    b8 r cis r |
+    d8 r r4 |
     R2 |
     r8 r16 a d8. a16 |
-    \tuplet 3/2 { b8( a) g fis( g) a | }
+    \tuplet 3/2 { b8( a) g fis( g) a } |
     \hide TupletNumber
 
     % --Bar 41-- %
-    d, r e r |
-    fis r fis, r |
-    g r a r |
-    b r cis r |
-    d r e r |
-    fis r g r |
+    d,8 r e r |
+    fis8 r fis, r |
+    g8 r a r |
+    b8 r cis r |
+    d8 r e r |
+    fis8 r g r |
 
     % --Bar 47-- %
-    a r b r |
+    a8 r b r |
     cis8. \noBeam a16 d8. a16 |
     \tuplet 3/2 {
       b8( a) g fis( g) a |
-      d,( fis) e d( e) fis |
+      d,8( fis) e d( e) fis |
     }
-    g r a r |
-    b r b, r |
+    g8 r a r |
+    b8 r b, r |
     r4 b'8 r |
 
     % --Bar 54-- %
-    fis r fis, r |
+    fis8 r fis, r |
     r4 fis'8 r |
-    gis r gis, r |
+    gis8 r gis, r |
     r4 gis'8 r |
-    a r fis r |
-    b, r e r |
-    a, r d r |
+    a8 r fis r |
+    b,8 r e r |
+    a,8 r d r |
 
     % --Bar 61-- %
     g,4 r |
     r8 r16 a d8. a16 |
     \tuplet 3/2 { b8( a) g } a8. a16 |
     d,8 r fis r |
-    g r c r |
+    g8 r c r |
     b8. \noBeam g'16 d'8. a16 |
     \tuplet 3/2 { b8( a) g fis( gis) a } |
     % --Bar 68-- %
-    gis r gis, r |
+    gis8 r gis, r |
     r4 gis'8 r |
-    gis r gis, r |
+    gis8 r gis, r |
     r4 gis'8 r |
-    a r r r16 fis |
+    a8 r r r16 fis |
     b8 r r r16 g |
     cis8 r r r16 a |
     d8 r fis, r |
 
     % --Bar 76-- %
-    g r a r |
-    \tuplet 3/2 { b( a) g } a8. a,16 |
+    g8 r a r |
+    \tuplet 3/2 { b8( a) g } a8. a,16 |
   }
+
   \alternative {
     {
       \tuplet 3/2 { d8( fis) e d( e fis) } |
-      b, r r4 |
-      \repeat unfold 6 { b8 r r4 | }
+      b,8 r r4 |
+      \repeat unfold 6 { b8 r r4 } |
 
       % --Bar 86 -- %
       r8 r16 fis' \tuplet 3/2 {
         b8( d) cis |
-        d( cis) b ais( g) cis |
+        d8( cis) b ais( g) cis |
       }
       fis,4 ~ \tuplet 3/2 {
         fis8 g e |
-        d( cis b)
+        d8( cis b)
       } r4 |
-      \repeat unfold 6 { b8 r r4 | }
+      \repeat unfold 6 { b8 r r4 } |
 
       % --Bar 96 -- %
       r8 r16 fis' \tuplet 3/2 {
         b8( a) gis |
-        a( gis) fis eis( fis) gis |
+        a8( gis) fis eis( fis) gis |
       }
-      cis,4 ~ \tuplet 3/2 {
-        cis8 d b |
-        a( gis fis)
-      } r4 |
-      \repeat unfold 7 { fis8 r r4 | }
+      cis,4 ~ \tuplet 3/2 { cis8 d b } |
+      \tuplet 3/2 { a8( gis fis) } r4 |
+      \repeat unfold 7 { fis8 r r4 } |
 
       % --Bar 107 -- %
       R2*21 |
 
       % --Bar 128 -- %
       r4 a8_\forteB r |
-      b r cis r |
-      d r dis r |
-      e r fis r |
-      g r gis r |
-      a r b r |
-      cis r cis, r |
+      b8 r cis r |
+      d8 r dis r |
+      e8 r fis r |
+      g8 r gis r |
+      a8 r b r |
+      cis8 r cis, r |
 
       % --Bar 135 -- %
-      d r e r |
-      fis r fis, r |
-      gis r gis' r |
-      a r a, r |
-      b r b' r |
-      cis r cis, r |
-      d r d' r |
-      d r cis r |
+      d8 r e r |
+      fis8 r fis, r |
+      gis8 r gis' r |
+      a8 r a, r |
+      b8 r b' r |
+      cis8 r cis, r |
+      d8 r d' r |
+      d8 r cis r |
 
       % --Bar 143 -- %
-      d r e r |
-      \tuplet 3/2 { fis( e) d cis( dis) e | }
+      d8 r e r |
+      \tuplet 3/2 { fis8( e) d cis( dis) e } |
       dis4 r8 b |
       e8. d!16 cis8. fis,16 |
       e8. d16 e8. e,16 |
       a8_\pianoB r a' r |
-      \repeat unfold 6 { a, r a' r | }
+      \repeat unfold 6 { a,8 r a' r } |
 
       % --Bar 155 -- %
-      a, r r4 |
+      a,8 r r4 |
       R2 * 22 |
 
       % --Bar 178 -- %
       r4 b |
-      e, r |
-      r a |
-      d, r |
+      e,4 r |
+      r4 a |
+      d,4 r |
       R2 * 10 |
 
       % --Bar 192 -- %
       r4 r8 a' |
-      d r r4 |
+      d8 r r4 |
       cis8 r r4 |
 
       % --Bar 195 -- %
       b8 r r4 |
       a8 r r4 |
       gis8 r fis r |
-      \repeat unfold 5 { cis'8 r r4 | }
+      \repeat unfold 5 { cis'8 r r4 } |
 
       % --Bar 203 -- %
       cis'8 r cis, r |
@@ -164,42 +163,35 @@ cello = \relative c {
       a8 r b r |
       e,8 r r4 |
       a8 r d r |
-      b r g r |
+      b8 r g r |
 
 
       % --Bar 211 -- %
-      e r a r |
-      d, r g r |
-      d' r c r |
+      e8 r a r |
+      d,8 r g r |
+      d'8 r c r |
       b2 ~ |
-      b8. \noBeam fis'16 b8. fis16 |
+      b8.\noBeam fis'16 b8. fis16 |
       g8. fis16 g8. e16 |
       fis2 ~ |
       fis2 ~ |
 
       % --Bar 219 -- %
-      \repeat unfold 3 { fis2 ~ | }
-      % --Bar 222 -- %
-      fis8. \noBeam b,16 fis'8. a,16 |
-      %should beam down
-      \tuplet 3/2 { b8( a) g ais( b) cis | }
-      fis,4 ~ \tuplet 3/2 { fis8 fis' e | }
-      d r r4 |
+      \repeat unfold 3 { fis2 ~ } |
+      fis8.\noBeam b,16 fis'8. a,16 |
+      \tuplet 3/2 { b8( a) g ais( b) cis } |
+      fis,4 ~ \tuplet 3/2 { fis8 fis' e } |
+      d8 r r4 |
 
       % --Bar 226 -- %
       R2*4 |
       r8 r16 g d8. e16 |
       fis8. e16 fis8. fis,16 |
       b4 r |
-      d r |
+      d4 r |
       R2*27 |
-    }
-    {
+    } {
       d2\fermata \bar "|."
     }
   }
-
-
-
 }
-

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello.ly
@@ -2,260 +2,272 @@
 
 \include "header.ly"
 
- \version "2.18.0"
+\version "2.18.0"
 cello =  \relative c {
- \clef bass
- \key d \major
- \time 2/4
+  \clef bass
+  \key d \major
+  \time 2/4
 
- \commonSettings
+  \commonSettings
 
-% --Bar 1-- %
-R2*28 |
+  % --Bar 1-- %
+  R2*28 |
 
-% --Bar 29-- %
-r4 fis,8 r |
-g r a r |
-b r cis r |
-d r e r |
+  % --Bar 29-- %
+  r4 fis,8 r |
+  g r a r |
+  b r cis r |
+  d r e r |
 
-% --Bar 33-- %
-fis r fis r |
-g r a r |
-b r a r |
-b r cis r |
-d r r4 |
-R2 |
-r8 r16 a d8. a16 |
- \tuplet 3/2 { b8( a) g  fis( g) a } |
-\tripletsHide
+  % --Bar 33-- %
+  fis r fis r |
+  g r a r |
+  b r a r |
+  b r cis r |
+  d r r4 |
+  R2 |
+  r8 r16 a d8. a16 |
+  \tuplet 3/2 { b8( a) g  fis( g) a } |
+  \tripletsHide
 
-% --Bar 41-- %
-d, r e r |
-fis r fis, r |
-g r a r |
-b r cis r |
-d r e r |
-fis r g r |
+  % --Bar 41-- %
+  d, r e r |
+  fis r fis, r |
+  g r a r |
+  b r cis r |
+  d r e r |
+  fis r g r |
 
-% --Bar 47-- %
-a r b r |
-%\autoBeamOff cis8. \autoBeamOn a16  d8. a16 | %[] workaround
-cis8.\noBeam a16  d8. a16 |
-\tuplet 3/2 { b8( a) g fis( g) a |
-d,( fis) e d(e ) fis | }
-g r a r |
-b r g, r |
-r4 b'8 r |
+  % --Bar 47-- %
+  a r b r |
+  %\autoBeamOff cis8. \autoBeamOn a16  d8. a16 | %[] workaround
+  cis8.\noBeam a16  d8. a16 |
+  \tuplet 3/2 {
+    b8( a) g fis( g) a |
+    d,( fis) e d(e ) fis |
+  }
+  g r a r |
+  b r g, r |
+  r4 b'8 r |
 
-% --Bar 54-- %
-fis r fis, r |
-r4 fis'8 r |
-gis r gis, r |
-r4 gis'8 r |
-a r fis r |
-b, r e r |
-a, r d r |
+  % --Bar 54-- %
+  fis r fis, r |
+  r4 fis'8 r |
+  gis r gis, r |
+  r4 gis'8 r |
+  a r fis r |
+  b, r e r |
+  a, r d r |
 
-% --Bar 61-- %
-g,4 r |
-r8 r16 a d8. a16 |
-\tuplet 3/2 { b8( a) g  }  a8. a16 |
-d,8 r fis r |
-g r c r |
-\autoBeamOff b8. \autoBeamOn g'16 d'8. a16 |
-\tuplet 3/2 { b8( a) g  fis( gis) a  } |
+  % --Bar 61-- %
+  g,4 r |
+  r8 r16 a d8. a16 |
+  \tuplet 3/2 { b8( a) g  }  a8. a16 |
+  d,8 r fis r |
+  g r c r |
+  \autoBeamOff b8. \autoBeamOn g'16 d'8. a16 |
+  \tuplet 3/2 { b8( a) g  fis( gis) a  } |
 
-% --Bar 68-- %
-gis r gis, r |
-r4 gis'8 r |
-gis r gis, r |
-r4 gis'8 r |
-a r r r16 fis | 
-b8 r r r16 g |
-cis 8 r r r16 a |
-d8 r fis, r |
+  % --Bar 68-- %
+  gis r gis, r |
+  r4 gis'8 r |
+  gis r gis, r |
+  r4 gis'8 r |
+  a r r r16 fis |
+  b8 r r r16 g |
+  cis 8 r r r16 a |
+  d8 r fis, r |
 
-% --Bar 76-- %
-g r a r |
-\tuplet 3/2 { b( a) g  } a8. a,16 |
-\tuplet 3/2 { d8( fis) e  d( e fis )}|
-b, r r4 |
-\repeat unfold 6 {b8 r r4 |}
+  % --Bar 76-- %
+  g r a r |
+  \tuplet 3/2 { b( a) g  } a8. a,16 |
+  \tuplet 3/2 { d8( fis) e  d( e fis )}|
+  b, r r4 |
+  \repeat unfold 6 {b8 r r4 |}
 
-% --Bar 86 -- %
-r8 r16 fis' \tuplet 3/2 {b8( d) cis | 
-d ( cis) b  ais ( g)  cis | }
-fis,4 ~ \tuplet 3/2 {fis8 g e |
-d( cis b) } r4 |
-\repeat unfold 6 {b8 r r4 |}
+  % --Bar 86 -- %
+  r8 r16 fis' \tuplet 3/2 {
+    b8( d) cis |
+    d ( cis) b  ais ( g)  cis |
+  }
+  fis,4 ~ \tuplet 3/2 {
+    fis8 g e |
+    d( cis b)
+  } r4 |
+  \repeat unfold 6 {b8 r r4 |}
 
-% --Bar 96 -- %
-r8 r16 fis' \tuplet 3/2 {b8( a) gis |
-a (gis) fis eis( fis) gis }|
-cis,4 ~ \tuplet 3/2 {cis8 d b |
-a( gis fis) } r4 |
-\repeat unfold 7 { fis8 r r4 |}
+  % --Bar 96 -- %
+  r8 r16 fis' \tuplet 3/2 {
+    b8( a) gis |
+    a (gis) fis eis( fis) gis
+  }|
+  cis,4 ~ \tuplet 3/2 {
+    cis8 d b |
+    a( gis fis)
+  } r4 |
+  \repeat unfold 7 { fis8 r r4 |}
 
-% --Bar 107 -- %
-R2*21 |
+  % --Bar 107 -- %
+  R2*21 |
 
-% --Bar 128 -- %
-r4 a8_\forteB r |
-b r cis r |
-d r dis r |
-e r fis r |
-g r gis r |
-a r b r |
-cis r cis, r  |
+  % --Bar 128 -- %
+  r4 a8_\forteB r |
+  b r cis r |
+  d r dis r |
+  e r fis r |
+  g r gis r |
+  a r b r |
+  cis r cis, r  |
 
-% --Bar 135 -- %
-d r e r |
-fis r fis, r |
-gis r gis' r |
-a r a, r |
-b r b' r |
-cis r cis, r |
-d r d' r |
-d r cis r |
+  % --Bar 135 -- %
+  d r e r |
+  fis r fis, r |
+  gis r gis' r |
+  a r a, r |
+  b r b' r |
+  cis r cis, r |
+  d r d' r |
+  d r cis r |
 
-% --Bar 143 -- %
-d r e r |
-\tuplet 3/2 { fis(e) d cis( dis) e }
-dis4 r8 b |
-e8. d!16 cis8. fis,16 |
-e8. d16 e8. e,16 |
-a8_\pianoB r a' r |
-\repeat unfold 6 { a, r a ' r |}
+  % --Bar 143 -- %
+  d r e r |
+  \tuplet 3/2 { fis(e) d cis( dis) e }
+  dis4 r8 b |
+  e8. d!16 cis8. fis,16 |
+  e8. d16 e8. e,16 |
+  a8_\pianoB r a' r |
+  \repeat unfold 6 { a, r a ' r |}
 
-% --Bar 155 -- %
-a, r r4 | 
-R2 * 22|
+  % --Bar 155 -- %
+  a, r r4 |
+  R2 * 22|
 
-% --Bar 178 -- %
-r4 b |
-e, r |
-r a |
-d, r |
-R2 * 10 |
+  % --Bar 178 -- %
+  r4 b |
+  e, r |
+  r a |
+  d, r |
+  R2 * 10 |
 
-% --Bar 192 -- %
-r4 r8 a' |
-d r r4 |
-cis8 r r4 |
+  % --Bar 192 -- %
+  r4 r8 a' |
+  d r r4 |
+  cis8 r r4 |
 
-% --Bar 195 -- %
-b8 r r4 |
-a8 r r4 |
-gis8 r fis r |
-cis'8 r r4 |
-cis'8 r r4 |
-cis,8 r r4 |
-cis'8 r r4 |
-cis,8 r r4 |
+  % --Bar 195 -- %
+  b8 r r4 |
+  a8 r r4 |
+  gis8 r fis r |
+  cis'8 r r4 |
+  cis'8 r r4 |
+  cis,8 r r4 |
+  cis'8 r r4 |
+  cis,8 r r4 |
 
-% --Bar 203 -- %
-cis'8 r cis, r |
-fis8 r r4 |
-fis8 r fis, r |
-g8 r r4 |
-a8 r b r |
-e,8 r r4 |
-a8 r d r |
-b r g r |
+  % --Bar 203 -- %
+  cis'8 r cis, r |
+  fis8 r r4 |
+  fis8 r fis, r |
+  g8 r r4 |
+  a8 r b r |
+  e,8 r r4 |
+  a8 r d r |
+  b r g r |
 
 
-% --Bar 211 -- %
-e r a r |
-d, r g r |
-d' r c r |
-b2~ |
-b8. \noBeam fis'16 b8. fis16 |
-g8. fis16 g8. e16 |
-fis2 ~ |
-fis2 ~ |
+  % --Bar 211 -- %
+  e r a r |
+  d, r g r |
+  d' r c r |
+  b2~ |
+  b8. \noBeam fis'16 b8. fis16 |
+  g8. fis16 g8. e16 |
+  fis2 ~ |
+  fis2 ~ |
 
-% --Bar 219 -- %
-\repeat unfold 3 {fis2 ~ |}
-% --Bar 222 -- %
-fis8. \noBeam b,16 fis'8. a,16 |
-%should beam down
-\tuplet 3/2 {b8( a) g ais(b) cis }|
-fis,4 ~ \tuplet 3/2 {fis8 fis' e } |
-d r r4 |
+  % --Bar 219 -- %
+  \repeat unfold 3 {fis2 ~ |}
+  % --Bar 222 -- %
+  fis8. \noBeam b,16 fis'8. a,16 |
+  %should beam down
+  \tuplet 3/2 {b8( a) g ais(b) cis }|
+  fis,4 ~ \tuplet 3/2 {fis8 fis' e } |
+  d r r4 |
 
-% --Bar 226 -- %
-R2*4 |
-r8 r16 g d8. e16|
-fis8. e16 fis8. fis,16 |
-b4 r |
-d r |
-%234
-%244
-%251
-%261
-R2 * 27 |
-r4 fis,8 r |
-g r a r |
-b r cis r |
-d r e r |
-fis r fis r |
-g r a r |
+  % --Bar 226 -- %
+  R2*4 |
+  r8 r16 g d8. e16|
+  fis8. e16 fis8. fis,16 |
+  b4 r |
+  d r |
+  %234
+  %244
+  %251
+  %261
+  R2 * 27 |
+  r4 fis,8 r |
+  g r a r |
+  b r cis r |
+  d r e r |
+  fis r fis r |
+  g r a r |
 
-% --Bar 267 -- %
-b r a r |
-b r cis r |
-d r r4 |
-R2 |
-r8 r16 a d8. a16 |
-\tuplet 3/2 {b8( a) g fis( a ) b } |
-d, r e r |
-fis r fis, r |
+  % --Bar 267 -- %
+  b r a r |
+  b r cis r |
+  d r r4 |
+  R2 |
+  r8 r16 a d8. a16 |
+  \tuplet 3/2 {b8( a) g fis( a ) b } |
+  d, r e r |
+  fis r fis, r |
 
-% --Bar 275 -- %
-g r a r |
-b r cis r |
-d r e r |
-fis r g r |
-a r b r |
+  % --Bar 275 -- %
+  g r a r |
+  b r cis r |
+  d r e r |
+  fis r g r |
+  a r b r |
 
-% --Bar 280 -- % 
-cis8. \noBeam a16 d8. a16 |
-\tuplet 3/2 {b8(a) g fis (g) a |
-d,( fis ) e d(e) fis }|
-g r a r |
-b r b, r |
-r4 b'8 r |
-fis r fis, r |
-r4 fis'8 r |
+  % --Bar 280 -- %
+  cis8. \noBeam a16 d8. a16 |
+  \tuplet 3/2 {
+    b8(a) g fis (g) a |
+    d,( fis ) e d(e) fis
+  }|
+  g r a r |
+  b r b, r |
+  r4 b'8 r |
+  fis r fis, r |
+  r4 fis'8 r |
 
-% --Bar 288 -- %
-gis r gis, r |
-r4 gis'8 r |
-a r fis r |
-b, r e r |
-a, r d r |
-g,4 r |
+  % --Bar 288 -- %
+  gis r gis, r |
+  r4 gis'8 r |
+  a r fis r |
+  b, r e r |
+  a, r d r |
+  g,4 r |
 
-% --Bar 294 -- %
-r8 r16 a d8. a16 |
-\tuplet 3/2 {b8 (a ) fis } a8. a16|
-d,8 r fis r |
-g r c r |
-b8. \noBeam g'16 d'8. a16 |
-\tuplet 3/2 {b8(a) g fis( gis) a }|
-gis r gis, r |
-r4 gis'8 r |
+  % --Bar 294 -- %
+  r8 r16 a d8. a16 |
+  \tuplet 3/2 {b8 (a ) fis } a8. a16|
+  d,8 r fis r |
+  g r c r |
+  b8. \noBeam g'16 d'8. a16 |
+  \tuplet 3/2 {b8(a) g fis( gis) a }|
+  gis r gis, r |
+  r4 gis'8 r |
 
-% --Bar 302 -- %
-gis r gis, r |
-r4 gis'8 r |
-a r r r16 fis |
-b8 r r r16 g |
-cis8 r r r16 a |
-d8 r fis, r |
-g r a r |
-\tuplet 3/2 {b(a ) g} a8. a,16 |
-d2-\fermata \bar "|."
+  % --Bar 302 -- %
+  gis r gis, r |
+  r4 gis'8 r |
+  a r r r16 fis |
+  b8 r r r16 g |
+  cis8 r r r16 a |
+  d8 r fis, r |
+  g r a r |
+  \tuplet 3/2 {b(a ) g} a8. a,16 |
+  d2-\fermata \bar "|."
 }
 

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello.ly
@@ -1,5 +1,3 @@
-#(ly:set-point-and-click 'line-column )
-
 \include "header.ly"
 
 \version "2.18.0"

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello.ly
@@ -1,13 +1,10 @@
 \version "2.18.0"
-
 \include "header.ly"
 
 cello = \relative c {
   \clef bass
   \key d \major
   \time 2/4
-
-  \commonSettings
 
   % --Bar 1-- %
   R2*28 |
@@ -26,8 +23,8 @@ cello = \relative c {
   d r r4 |
   R2 |
   r8 r16 a d8. a16 |
-  \tuplet 3/2 { b8( a) g fis( g) a } |
-  \tripletsHide
+  \tuplet 3/2 { b8( a) g fis( g) a | }
+  \hide TupletNumber
 
   % --Bar 41-- %
   d, r e r |
@@ -39,8 +36,7 @@ cello = \relative c {
 
   % --Bar 47-- %
   a r b r |
-  %\autoBeamOff cis8. \autoBeamOn a16 d8. a16 | %[] workaround
-  cis8.\noBeam a16 d8. a16 |
+  cis8. \noBeam a16 d8. a16 |
   \tuplet 3/2 {
     b8( a) g fis( g) a |
     d,( fis) e d( e) fis |
@@ -64,8 +60,8 @@ cello = \relative c {
   \tuplet 3/2 { b8( a) g } a8. a16 |
   d,8 r fis r |
   g r c r |
-  \autoBeamOff b8. \autoBeamOn g'16 d'8. a16 |
-  \tuplet 3/2 { b8( a) g fis( gis) a } |
+  b8. \noBeam g'16 d'8. a16 |
+  \tuplet 3/2 { b8( a) g fis( gis) a | }
 
   % --Bar 68-- %
   gis r gis, r |
@@ -98,8 +94,8 @@ cello = \relative c {
   % --Bar 96 -- %
   r8 r16 fis' \tuplet 3/2 {
     b8( a) gis |
-    a( gis) fis eis( fis) gis
-  } |
+    a( gis) fis eis( fis) gis |
+  }
   cis,4 ~ \tuplet 3/2 {
     cis8 d b |
     a( gis fis)
@@ -130,7 +126,7 @@ cello = \relative c {
 
   % --Bar 143 -- %
   d r e r |
-  \tuplet 3/2 { fis( e) d cis( dis) e }
+  \tuplet 3/2 { fis( e) d cis( dis) e | }
   dis4 r8 b |
   e8. d!16 cis8. fis,16 |
   e8. d16 e8. e,16 |

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello.ly
@@ -61,6 +61,7 @@ cello = \relative c {
     g8 r c r |
     b8. \noBeam g'16 d'8. a16 |
     \tuplet 3/2 { b8( a) g fis( gis) a } |
+
     % --Bar 68-- %
     gis8 r gis, r |
     r4 gis'8 r |
@@ -87,10 +88,8 @@ cello = \relative c {
         b8( d) cis |
         d8( cis) b ais( g) cis |
       }
-      fis,4 ~ \tuplet 3/2 {
-        fis8 g e |
-        d8( cis b)
-      } r4 |
+      fis,4 ~ \tuplet 3/2 { fis8 g e } |
+      \tuplet 3/2 { d8( cis b) } r4 |
       \repeat unfold 6 { b8 r r4 } |
 
       % --Bar 96 -- %

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello.ly
@@ -2,7 +2,7 @@
 
 \include "header.ly"
 
- \version "2.4.0"
+ \version "2.18.0"
 cello =  \relative c {
  \clef bass
  \key d \major
@@ -27,7 +27,7 @@ b r cis r |
 d r r4 |
 R2 |
 r8 r16 a d8. a16 |
- \times 2/3 { b8( a) g  fis( g) a } |
+ \tuplet 3/2 { b8( a) g  fis( g) a } |
 \tripletsHide
 
 % --Bar 41-- %
@@ -42,7 +42,7 @@ fis r g r |
 a r b r |
 %\autoBeamOff cis8. \autoBeamOn a16  d8. a16 | %[] workaround
 cis8.\noBeam a16  d8. a16 |
-\times 2/3 { b8( a) g fis( g) a |
+\tuplet 3/2 { b8( a) g fis( g) a |
 d,( fis) e d(e ) fis | }
 g r a r |
 b r g, r |
@@ -60,11 +60,11 @@ a, r d r |
 % --Bar 61-- %
 g,4 r |
 r8 r16 a d8. a16 |
-\times 2/3 { b8( a) g  }  a8. a16 |
+\tuplet 3/2 { b8( a) g  }  a8. a16 |
 d,8 r fis r |
 g r c r |
 \autoBeamOff b8. \autoBeamOn g'16 d'8. a16 |
-\times 2/3 { b8( a) g  fis( gis) a  } |
+\tuplet 3/2 { b8( a) g  fis( gis) a  } |
 
 % --Bar 68-- %
 gis r gis, r |
@@ -78,22 +78,22 @@ d8 r fis, r |
 
 % --Bar 76-- %
 g r a r |
-\times 2/3 { b( a) g  } a8. a,16 |
-\times 2/3 { d8( fis) e  d( e fis )}|
+\tuplet 3/2 { b( a) g  } a8. a,16 |
+\tuplet 3/2 { d8( fis) e  d( e fis )}|
 b, r r4 |
 \repeat unfold 6 {b8 r r4 |}
 
 % --Bar 86 -- %
-r8 r16 fis' \times 2/3 {b8( d) cis | 
+r8 r16 fis' \tuplet 3/2 {b8( d) cis | 
 d ( cis) b  ais ( g)  cis | }
-fis,4 ~ \times 2/3 {fis8 g e |
+fis,4 ~ \tuplet 3/2 {fis8 g e |
 d( cis b) } r4 |
 \repeat unfold 6 {b8 r r4 |}
 
 % --Bar 96 -- %
-r8 r16 fis' \times 2/3 {b8( a) gis |
+r8 r16 fis' \tuplet 3/2 {b8( a) gis |
 a (gis) fis eis( fis) gis }|
-cis,4 ~ \times 2/3 {cis8 d b |
+cis,4 ~ \tuplet 3/2 {cis8 d b |
 a( gis fis) } r4 |
 \repeat unfold 7 { fis8 r r4 |}
 
@@ -121,7 +121,7 @@ d r cis r |
 
 % --Bar 143 -- %
 d r e r |
-\times 2/3 { fis(e) d cis( dis) e }
+\tuplet 3/2 { fis(e) d cis( dis) e }
 dis4 r8 b |
 e8. d!16 cis8. fis,16 |
 e8. d16 e8. e,16 |
@@ -180,8 +180,8 @@ fis2 ~ |
 % --Bar 222 -- %
 fis8. \noBeam b,16 fis'8. a,16 |
 %should beam down
-\times 2/3 {b8( a) g ais(b) cis }|
-fis,4 ~ \times 2/3 {fis8 fis' e } |
+\tuplet 3/2 {b8( a) g ais(b) cis }|
+fis,4 ~ \tuplet 3/2 {fis8 fis' e } |
 d r r4 |
 
 % --Bar 226 -- %
@@ -208,7 +208,7 @@ b r cis r |
 d r r4 |
 R2 |
 r8 r16 a d8. a16 |
-\times 2/3 {b8( a) g fis( a ) b } |
+\tuplet 3/2 {b8( a) g fis( a ) b } |
 d, r e r |
 fis r fis, r |
 
@@ -221,7 +221,7 @@ a r b r |
 
 % --Bar 280 -- % 
 cis8. \noBeam a16 d8. a16 |
-\times 2/3 {b8(a) g fis (g) a |
+\tuplet 3/2 {b8(a) g fis (g) a |
 d,( fis ) e d(e) fis }|
 g r a r |
 b r b, r |
@@ -239,11 +239,11 @@ g,4 r |
 
 % --Bar 294 -- %
 r8 r16 a d8. a16 |
-\times 2/3 {b8 (a ) fis } a8. a16|
+\tuplet 3/2 {b8 (a ) fis } a8. a16|
 d,8 r fis r |
 g r c r |
 b8. \noBeam g'16 d'8. a16 |
-\times 2/3 {b8(a) g fis( gis) a }|
+\tuplet 3/2 {b8(a) g fis( gis) a }|
 gis r gis, r |
 r4 gis'8 r |
 
@@ -255,7 +255,7 @@ b8 r r r16 g |
 cis8 r r r16 a |
 d8 r fis, r |
 g r a r |
-\times 2/3 {b(a ) g} a8. a,16 |
+\tuplet 3/2 {b(a ) g} a8. a,16 |
 d2-\fermata \bar "|."
 }
 

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello.ly
@@ -1,7 +1,7 @@
 \include "header.ly"
 
 \version "2.18.0"
-cello =  \relative c {
+cello = \relative c {
   \clef bass
   \key d \major
   \time 2/4
@@ -25,7 +25,7 @@ cello =  \relative c {
   d r r4 |
   R2 |
   r8 r16 a d8. a16 |
-  \tuplet 3/2 { b8( a) g  fis( g) a } |
+  \tuplet 3/2 { b8( a) g fis( g) a } |
   \tripletsHide
 
   % --Bar 41-- %
@@ -38,8 +38,8 @@ cello =  \relative c {
 
   % --Bar 47-- %
   a r b r |
-  %\autoBeamOff cis8. \autoBeamOn a16  d8. a16 | %[] workaround
-  cis8.\noBeam a16  d8. a16 |
+  %\autoBeamOff cis8. \autoBeamOn a16 d8. a16 | %[] workaround
+  cis8.\noBeam a16 d8. a16 |
   \tuplet 3/2 {
     b8( a) g fis( g) a |
     d,( fis) e d(e ) fis |
@@ -60,11 +60,11 @@ cello =  \relative c {
   % --Bar 61-- %
   g,4 r |
   r8 r16 a d8. a16 |
-  \tuplet 3/2 { b8( a) g  }  a8. a16 |
+  \tuplet 3/2 { b8( a) g } a8. a16 |
   d,8 r fis r |
   g r c r |
   \autoBeamOff b8. \autoBeamOn g'16 d'8. a16 |
-  \tuplet 3/2 { b8( a) g  fis( gis) a  } |
+  \tuplet 3/2 { b8( a) g fis( gis) a } |
 
   % --Bar 68-- %
   gis r gis, r |
@@ -78,32 +78,32 @@ cello =  \relative c {
 
   % --Bar 76-- %
   g r a r |
-  \tuplet 3/2 { b( a) g  } a8. a,16 |
-  \tuplet 3/2 { d8( fis) e  d( e fis )}|
+  \tuplet 3/2 { b( a) g } a8. a,16 |
+  \tuplet 3/2 { d8( fis) e d( e fis )} |
   b, r r4 |
-  \repeat unfold 6 {b8 r r4 |}
+  \repeat unfold 6 { b8 r r4 | }
 
   % --Bar 86 -- %
   r8 r16 fis' \tuplet 3/2 {
     b8( d) cis |
-    d ( cis) b  ais ( g)  cis |
+    d ( cis) b ais ( g) cis |
   }
   fis,4 ~ \tuplet 3/2 {
     fis8 g e |
     d( cis b)
   } r4 |
-  \repeat unfold 6 {b8 r r4 |}
+  \repeat unfold 6 { b8 r r4 | }
 
   % --Bar 96 -- %
   r8 r16 fis' \tuplet 3/2 {
     b8( a) gis |
     a (gis) fis eis( fis) gis
-  }|
+  } |
   cis,4 ~ \tuplet 3/2 {
     cis8 d b |
     a( gis fis)
   } r4 |
-  \repeat unfold 7 { fis8 r r4 |}
+  \repeat unfold 7 { fis8 r r4 | }
 
   % --Bar 107 -- %
   R2*21 |
@@ -115,7 +115,7 @@ cello =  \relative c {
   e r fis r |
   g r gis r |
   a r b r |
-  cis r cis, r  |
+  cis r cis, r |
 
   % --Bar 135 -- %
   d r e r |
@@ -134,11 +134,11 @@ cello =  \relative c {
   e8. d!16 cis8. fis,16 |
   e8. d16 e8. e,16 |
   a8_\pianoB r a' r |
-  \repeat unfold 6 { a, r a ' r |}
+  \repeat unfold 6 { a, r a ' r | }
 
   % --Bar 155 -- %
   a, r r4 |
-  R2 * 22|
+  R2 * 22 |
 
   % --Bar 178 -- %
   r4 b |
@@ -177,24 +177,24 @@ cello =  \relative c {
   e r a r |
   d, r g r |
   d' r c r |
-  b2~ |
+  b2 ~ |
   b8. \noBeam fis'16 b8. fis16 |
   g8. fis16 g8. e16 |
   fis2 ~ |
   fis2 ~ |
 
   % --Bar 219 -- %
-  \repeat unfold 3 {fis2 ~ |}
+  \repeat unfold 3 { fis2 ~ | }
   % --Bar 222 -- %
   fis8. \noBeam b,16 fis'8. a,16 |
   %should beam down
-  \tuplet 3/2 {b8( a) g ais(b) cis }|
-  fis,4 ~ \tuplet 3/2 {fis8 fis' e } |
+  \tuplet 3/2 { b8( a) g ais(b) cis } |
+  fis,4 ~ \tuplet 3/2 { fis8 fis' e } |
   d r r4 |
 
   % --Bar 226 -- %
   R2*4 |
-  r8 r16 g d8. e16|
+  r8 r16 g d8. e16 |
   fis8. e16 fis8. fis,16 |
   b4 r |
   d r |
@@ -216,7 +216,7 @@ cello =  \relative c {
   d r r4 |
   R2 |
   r8 r16 a d8. a16 |
-  \tuplet 3/2 {b8( a) g fis( a ) b } |
+  \tuplet 3/2 { b8( a) g fis( a ) b } |
   d, r e r |
   fis r fis, r |
 
@@ -232,7 +232,7 @@ cello =  \relative c {
   \tuplet 3/2 {
     b8(a) g fis (g) a |
     d,( fis ) e d(e) fis
-  }|
+  } |
   g r a r |
   b r b, r |
   r4 b'8 r |
@@ -249,11 +249,11 @@ cello =  \relative c {
 
   % --Bar 294 -- %
   r8 r16 a d8. a16 |
-  \tuplet 3/2 {b8 (a ) fis } a8. a16|
+  \tuplet 3/2 { b8 (a ) fis } a8. a16 |
   d,8 r fis r |
   g r c r |
   b8. \noBeam g'16 d'8. a16 |
-  \tuplet 3/2 {b8(a) g fis( gis) a }|
+  \tuplet 3/2 { b8(a) g fis( gis) a } |
   gis r gis, r |
   r4 gis'8 r |
 
@@ -265,7 +265,7 @@ cello =  \relative c {
   cis8 r r r16 a |
   d8 r fis, r |
   g r a r |
-  \tuplet 3/2 {b(a ) g} a8. a,16 |
+  \tuplet 3/2 { b(a ) g} a8. a,16 |
   d2-\fermata \bar "|."
 }
 

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello.ly
@@ -1,6 +1,7 @@
+\version "2.18.0"
+
 \include "header.ly"
 
-\version "2.18.0"
 cello = \relative c {
   \clef bass
   \key d \major
@@ -42,7 +43,7 @@ cello = \relative c {
   cis8.\noBeam a16 d8. a16 |
   \tuplet 3/2 {
     b8( a) g fis( g) a |
-    d,( fis) e d(e ) fis |
+    d,( fis) e d( e) fis |
   }
   g r a r |
   b r g, r |
@@ -79,14 +80,14 @@ cello = \relative c {
   % --Bar 76-- %
   g r a r |
   \tuplet 3/2 { b( a) g } a8. a,16 |
-  \tuplet 3/2 { d8( fis) e d( e fis )} |
+  \tuplet 3/2 { d8( fis) e d( e fis) } |
   b, r r4 |
   \repeat unfold 6 { b8 r r4 | }
 
   % --Bar 86 -- %
   r8 r16 fis' \tuplet 3/2 {
     b8( d) cis |
-    d ( cis) b ais ( g) cis |
+    d( cis) b ais( g) cis |
   }
   fis,4 ~ \tuplet 3/2 {
     fis8 g e |
@@ -97,7 +98,7 @@ cello = \relative c {
   % --Bar 96 -- %
   r8 r16 fis' \tuplet 3/2 {
     b8( a) gis |
-    a (gis) fis eis( fis) gis
+    a( gis) fis eis( fis) gis
   } |
   cis,4 ~ \tuplet 3/2 {
     cis8 d b |
@@ -129,12 +130,12 @@ cello = \relative c {
 
   % --Bar 143 -- %
   d r e r |
-  \tuplet 3/2 { fis(e) d cis( dis) e }
+  \tuplet 3/2 { fis( e) d cis( dis) e }
   dis4 r8 b |
   e8. d!16 cis8. fis,16 |
   e8. d16 e8. e,16 |
   a8_\pianoB r a' r |
-  \repeat unfold 6 { a, r a ' r | }
+  \repeat unfold 6 { a, r a' r | }
 
   % --Bar 155 -- %
   a, r r4 |
@@ -188,8 +189,8 @@ cello = \relative c {
   % --Bar 222 -- %
   fis8. \noBeam b,16 fis'8. a,16 |
   %should beam down
-  \tuplet 3/2 { b8( a) g ais(b) cis } |
-  fis,4 ~ \tuplet 3/2 { fis8 fis' e } |
+  \tuplet 3/2 { b8( a) g ais( b) cis | }
+  fis,4 ~ \tuplet 3/2 { fis8 fis' e | }
   d r r4 |
 
   % --Bar 226 -- %
@@ -216,7 +217,7 @@ cello = \relative c {
   d r r4 |
   R2 |
   r8 r16 a d8. a16 |
-  \tuplet 3/2 { b8( a) g fis( a ) b } |
+  \tuplet 3/2 { b8( a) g fis( a) b | }
   d, r e r |
   fis r fis, r |
 
@@ -230,9 +231,9 @@ cello = \relative c {
   % --Bar 280 -- %
   cis8. \noBeam a16 d8. a16 |
   \tuplet 3/2 {
-    b8(a) g fis (g) a |
-    d,( fis ) e d(e) fis
-  } |
+    b8( a) g fis( g) a |
+    d,( fis) e d( e) fis |
+  }
   g r a r |
   b r b, r |
   r4 b'8 r |
@@ -249,11 +250,11 @@ cello = \relative c {
 
   % --Bar 294 -- %
   r8 r16 a d8. a16 |
-  \tuplet 3/2 { b8 (a ) fis } a8. a16 |
+  \tuplet 3/2 { b8( a) fis } a8. a16 |
   d,8 r fis r |
   g r c r |
   b8. \noBeam g'16 d'8. a16 |
-  \tuplet 3/2 { b8(a) g fis( gis) a } |
+  \tuplet 3/2 { b8( a) g fis( gis) a } |
   gis r gis, r |
   r4 gis'8 r |
 
@@ -265,7 +266,7 @@ cello = \relative c {
   cis8 r r r16 a |
   d8 r fis, r |
   g r a r |
-  \tuplet 3/2 { b(a ) g} a8. a,16 |
-  d2-\fermata \bar "|."
+  \tuplet 3/2 { b( a) g } a8. a,16 |
+  d2\fermata \bar "|."
 }
 

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/cello.ly
@@ -2,6 +2,7 @@
 \include "header.ly"
 
 cello = \relative c {
+  \tempo "Allegro."
   \clef bass
   \key d \major
   \time 2/4

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute-score.ly
@@ -1,4 +1,4 @@
-\version "2.4.0"
+\version "2.18.0"
 \include "flute.ly"
 
 \score 

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute-score.ly
@@ -1,6 +1,9 @@
 \version "2.18.0"
-
 \include "flute.ly"
+
+\header {
+  instrument = "Flauto traverso"
+}
 
 \score {
   \flute

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute-score.ly
@@ -1,14 +1,14 @@
 \version "2.18.0"
 \include "flute.ly"
 
-\score 
+\score
 {
-	\flute
-	\midi {}
- 	\layout 
-	{
-	}
-	\header
-	{
-	}
+  \flute
+  \midi {}
+  \layout
+  {
+  }
+  \header
+  {
+  }
 }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute-score.ly
@@ -1,14 +1,9 @@
 \version "2.18.0"
+
 \include "flute.ly"
 
-\score
-{
+\score {
   \flute
   \midi {}
-  \layout
-  {
-  }
-  \header
-  {
-  }
+  \layout {}
 }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute.ly
@@ -17,13 +17,13 @@ flute = \relative c'' {
     \omit TupletNumber
 
     %--Bar 5-- %
-    a, r fis r |
-    g r a r |
+    a,8 r fis r |
+    g8 r a r |
     \onceShowTupletNumber
     \tuplet 3/2 {
-      b d fis fis e fis |
-      d g fis e a g |
-      fis( a) g fis( a) g |
+      b8 d fis fis e fis |
+      d8 g fis e a g |
+      fis8( a) g fis( a) g |
     }
 
     %--Bar 10--%
@@ -31,22 +31,22 @@ flute = \relative c'' {
     fis 8. a,16 e'8. a,16 |
     fis'8 r gis r |
     a2 ~ |
-    a ~ |
+    a2 ~ |
     a8 r gis r |
-    a r b r |
+    a8 r b r |
 
     %--Bar 17--%
     e,8. e16 a8. e16 |
     \onceShowTupletNumber
     \tuplet 3/2 {
       fis8 e d cis d e |
-      a,( cis) b a( cis) b |
+      a,8( cis) b a( cis) b |
     }
     a2 ~ |
     \tuplet 3/2 { a8 cis b a( cis) b } |
     a2 ~ |
-    a ~ |
-    a |
+    a2 ~ |
+    a2 |
 
     %--Bar 25--%
     \onceShowTupletNumber
@@ -54,7 +54,7 @@ flute = \relative c'' {
     \tuplet 3/2 { cis8 fis e } d4 ~ |
     d8. b'16 cis,8. fis16 |
     \tuplet 3/2 { e8 d cis b cis d } |
-    \tuplet 3/2 { cis b a } d4 ~ |
+    \tuplet 3/2 { cis8 b a } d4 ~ |
     \tuplet 3/2 { d8 cis b } a8. g16 |
     \tuplet 3/2 { fis8 e d } a' r |
     R2 |
@@ -62,29 +62,29 @@ flute = \relative c'' {
     %--Bar 33--%
     r8 r16 a' d8. a16 |
     \tuplet 3/2 { b8 a g fis g a } |
-    d, r cis r |
-    d r e r |
-    \tuplet 3/2 { d fis a a g a } |
-    \tuplet 3/2 { fis b a gis cis b } |
+    d,8 r cis r |
+    d8 r e r |
+    \tuplet 3/2 { d8 fis a a g a } |
+    \tuplet 3/2 { fis8 b a gis cis b } |
     a4 ~ \tuplet 3/2 { a8 b cis } |
-    \tuplet 3/2 { d cis b a b g } |
+    \tuplet 3/2 { d8 cis b a b g } |
 
     %--Bar 41--%
-    fis r g r |
-    a r c, r |
-    b r cis! r |
-    d r \tuplet 3/2 { a( cis e) } |
-    \tuplet 3/2 { a,( d fis) cis( e g) } |
-    a r b r |
+    fis8 r g r |
+    a8 r c, r |
+    b8 r cis! r |
+    d8 r \tuplet 3/2 { a( cis e) } |
+    \tuplet 3/2 { a,8( d fis) cis( e g) } |
+    a8 r b r |
 
     %--Bar 47--%
-    a r g r |
-    g r \tuplet 3/2 { fis g a } |
+    a8 r g r |
+    g8 r \tuplet 3/2 { fis g a } |
     d,4 ~ \onceShowTupletNumber \tuplet 3/2 { d8 e cis } |
     d8.\noBeam a'16 d8. a16 | % check beaming []
     \tuplet 3/2 {
       b8 a g fis g a |
-      d, fis e d fis e |
+      d,8 fis e d fis e |
     }
     d2 ~ |
 
@@ -92,8 +92,8 @@ flute = \relative c'' {
     %--Bar 54--%
     \tuplet 3/2 { d8 \noBeam a' g fis a g } |
     fis2 |
-    e ~ |
-    e ~ |
+    e2 ~ |
+    e2 ~ |
     \undo \omit TupletNumber
     e4 ~ \tuplet 3/2 { e8 fis e } |
     d4 ~ \tuplet 3/2 { d8 e d } |
@@ -105,7 +105,7 @@ flute = \relative c'' {
     \omit TupletNumber
     d,8. e16 cis8. d16 |
     d4 c |
-    b a |
+    b4 a |
     \tuplet 3/2 { g8 a b a b \once \set suggestAccidentals = ##t c } |
     fis,4 d' ~ |
 
@@ -115,8 +115,8 @@ flute = \relative c'' {
     \tuplet 3/2 { d8 \noBeam b cis d b cis } |
     d4 ~ d8. e16 |
     cis2 |
-    d |
-    e |
+    d2 |
+    e2 |
     fis8. \noBeam a16 d8. a16 |
 
     %--Bar 76-%
@@ -137,53 +137,53 @@ flute = \relative c'' {
       %--Bar 85-%
       \tuplet 3/2 {
         e8 fis g fis g e |
-        d b cis d fis e |
-        fis e d cis d b |
-        ais cis fis e d cis |
+        d8 b cis d fis e |
+        fis8 e d cis d b |
+        ais8 cis fis e d cis |
         \onceShowTupletNumber
-        b(^\piano d fis) fis(-\cantabileB e fis) |
-        b,( d fis) fis( e fis) |
-        b,( dis e) e( dis e) |
-        ais,( cis e) e( d! e) |
+        b8(^\piano d fis) fis(-\cantabileB e fis) |
+        b,8( d fis) fis( e fis) |
+        b,8( dis e) e( dis e) |
+        ais,8( cis e) e( d! e) |
       }
 
       %--Bar 93-%
       \tuplet 3/2 {
-        b( d fis) fis( e fis) |
-        cis( e g) g( fis g) |
-        ais,( fis) e' d( e) cis |
+        b8( d fis) fis( e fis) |
+        cis8( e g) g( fis g) |
+        ais,8( fis) e' d( e) cis |
       }
-      b r b r |
-      cis r \tuplet 3/2 { b( a) b } |
+      b8 r b r |
+      cis8 r \tuplet 3/2 { b( a) b } |
       \tuplet 3/2 {
-        cis( b) a gis( fis) eis |
-        fis( cis' fis) fis( e fis) | %99
-        a,( cis fis) fis( eis fis) | % 100
+        cis8( b) a gis( fis) eis |
+        fis8( cis' fis) fis( e fis) | %99
+        a,8( cis fis) fis( eis fis) | % 100
       }
 
       %101
       \tuplet 3/2 {
-        b,( cis d) b( cis a) |
-        gis( b eis) eis( dis eis) |
-        a,( cis fis) fis( eis fis) |
-        d!( b gis) eis( gis fis) |
-        eis( gis) fis eis( fis) gis |
+        b,8( cis d) b( cis a) |
+        gis8( b eis) eis( dis eis) |
+        a,8( cis fis) fis( eis fis) |
+        d!8( b gis) eis( gis fis) |
+        eis8( gis) fis eis( fis) gis |
       }
-      a r r4 |
+      a8 r r4 |
       \tuplet 3/2 { r8 a-\forte b cis e d } |
-      e r r4 |
+      e8 r r4 |
       \tuplet 3/2 { r8 gis, a b d cis | }
 
       %110
       d2-\trill |
-      cis-\trill |
-      b ~ |
+      cis2-\trill |
+      b2 ~ |
       \tuplet 3/2 { b8 \noBeam gis a b( gis) a }
       b2 |
       a4 a' ~ |
-      a gis ~ |
-      gis cis ~ |
-      cis b8. a16 |
+      a4 gis ~ |
+      gis4 cis ~ |
+      cis4 b8. a16 |
 
       %119
       gis2 ~ |
@@ -193,16 +193,16 @@ flute = \relative c'' {
       ais4 r |
       r8 r16 fis' cis'8. gis16 |
       \tuplet 3/2 { a8( gis) fis eis( fis) gis } |
-      cis,4 fis4 ~ |
+      cis,4 fis ~ |
       %127
       fis8. gis16 eis8. fis16 |
       fis2 ~ |
-      fis |
+      fis2 |
       r8 r16 fis b8. fis16 |
       \tuplet 3/2 {
         g!8( fis) e dis( e) fis |
-        b,( e) g b( a) b |
-        e,( d) a
+        b,8( e) g b( a) b |
+        e,8( d) a
       } d4 ~ |
       \tuplet 3/2 { d8 cis e } a8. e16 |
 
@@ -214,38 +214,38 @@ flute = \relative c'' {
       fis8. \tuplet 3/2 16 { e32 d cis } \tuplet 3/2 { b8 d gis } |
       gis8. \tuplet 3/2 16 { fis32 e d } \tuplet 3/2 { cis8 e a } |
       a8. \tuplet 3/2 16 { gis32 fis e } \tuplet 3/2 { d8 fis b } |
-      \tuplet 3/2 { e, fis gis } a4 ~ |
+      \tuplet 3/2 { e,8 fis gis } a4 ~ |
 
       %143
       a2 ~ |
-      a ~ |
+      a2 ~ |
       \tuplet 3/2 {
         a8 gis fis b cis a |
-        gis( fis e)
+        gis8( fis e)
       } a8. d,16 |
       cis8 r b-\trill r |
       \tuplet 3/2 {
-        a(-\piano cis e) e( d e) |
-        a,( cis e) e( d e) |
-        a,( cis d) d( cis d) |
+        a8(-\piano cis e) e( d e) |
+        a,8( cis e) e( d e) |
+        a,8( cis d) d( cis d) |
 
         %151
-        gis,( b d) d( cis d) |
-        a( cis e) e( d e) |
-        b( d fis) fis( e fis) |
-        gis,( e) d' cis( d) b |
+        gis,8( b d) d( cis d) |
+        a8( cis e) e( d e) |
+        b8( d fis) fis( e fis) |
+        gis,8( e) d' cis( d) b |
       }
-      a r r4 |
+      a8 r r4 |
       R2 |
-      r8 r16 b16-\pianoB e8. b16 |
+      r8 r16 b-\pianoB e8. b16 |
       \tuplet 3/2 { c8 b a g a b } |
 
       %159
-      e, r r4 |
+      e,8 r r4 |
       R2 |
-      r8 r16 fis16 b8. fis16 |
+      r8 r16 fis b8. fis16 |
       \tuplet 3/2 { g8( fis) e d( e) fis | }
-      b r r4 |
+      b8 r r4 |
       R2*13 |
 
 
@@ -263,7 +263,7 @@ flute = \relative c'' {
       \tuplet 3/2 { e'8(-\piano cis) d e( cis) d } |
       e2 ~ |
       \tuplet 3/2 { e8 \noBeam g fis e( g) fis } |
-      e r r4 |
+      e8 r r4 |
 
       %193
       r8 r16 fis b4 ~ |
@@ -295,22 +295,22 @@ flute = \relative c'' {
       \tuplet 3/2 { e8 d! cis d e cis } |
       b4 ~ \tuplet 3/2 { b8 cis b } |
       \tuplet 3/2 {
-        ais( gis) ais b cis d |
-        e( fis e) d( cis b) |
+        ais8( gis) ais b cis d |
+        e8( fis e) d( cis b) |
 
         %219
         %on triplets?
-        ais( gis ais) b( cis d) |
+        ais8( gis ais) b( cis d) |
       }
       cis4 ~ \tuplet 3/2 { cis8( d e ) } |
-      \tuplet 3/2 { d( e fis) } e4 ~ |
+      \tuplet 3/2 { d8( e fis) } e4 ~ |
       e8. d16 cis4 ~ |
       \tuplet 3/2 { cis8 ais b } fis'8. cis16 |
       \tuplet 3/2 { d8( cis)b ais(b) cis } |
       fis,4 b ~ |
-      b cis ~ |
-      cis d ~ |
-      d e ~ |
+      b4 cis ~ |
+      cis4 d ~ |
+      d4 e ~ |
       e8. g16 fis8. e16 |
       fis8. e16 fis8. g16 |
       d8 r cis-\trill r |

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute.ly
@@ -6,412 +6,318 @@ flute = \relative c'' {
   \key d \major
   \time 2/4
 
-  \commonSettings
-
   % --Bar 1-- %
-  R2 |
-  R2 |
-  r8 r16 d a'8. e16 |
-  \tuplet 3/2 { fis8 e d } \tuplet 3/2 { cis d e } |
+  \repeat unfold 2 {
+    R2 |
+    R2 |
+    r8 r16 d a'8. e16 |
+    \onceShowTupletNumber
+    \tuplet 3/2 { fis8 e d cis d e } |
+    \omit TupletNumber
 
-  %--Bar 5-- %
-  a, r fis r |
-  g r a r |
-  \tuplet 3/2 {
-    b d fis \tripletsHide fis e fis |
-    d g fis e a g |
-    fis( a) g fis( a) g |
+    %--Bar 5-- %
+    a, r fis r |
+    g r a r |
+    \onceShowTupletNumber
+    \tuplet 3/2 {
+      b d fis fis e fis |
+      d g fis e a g |
+      fis( a) g fis( a) g |
+    }
+
+    %--Bar 10--%
+    fis8. b16 a8. g16 |
+    fis 8. a,16 e'8. a,16 |
+    fis'8 r gis r |
+    a2 ~ |
+    a ~ |
+    a8 r gis r |
+    a r b r |
+
+    %--Bar 17--%
+    e,8. e16 a8. e16 |
+    \onceShowTupletNumber
+    \tuplet 3/2 {
+      fis8 e d cis d e |
+      a,( cis) b a( cis) b |
+    }
+    a2 ~ |
+    \tuplet 3/2 { a8 cis b a( cis) b } |
+    a2 ~ |
+    a ~ |
+    a |
+
+    %--Bar 25--%
+    \onceShowTupletNumber
+    \tuplet 3/2 { gis8 a b } cis4 ~ |
+    \tuplet 3/2 { cis8 fis e } d4 ~ |
+    d8. b'16 cis,8. fis16 |
+    \tuplet 3/2 { e8 d cis b cis d } |
+    \tuplet 3/2 { cis b a } d4 ~ |
+    \tuplet 3/2 { d8 cis b } a8. g16 |
+    \tuplet 3/2 { fis8 e d } a' r |
+    R2 |
+
+    %--Bar 33--%
+    r8 r16 a' d8. a16 |
+    \tuplet 3/2 { b8 a g fis g a } |
+    d, r cis r |
+    d r e r |
+    \tuplet 3/2 { d fis a a g a } |
+    \tuplet 3/2 { fis b a gis cis b } |
+    a4 ~ \tuplet 3/2 { a8 b cis } |
+    \tuplet 3/2 { d cis b a b g } |
+
+    %--Bar 41--%
+    fis r g r |
+    a r c, r |
+    b r cis! r |
+    d r \tuplet 3/2 { a( cis e) } |
+    \tuplet 3/2 { a,( d fis) cis( e g) } |
+    a r b r |
+
+    %--Bar 47--%
+    a r g r |
+    g r \tuplet 3/2 { fis g a } |
+    d,4 ~ \onceShowTupletNumber \tuplet 3/2 { d8 e cis } |
+    d8.\noBeam a'16 d8. a16 | % check beaming []
+    \tuplet 3/2 {
+      b8 a g fis g a |
+      d, fis e d fis e |
+    }
+    d2 ~ |
+
+
+    %--Bar 54--%
+    \tuplet 3/2 { d8 \noBeam a' g fis a g } |
+    fis2 |
+    e ~ |
+    e ~ |
+    \undo \omit TupletNumber
+    e4 ~ \tuplet 3/2 { e8 fis e } |
+    d4 ~ \tuplet 3/2 { d8 e d } |
+    cis4 \tuplet 3/2 { c8 d c } |
+
+    %--Bar 61--%
+    b4 g' ~ |
+    \tuplet 3/2 { g8 cis, e fis g a } |
+    \omit TupletNumber
+    d,8. e16 cis8. d16 |
+    d4 c |
+    b a |
+    \tuplet 3/2 { g8 a b a b \once \set suggestAccidentals = ##t c } |
+    fis,4 d' ~ |
+
+    %--Bar 68--%
+    \tuplet 3/2 { d8 \noBeam fis e d fis e } |
+    d2 ~ |
+    \tuplet 3/2 { d8 \noBeam b cis d b cis } |
+    d4 ~ d8. e16 |
+    cis2 |
+    d |
+    e |
+    fis8. \noBeam a16 d8. a16 |
+
+    %--Bar 76-%
+    \onceShowTupletNumber
+    \tuplet 3/2 { b8( a) g fis( g) a } |
+    d,8. e16 cis8. d16 |
   }
+  \alternative {
+    {
+      d2 |
+      r8 r16 fis -\cantabileB b8. fis16 | % \markup { }
+      g2 ~ |
+      g8. g16 \tuplet 3/2 { a8( fis) g } |
+      fis2 ~ |
+      fis8. fis16 b8. g16 |
+      e2 ~ |
 
-  %--Bar 10--%
-  fis8. b16 a8. g16 |
-  fis 8. a,16 e'8. a,16 |
-  fis'8 r gis r |
-  a2 ~ |
-  a ~ |
-  a8 r gis r |
-  a r b r |
+      %--Bar 85-%
+      \tuplet 3/2 {
+        e8 fis g fis g e |
+        d b cis d fis e |
+        fis e d cis d b |
+        ais cis fis e d cis |
+        \onceShowTupletNumber
+        b(^\piano d fis) fis(-\cantabileB e fis) |
+        b,( d fis) fis( e fis) |
+        b,( dis e) e( dis e) |
+        ais,( cis e) e( d! e) |
+      }
 
-  %--Bar 17--%
-  e,8. e16 a8. e16 | \tripletsShowOnce
-  \tuplet 3/2 {
-    fis8 e d cis d e |
-    a,( cis) b a( cis) b |
+      %--Bar 93-%
+      \tuplet 3/2 {
+        b( d fis) fis( e fis) |
+        cis( e g) g( fis g) |
+        ais,( fis) e' d( e) cis |
+      }
+      b r b r |
+      cis r \tuplet 3/2 { b( a) b } |
+      \tuplet 3/2 {
+        cis( b) a gis( fis) eis |
+        fis( cis' fis) fis( e fis) | %99
+        a,( cis fis) fis( eis fis) | % 100
+      }
+
+      %101
+      \tuplet 3/2 {
+        b,( cis d) b( cis a) |
+        gis( b eis) eis( dis eis) |
+        a,( cis fis) fis( eis fis) |
+        d!( b gis) eis( gis fis) |
+        eis( gis) fis eis( fis) gis |
+      }
+      a r r4 |
+      \tuplet 3/2 { r8 a-\forte b cis e d } |
+      e r r4 |
+      \tuplet 3/2 { r8 gis, a b d cis | }
+
+      %110
+      d2-\trill |
+      cis-\trill |
+      b ~ |
+      \tuplet 3/2 { b8 \noBeam gis a b( gis) a }
+      b2 |
+      a4 a' ~ |
+      a gis ~ |
+      gis cis ~ |
+      cis b8. a16 |
+
+      %119
+      gis2 ~ |
+      gis4 fis8. e16 |
+      d2 ~ |
+      d4 cis 8. b16 |
+      ais4 r |
+      r8 r16 fis' cis'8. gis16 |
+      \tuplet 3/2 { a8( gis) fis eis( fis) gis } |
+      cis,4 fis4 ~ |
+      %127
+      fis8. gis16 eis8. fis16 |
+      fis2 ~ |
+      fis |
+      r8 r16 fis b8. fis16 |
+      \tuplet 3/2 {
+        g!8( fis) e dis( e) fis |
+        b,( e) g b( a) b |
+        e,( d) a
+      } d4 ~ |
+      \tuplet 3/2 { d8 cis e } a8. e16 |
+
+      %135
+      \tuplet 3/2 { fis8 e d cis d e } |
+      a,8. gis16 \tuplet 3/2 { fis8 a d } |
+      d8. \tuplet 3/2 16 { cis32 b a } \tuplet 3/2 { gis8 b e } |
+      e8. \tuplet 3/2 16 { d32 cis b } \tuplet 3/2 { a8 cis fis } |
+      fis8. \tuplet 3/2 16 { e32 d cis } \tuplet 3/2 { b8 d gis } |
+      gis8. \tuplet 3/2 16 { fis32 e d } \tuplet 3/2 { cis8 e a } |
+      a8. \tuplet 3/2 16 { gis32 fis e } \tuplet 3/2 { d8 fis b } |
+      \tuplet 3/2 { e, fis gis } a4 ~ |
+
+      %143
+      a2 ~ |
+      a ~ |
+      \tuplet 3/2 {
+        a8 gis fis b cis a |
+        gis( fis e)
+      } a8. d,16 |
+      cis8 r b-\trill r |
+      \tuplet 3/2 {
+        a(-\piano cis e) e( d e) |
+        a,( cis e) e( d e) |
+        a,( cis d) d( cis d) |
+
+        %151
+        gis,( b d) d( cis d) |
+        a( cis e) e( d e) |
+        b( d fis) fis( e fis) |
+        gis,( e) d' cis( d) b |
+      }
+      a r r4 |
+      R2 |
+      r8 r16 b16-\pianoB e8. b16 |
+      \tuplet 3/2 { c8 b a g a b } |
+
+      %159
+      e, r r4 |
+      R2 |
+      r8 r16 fis16 b8. fis16 |
+      \tuplet 3/2 { g8( fis) e d( e) fis | }
+      b r r4 |
+      R2*13 |
+
+
+      %177
+      r8 r16 cis fis8. cis16 |
+      dis4 r |
+      r8 r16 b e8. b16 |
+      cis4 r |
+      r8 r16 a d8. a16 |
+      \tuplet 3/2 { b8( a) g fis( g) a } |
+      d,4 r |
+      R2 * 5 |
+
+      %189
+      \tuplet 3/2 { e'8(-\piano cis) d e( cis) d } |
+      e2 ~ |
+      \tuplet 3/2 { e8 \noBeam g fis e( g) fis } |
+      e r r4 |
+
+      %193
+      r8 r16 fis b4 ~ |
+      b8. e,16 a4 ~ |
+      a8. b16 gis4 ~ |
+      gis8. a16 fis8. gis16 |
+      eis8. fis16 fis8.-\trill eis32 fis |
+      gis4 ~ gis8. cis,16 |
+      a'2 ~ |
+      \tuplet 3/2 { a8 gis fis gis a b } |
+      cis2 ~ |
+      %202
+
+      \tuplet 3/2 { cis8 b a b cis d } |
+      eis,4 e ~ |
+      \tuplet 3/2 { e8 d cis d e fis } |
+      cis4 c ~ |
+      \tuplet 3/2 { c8 b a g fis e } |
+      fis2 ~ |
+      \tuplet 3/2 { fis8 e fis g a b } |
+      c2 ~ |
+      \tuplet 3/2 { c8 b c d e fis } |
+
+      %211
+      g4 ~ \tuplet 3/2 { g8 a g } |
+      fis4 g ~ |
+      \tuplet 3/2 { g8 fis e fis g e } |
+      dis4 e ~ |
+      \tuplet 3/2 { e8 d! cis d e cis } |
+      b4 ~ \tuplet 3/2 { b8 cis b } |
+      \tuplet 3/2 {
+        ais( gis) ais b cis d |
+        e( fis e) d( cis b) |
+
+        %219
+        %on triplets?
+        ais( gis ais) b( cis d) |
+      }
+      cis4 ~ \tuplet 3/2 { cis8( d e ) } |
+      \tuplet 3/2 { d( e fis) } e4 ~ |
+      e8. d16 cis4 ~ |
+      \tuplet 3/2 { cis8 ais b } fis'8. cis16 |
+      \tuplet 3/2 { d8( cis)b ais(b) cis } |
+      fis,4 b ~ |
+      b cis ~ |
+      cis d ~ |
+      d e ~ |
+      e8. g16 fis8. e16 |
+      fis8. e16 fis8. g16 |
+      d8 r cis-\trill r |
+      b4 r |
+      %233
+    }
+    {
+      d2\fermata \bar "|." |
+    }
   }
-  a2 ~ |
-  \tuplet 3/2 { a8 cis b a( cis) b } |
-  a2 ~ |
-  a ~ |
-  a |
-
-  %--Bar 25--%
-  \tripletsShowOnce \tuplet 3/2 { gis8 a b } cis4 ~ |
-  \tuplet 3/2 { cis8 fis e } d4 ~ |
-  d8. b'16 cis,8. fis16 |
-  \tuplet 3/2 { e8 d cis b cis d } |
-  \tuplet 3/2 { cis b a } d4 ~ |
-  \tuplet 3/2 { d8 cis b } a8. g16 |
-  \tripletsShowOnce \tuplet 3/2 { fis8 e d } a' r |
-  R2 |
-
-  %--Bar 33--%
-  r8 r16 a' d8. a16 |
-  \tuplet 3/2 { b8 a g fis g a } |
-  d, r cis r |
-  d r e r |
-  \tuplet 3/2 { d fis a a g a } |
-  \tuplet 3/2 { fis b a gis cis b } |
-  a4 ~ \tuplet 3/2 { a8 b cis } |
-  \tuplet 3/2 { d cis b a b g } |
-
-  %--Bar 41--%
-  fis r g r |
-  a r c, r |
-  b r cis! r |
-  d r \tuplet 3/2 { a( cis e) } |
-  \tuplet 3/2 { a,( d fis) cis( e g) } |
-  a r b r |
-
-  %--Bar 47--%
-  a r g r |
-  g r \tuplet 3/2 { fis g a } |
-  d,4 ~ \tripletsShowOnce \tuplet 3/2 { d8 e cis } |
-  \autoBeamOff d8. \autoBeamOn a'16 d8. a16 | % check beaming []
-  \tuplet 3/2 {
-    b8 a g fis g a |
-    d, fis e d fis e |
-  }
-  d2 ~ |
-
-
-  %--Bar 54--%
-  \tuplet 3/2 { d8 \noBeam a' g fis a g } |
-  fis2 |
-  e ~ |
-  e ~ |
-  e4 ~ \tripletsShow \tuplet 3/2 { e8 fis e } |
-  d4 ~ \tuplet 3/2 { d8 e d } |
-  cis4 \tuplet 3/2 { c8 d c } |
-
-  %--Bar 61--%
-  b4 g' ~ |
-  \tuplet 3/2 { g8 cis, e fis g a } | \tripletsHide
-  d,8. e16 cis8. d16 |
-  d4 c |
-  b a |
-  \tuplet 3/2 { g8 a b a b cis^\fbna} |
-  fis,4 d' ~ |
-
-  %--Bar 68--%
-  \tuplet 3/2 { d8 \noBeam fis e d fis e } |
-  d2 ~ |
-  \tuplet 3/2 { d8 \noBeam b cis d b cis } |
-  d4 ~ d8. e16 |
-  cis2 |
-  d |
-  e |
-  fis8. \noBeam a16 d8. a16 |
-
-  %--Bar 76-%
-  \tripletsShowOnce \tuplet 3/2 { b8( a) g fis(g) a } |
-  d,8. e16 cis8. d16 |
-  d2 |
-  r8 r16 fis -\cantabileB b8. fis16 | % \markup { }
-  g2 ~ |
-  g8. g16 \tuplet 3/2 { a8( fis) g } |
-  fis2 ~ |
-  fis8. fis16 b8. g16 |
-  e2 ~ |
-
-  %--Bar 85-%
-  \tuplet 3/2 {
-    e8 fis g fis g e |
-    d b cis d fis e |
-    fis e d cis d b |
-    ais cis fis e d cis | \tripletsShowOnce
-    b(^\piano d fis) fis(-\cantabileB e fis) |
-    b,( d fis) fis( e fis) |
-    b,( dis e) e( dis e) |
-    ais,( cis e) e( d! e) |
-  }
-
-  %--Bar 93-%
-  \tuplet 3/2 {
-    b( d fis) fis( e fis) |
-    cis( e g) g( fis g) |
-    ais,( fis) e' d( e) cis |
-  }
-  b r b r |
-  cis r \tuplet 3/2 { b( a) b } |
-  \tuplet 3/2 {
-    cis( b) a gis( fis) eis |
-    fis( cis' fis) fis( e fis) | %99
-    a,( cis fis) fis( eis fis) | % 100
-  }
-
-  %101
-  \tuplet 3/2 {
-    b,( cis d) b( cis a) |
-    gis( b eis) eis( dis eis) |
-    a,( cis fis) fis( eis fis) |
-    d!( b gis) eis( gis fis) |
-    eis( gis) fis eis( fis) gis |
-  }
-  a r r4 |
-  \tuplet 3/2 { r8 a-\forte b cis e d } |
-  e r r4 |
-  \tuplet 3/2 { r8 gis, a b d cis | }
-
-  %110
-  d2-\trill |
-  cis-\trill |
-  b ~ |
-  \tuplet 3/2 { b8 \noBeam gis a b( gis) a }
-  b2 |
-  a4 a' ~ |
-  a gis ~ |
-  gis cis ~ |
-  cis b8. a16 |
-
-  %119
-  gis2 ~ |
-  gis4 fis8. e16 |
-  d2 ~ |
-  d4 cis 8. b16 |
-  ais4 r |
-  r8 r16 fis' cis'8. gis16 |
-  \tuplet 3/2 { a8( gis) fis eis( fis) gis } |
-  cis,4 fis4 ~ |
-  %127
-  fis8. gis16 eis8. fis16 |
-  fis2 ~ |
-  fis |
-  r8 r16 fis b8. fis16 |
-  \tuplet 3/2 {
-    g!8( fis) e dis( e) fis |
-    b,( e) g b( a) b |
-    e,( d) a
-  } d4 ~ |
-  \tuplet 3/2 { d8 cis e } a8. e16 |
-
-  %135
-  \tuplet 3/2 { fis8 e d cis d e } |
-  a,8. gis16 \tuplet 3/2 { fis8 a d } |
-  d8. \tuplet 3/2 { cis32 b a gis8 b e } |
-  e8. \tuplet 3/2 { d32 cis b a8 cis fis } |
-  fis8. \tuplet 3/2 { e32 d cis b8 d gis } |
-  gis8. \tuplet 3/2 { fis32 e d cis8 e a } |
-  a8. \tuplet 3/2 { gis32 fis e d8 fis b } |
-  \tuplet 3/2 { e, fis gis } a4 ~ |
-
-  %143
-  a2 ~ |
-  a ~ |
-  \tuplet 3/2 {
-    a8 gis fis b cis a |
-    gis( fis e)
-  } a8. d,16 |
-  cis8 r b-\trill r |
-  \tuplet 3/2 {
-    a(-\piano cis e) e( d e) |
-    a,( cis e) e( d e) |
-    a,( cis d) d( cis d) |
-
-    %151
-    gis,( b d) d( cis d) |
-    a( cis e) e( d e) |
-    b( d fis) fis( e fis) |
-    gis,( e) d' cis( d) b |
-  }
-  a r r4 |
-  R2 |
-  r8 r16 b16-\pianoB e8. b16 |
-  \tuplet 3/2 { c8 b a g a b } |
-
-  %159
-  e, r r4 |
-  R2 |
-  r8 r16 fis16 b8. fis16 |
-  \tuplet 3/2 { g8( fis) e d( e) fis | }
-  b r r4 |
-  R2*13 |
-
-
-  %177
-  r8 r16 cis fis8. cis16 |
-  dis4 r |
-  r8 r16 b e8. b16 |
-  cis4 r |
-  r8 r16 a d8. a16 |
-  \tuplet 3/2 { b8( a) g fis( g) a } |
-  d,4 r |
-  R2 * 5 |
-
-  %189
-  \tuplet 3/2 { e'8(-\piano cis) d e( cis) d } |
-  e2 ~ |
-  \tuplet 3/2 { e8 \noBeam g fis e( g) fis } |
-  e r r4 |
-
-  %193
-  r8 r16 fis b4 ~ |
-  b8. e,16 a4 ~ |
-  a8. b16 gis4 ~ |
-  gis8. a16 fis8. gis16 |
-  eis8. fis16 fis8.-\trill eis32 fis |
-  gis4 ~ gis8. cis,16 |
-  a'2 ~ |
-  \tuplet 3/2 { a8 gis fis gis a b } |
-  cis2 ~ |
-  %202
-
-  \tuplet 3/2 { cis8 b a b cis d } |
-  eis,4 e ~ |
-  \tuplet 3/2 { e8 d cis d e fis } |
-  cis4 c ~ |
-  \tuplet 3/2 { c8 b a g fis e } |
-  fis2 ~ |
-  \tuplet 3/2 { fis8 e fis g a b } |
-  c2 ~ |
-  \tuplet 3/2 { c8 b c d e fis } |
-
-  %211
-  g4 ~ \tuplet 3/2 { g8 a g } |
-  fis4 g ~ |
-  \tuplet 3/2 { g8 fis e fis g e } |
-  dis4 e ~ |
-  \tuplet 3/2 { e8 d! cis d e cis } |
-  b4 ~ \tuplet 3/2 { b8 cis b } |
-  \tuplet 3/2 {
-    ais( gis) ais b cis d |
-    e( fis e) d( cis b) |
-
-    %219
-    %on triplets?
-    ais( gis ais) b( cis d) |
-  }
-  cis4 ~ \tuplet 3/2 { cis8( d e ) } |
-  \tuplet 3/2 { d( e fis) } e4 ~ |
-  e8. d16 cis4 ~ |
-  \tuplet 3/2 { cis8 ais b } fis'8. cis16 |
-  \tuplet 3/2 { d8( cis)b ais(b) cis } |
-  fis,4 b ~ |
-  b cis ~ |
-  cis d ~ |
-  d e ~ |
-  e8. g16 fis8. e16 |
-  fis8. e16 fis8. g16 |
-  d8 r cis-\trill r |
-  b4 r |
-
-  %233
-  R2 |
-  R2 |
-  r8 r16 d a'8. e16 | \tripletsShowOnce
-  \tuplet 3/2 { fis8 e d } \tuplet 3/2 { cis d e } |
-
-  %--Bar 5-- %
-  a, r fis r |
-  g r a r |
-  \tuplet 3/2 {
-    \tripletsShowOnce
-    b d fis fis e fis |
-    d g fis e a g |
-    fis( a) g fis( a) g |
-  }
-
-  %--Bar 10--%
-  fis8. b16 a8. g16 |
-  fis 8. a,16 e'8. a,16 |
-  fis'8 r gis r |
-  a2 ~ |
-  a ~ |
-  a8 r gis r |
-  a r b r |
-
-  %--Bar 17--%
-  e,8. e16 a8. e16 |
-  \tripletsShowOnce \tuplet 3/2 {
-    fis8 e d cis d e |
-    a,( cis) b a( cis) b |
-  }
-  a2 ~ |
-  \tuplet 3/2 { a8 cis b a( cis) b } |
-  a2 ~ |
-  a ~ |
-  a |
-
-  %--Bar 25--%
-  \tripletsShowOnce \tuplet 3/2 { gis8 a b } cis4 ~ |
-  \tuplet 3/2 { cis8 fis e } d4 ~ |
-  d8. b'16 cis,8. fis16 |
-  \tuplet 3/2 { e8 d cis b cis d } |
-  \tuplet 3/2 { cis b a } d4 ~ |
-  \tuplet 3/2 { d8 cis b } a8. g16 |
-  \tuplet 3/2 { fis8 e d } a' r |
-  R2 |
-
-  %--Bar 265 --%
-  r8 r16 a' d8. a16 |
-  \tuplet 3/2 { b8 a g fis g a } |
-  d, r cis r |
-  d r e r |
-  \tuplet 3/2 { d fis a a g a } |
-  \tuplet 3/2 { fis b a gis cis b } |
-  a4 ~ \tuplet 3/2 { a8 b cis } |
-  \tuplet 3/2 { d cis b a b g } |
-
-  %--Bar 273--%
-  fis r g r |
-  a r c, r |
-  b r cis! r |
-  d r \tuplet 3/2 { a( cis e) } |
-  \tuplet 3/2 { a,( d fis) cis( e g) } |
-  a r b r |
-
-  %--Bar 279--%
-  a r g r |
-  g r \tuplet 3/2 { fis g a } |
-  d,4 ~ \tripletsShowOnce \tuplet 3/2 { d8 \noBeam e cis } |
-  \autoBeamOff d8. \autoBeamOn a'16 d8. a16 | % check beaming []
-  \tuplet 3/2 {
-    b8 a g fis g a |
-    d, fis e d fis e |
-  }
-  d2 ~ |
-
-
-  %--Bar 286--%
-  \tuplet 3/2 { d8 \noBeam a' g fis a g } |
-  fis2 |
-  e ~ |
-  e ~ |
-  e4 ~ \tripletsShow \tuplet 3/2 { e8 \noBeam fis e } |
-  d4 ~ \tuplet 3/2 { d8 e d } |
-  cis4 \tuplet 3/2 { c8 d c } |
-
-  %--Bar 293--%
-  b4 g' ~ |
-  \tuplet 3/2 { g8 cis, e fis g a } | \tripletsHide
-  d,8. e16 cis8. d16 |
-  d4 c |
-  b a |
-  \tuplet 3/2 { g8 a b a b cis^\fbna} |
-  fis,4 d' ~ |
-
-  %--Bar 300--%
-  \tuplet 3/2 { d8 \noBeam fis e d fis e } |
-  d2 ~ |
-  \tuplet 3/2 { d8 \noBeam b cis d b cis } |
-  d4 ~ d8. e16 |
-  cis2 |
-  d |
-  e |
-  fis8. \noBeam a16 d8. a16 |
-
-  %--Bar 308-%
-  \tripletsShowOnce \tuplet 3/2 { b8( a) g fis( g) a } |
-  d,8. e16 cis8. d16 |
-  d2\fermata \bar "|." |
-} %end flute notes
-
+}

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute.ly
@@ -1,7 +1,7 @@
 #(ly:set-point-and-click 'line-column )
 
 \include "header.ly"
-\version "2.4.0"
+\version "2.18.0"
 
 flute =  \relative c'' {
  \clef treble
@@ -14,12 +14,12 @@ flute =  \relative c'' {
  R2|
  R2|
  r8 r16 d a'8. e16 |
- \times 2/3 { fis8 e d } \times 2/3 { cis d e } |
+ \tuplet 3/2 { fis8 e d } \tuplet 3/2 { cis d e } |
 
  %--Bar 5-- %
  a, r fis r | 
  g r a r |
- \times 2/3 { 
+ \tuplet 3/2 { 
   b d fis  \tripletsHide fis e fis |
   d g fis   e a g |
   fis( a) g   fis( a) g |
@@ -36,74 +36,74 @@ flute =  \relative c'' {
 
 %--Bar 17--%
 e,8. e16 a8. e16 |  \tripletsShowOnce
- \times 2/3 { fis8 e d   cis d e |
+ \tuplet 3/2 { fis8 e d   cis d e |
   a, ( cis) b   a ( cis) b |  }
 a2 ~|
- \times 2/3 { a8 cis b  a( cis) b } |
+ \tuplet 3/2 { a8 cis b  a( cis) b } |
 a2~ |
 a~ |
 a |
 
 %--Bar 25--%
- \tripletsShowOnce \times 2/3 { gis8 a b } cis4~ |
-\times 2/3 { cis8 fis e } d4~ |
+ \tripletsShowOnce \tuplet 3/2 { gis8 a b } cis4~ |
+\tuplet 3/2 { cis8 fis e } d4~ |
 d8. b'16 cis,8. fis16 |
-\times 2/3 { e8 d cis  b cis d } |
-\times 2/3 { cis b a } d4~|
-\times 2/3 { d8 cis b } a8. g16|
- \tripletsShowOnce \times 2/3 { fis8 e d } a' r|
+\tuplet 3/2 { e8 d cis  b cis d } |
+\tuplet 3/2 { cis b a } d4~|
+\tuplet 3/2 { d8 cis b } a8. g16|
+ \tripletsShowOnce \tuplet 3/2 { fis8 e d } a' r|
 R2|
 
 %--Bar 33--%
 r8 r16 a' d8. a16 |
-\times 2/3 { b8 a g   fis g a } |
+\tuplet 3/2 { b8 a g   fis g a } |
 d, r cis r |
 d r e r |
-\times 2/3 { d fis a   a g a } |
-\times 2/3 { fis b a   gis cis b } |
-a4 ~ \times 2/3 { a8 b cis } |
-\times 2/3 { d cis b   a b g } |
+\tuplet 3/2 { d fis a   a g a } |
+\tuplet 3/2 { fis b a   gis cis b } |
+a4 ~ \tuplet 3/2 { a8 b cis } |
+\tuplet 3/2 { d cis b   a b g } |
 
 %--Bar 41--%
 fis r g r |
 a r c, r |
 b r cis! r |
-d r \times 2/3 { a( cis  e) } |
-\times 2/3 {  a,( d  fis) cis( e  g) } |
+d r \tuplet 3/2 { a( cis  e) } |
+\tuplet 3/2 {  a,( d  fis) cis( e  g) } |
 a r b r |
 
 %--Bar 47--%
 a r g r |
-g r \times 2/3 { fis g a } |
-d,4 ~  \tripletsShowOnce \times 2/3 { d8 e cis } |
+g r \tuplet 3/2 { fis g a } |
+d,4 ~  \tripletsShowOnce \tuplet 3/2 { d8 e cis } |
 \autoBeamOff d8. \autoBeamOn a'16 d8. a16 | % check beaming []
-\times 2/3 { b8 a g  fis g a |
+\tuplet 3/2 { b8 a g  fis g a |
 d, fis e d fis e | }
 d2~ |
 
 
 %--Bar 54--%
-\times 2/3 { d8 \noBeam a' g fis a g } |
+\tuplet 3/2 { d8 \noBeam a' g fis a g } |
 fis2 |
 e ~|
 e ~|
-e4 ~  \tripletsShow \times 2/3 { e8 fis e } |
-d4 ~   \times 2/3 { d8 e d } |
-cis4   \times 2/3 { c8 d c } |
+e4 ~  \tripletsShow \tuplet 3/2 { e8 fis e } |
+d4 ~   \tuplet 3/2 { d8 e d } |
+cis4   \tuplet 3/2 { c8 d c } |
 
 %--Bar 61--%
 b4 g'~|
-\times 2/3 { g8 cis, e fis g a } |  \tripletsHide
+\tuplet 3/2 { g8 cis, e fis g a } |  \tripletsHide
 d,8. e16 cis8. d16 |
 d4 c |
 b a |
-\times 2/3 { g8 a b a b cis^\fbna} | 
+\tuplet 3/2 { g8 a b a b cis^\fbna} | 
 fis,4 d' ~ |
 
 %--Bar 68--%
-\times 2/3 { d8 \noBeam fis e d fis e } |
+\tuplet 3/2 { d8 \noBeam fis e d fis e } |
 d2~ |
-\times 2/3 { d8 \noBeam b cis d b cis } |
+\tuplet 3/2 { d8 \noBeam b cis d b cis } |
 d4~ d8. e16 |
 cis2 |
 d |
@@ -111,18 +111,18 @@ e |
 fis8. \noBeam a16 d8. a16 |
 
 %--Bar 76-%
- \tripletsShowOnce \times 2/3 { b8( a) g fis(g) a } |
+ \tripletsShowOnce \tuplet 3/2 { b8( a) g fis(g) a } |
 d,8. e16 cis8. d16 |
 d2 |
 r8 r16 fis -\cantabileB b8. fis16 | % \markup {  }
 g2 ~ |
-g8. g16 \times 2/3 { a8( fis) g } |
+g8. g16 \tuplet 3/2 { a8( fis) g } |
 fis2~ |
 fis8. fis16 b8. g16|
 e2~ |
 
 %--Bar 85-%
- \times 2/3 { e8 fis g fis g e |
+ \tuplet 3/2 { e8 fis g fis g e |
   d b cis d fis e |
   fis e d cis d b |
   ais cis fis e d cis | \tripletsShowOnce
@@ -133,32 +133,32 @@ e2~ |
  }
 
 %--Bar 93-%
-\times 2/3 { b (d fis) fis( e fis) |
+\tuplet 3/2 { b (d fis) fis( e fis) |
 	cis( e g) g(fis g) |
 	ais,( fis) e' d(e) cis | }
 	b r b r |
-	cis r \times 2/3{ b( a) b }|
-\times 2/3{cis(b) a gis(fis)eis|
+	cis r \tuplet 3/2{ b( a) b }|
+\tuplet 3/2{cis(b) a gis(fis)eis|
 	fis( cis' fis) fis( e fis) | %99
 	a,( cis fis)  fis (eis fis) |% 100
 	}
 
 %101
-\times 2/3 { b,( cis d) b( cis a) |
+\tuplet 3/2 { b,( cis d) b( cis a) |
 gis( b eis)  eis( dis eis) |
 a,( cis fis)  fis( eis fis) |
 d!( b gis )  eis( gis fis) |
 eis ( gis) fis  eis( fis) gis | }
 a r r4 |
-\times 2/3 { r8 a-\forte b cis e d } |
+\tuplet 3/2 { r8 a-\forte b cis e d } |
 e r r4 |
-\times 2/3 { r8 gis, a b d cis | }
+\tuplet 3/2 { r8 gis, a b d cis | }
 
 %110
 d2-\trill |
 cis-\trill |
 b ~ |
-\times 2/3 { b8 \noBeam gis a  b( gis) a }
+\tuplet 3/2 { b8 \noBeam gis a  b( gis) a }
 b2 |
 a4 a' ~ |
 a gis~ |
@@ -172,35 +172,35 @@ d2 ~ |
 d4 cis 8. b16|
 ais4 r |
 r8 r16 fis' cis'8. gis16 |
-\times 2/3 { a8( gis) fis  eis( fis) gis }|
+\tuplet 3/2 { a8( gis) fis  eis( fis) gis }|
 cis,4 fis4~ |
 %127
 fis8. gis16 eis8. fis16 |
 fis2 ~ |
 fis |
 r8 r16 fis b8. fis16 |
-\times 2/3 { g!8( fis) e  dis( e) fis|
+\tuplet 3/2 { g!8( fis) e  dis( e) fis|
 b,( e) g  b( a) b |
 e,(d) a } d4 ~ |
-\times 2/3 { d8 cis e } a8. e16 |
+\tuplet 3/2 { d8 cis e } a8. e16 |
 
 %135
-\times 2/3 { fis8 e d cis d e } |
-a,8. gis16 \times 2/3 { fis8 a d } |
-d8. \times 2/3 { cis32 b a gis8 b e } |
-e8. \times 2/3 { d32 cis b a8 cis fis } |
-fis8. \times 2/3 { e32 d cis b8 d gis } |
-gis8. \times 2/3 { fis32 e d cis8 e a } |
-a8. \times 2/3 { gis32 fis e d8 fis b } |
-\times 2/3 { e, fis gis } a4~ |
+\tuplet 3/2 { fis8 e d cis d e } |
+a,8. gis16 \tuplet 3/2 { fis8 a d } |
+d8. \tuplet 3/2 { cis32 b a gis8 b e } |
+e8. \tuplet 3/2 { d32 cis b a8 cis fis } |
+fis8. \tuplet 3/2 { e32 d cis b8 d gis } |
+gis8. \tuplet 3/2 { fis32 e d cis8 e a } |
+a8. \tuplet 3/2 { gis32 fis e d8 fis b } |
+\tuplet 3/2 { e, fis gis } a4~ |
 
 %143
 a2 ~ |
 a ~ |
-\times 2/3 { a8 gis fis b cis a |
+\tuplet 3/2 { a8 gis fis b cis a |
 gis( fis e)} a8. d,16 |
 cis8 r b-\trill r |
-\times 2/3 { a-\piano( cis e) e( d e)|
+\tuplet 3/2 { a-\piano( cis e) e( d e)|
 a,( cis e) e( d e) |
 a,( cis d) d( cis d) |
 
@@ -212,13 +212,13 @@ gis,( e) d'  cis( d) b |}
 a r r4 |
 R2 |
 r8 r16 b16-\pianoB e8. b16 |
-\times 2/3 { c8 b a g a b } |
+\tuplet 3/2 { c8 b a g a b } |
 
 %159
 e, r r4 | 
 R2 |
 r8 r16 fis16 b8. fis16 |
-\times 2/3 { g8( fis) e d( e) fis | }
+\tuplet 3/2 { g8( fis) e d( e) fis | }
 b r r4 |
 R2*13 |
 
@@ -229,14 +229,14 @@ dis4 r |
 r8 r16 b e8. b16 |
 cis4 r |
 r8 r16 a d8. a16 |
-\times 2/3 { b8( a) g fis( g) a } |
+\tuplet 3/2 { b8( a) g fis( g) a } |
 d,4 r |
 R2 * 5 |
 
 %189
-\times 2/3 { e'8-\piano ( cis) d  e( cis) d } |
+\tuplet 3/2 { e'8-\piano ( cis) d  e( cis) d } |
 e2 ~ |
-\times 2/3 { e8 \noBeam g fis e( g) fis } |
+\tuplet 3/2 { e8 \noBeam g fis e( g) fis } |
 e r r4 |
 
 %193
@@ -247,38 +247,38 @@ gis8. a16 fis8. gis16 |
 eis8. fis16 fis8.-\trill eis32 fis |
 gis4 ~ gis8. cis,16 |
 a'2 ~ |
-\times 2/3 { a8 gis fis gis a b } |
+\tuplet 3/2 { a8 gis fis gis a b } |
 cis2 ~ |
 %202 
 
-\times 2/3 { cis8 b a b cis d } |
+\tuplet 3/2 { cis8 b a b cis d } |
 eis,4  e~ |
-\times 2/3 { e8 d cis d e fis } |
+\tuplet 3/2 { e8 d cis d e fis } |
 cis4 c ~ |
-\times 2/3 { c8 b a g fis e  } |
+\tuplet 3/2 { c8 b a g fis e  } |
 fis2 ~ |
-\times 2/3 { fis8 e fis g a b } |
+\tuplet 3/2 { fis8 e fis g a b } |
 c2~ |
-\times 2/3 { c8 b c d e fis } |
+\tuplet 3/2 { c8 b c d e fis } |
 
 %211
-g4 ~ \times 2/3 { g8 a g } |
+g4 ~ \tuplet 3/2 { g8 a g } |
 fis4 g ~ |
-\times 2/3 { g8 fis e fis g e } |
+\tuplet 3/2 { g8 fis e fis g e } |
 dis4 e ~ |
-\times 2/3 { e8 d! cis d e cis } |
-b4 ~ \times 2/3 { b8 cis b } |
-\times 2/3 { ais( gis) ais b cis d |
+\tuplet 3/2 { e8 d! cis d e cis } |
+b4 ~ \tuplet 3/2 { b8 cis b } |
+\tuplet 3/2 { ais( gis) ais b cis d |
 e ( fis e) d( cis b) |
 
 %219
 %on triplets?
 ais( gis ais) b( cis d) | }
-cis4 ~ \times 2/3 { cis8( d e ) } |
-\times 2/3 { d( e fis) } e4 ~ |
+cis4 ~ \tuplet 3/2 { cis8( d e ) } |
+\tuplet 3/2 { d( e fis) } e4 ~ |
 e8. d16 cis4 ~ |
-\times 2/3 { cis8 ais b } fis'8. cis16 |
-\times 2/3 { d8( cis)b ais(b) cis  } |
+\tuplet 3/2 { cis8 ais b } fis'8. cis16 |
+\tuplet 3/2 { d8( cis)b ais(b) cis  } |
 fis,4 b ~ |
 b cis ~ |
 cis d ~ |
@@ -292,12 +292,12 @@ b4 r |
 R2|
  R2|
  r8 r16 d a'8. e16 | \tripletsShowOnce
- \times 2/3 { fis8 e d } \times 2/3 { cis d e } |
+ \tuplet 3/2 { fis8 e d } \tuplet 3/2 { cis d e } |
 
  %--Bar 5-- %
  a, r fis r | 
  g r a r |
- \times 2/3 { \tripletsShowOnce
+ \tuplet 3/2 { \tripletsShowOnce
   b d fis   fis e fis |
   d g fis   e a g |
   fis( a) g   fis( a) g |
@@ -314,74 +314,74 @@ R2|
 
 %--Bar 17--%
 e,8. e16 a8. e16|
- \tripletsShowOnce \times 2/3 { fis8 e d   cis d e |
+ \tripletsShowOnce \tuplet 3/2 { fis8 e d   cis d e |
   a, ( cis) b   a ( cis) b |  }
 a2 ~|
- \times 2/3 { a8 cis b  a( cis) b } |
+ \tuplet 3/2 { a8 cis b  a( cis) b } |
 a2~ |
 a~ |
 a |
 
 %--Bar 25--%
-\tripletsShowOnce \times 2/3 { gis8 a b } cis4~ |
-\times 2/3 { cis8 fis e } d4~ |
+\tripletsShowOnce \tuplet 3/2 { gis8 a b } cis4~ |
+\tuplet 3/2 { cis8 fis e } d4~ |
 d8. b'16 cis,8. fis16 |
-\times 2/3 { e8 d cis  b cis d } |
-\times 2/3 { cis b a } d4~|
-\times 2/3 { d8 cis b } a8. g16|
-\times 2/3 { fis8 e d } a' r|
+\tuplet 3/2 { e8 d cis  b cis d } |
+\tuplet 3/2 { cis b a } d4~|
+\tuplet 3/2 { d8 cis b } a8. g16|
+\tuplet 3/2 { fis8 e d } a' r|
 R2|
 
 %--Bar 265 --%
 r8 r16 a' d8. a16 |
-\times 2/3 { b8 a g   fis g a } |
+\tuplet 3/2 { b8 a g   fis g a } |
 d, r cis r |
 d r e r |
-\times 2/3 { d fis a   a g a } |
-\times 2/3 { fis b a   gis cis b } |
-a4 ~ \times 2/3 { a8 b cis } |
-\times 2/3 { d cis b   a b g } |
+\tuplet 3/2 { d fis a   a g a } |
+\tuplet 3/2 { fis b a   gis cis b } |
+a4 ~ \tuplet 3/2 { a8 b cis } |
+\tuplet 3/2 { d cis b   a b g } |
 
 %--Bar 273--%
 fis r g r |
 a r c, r |
 b r cis! r |
-d r \times 2/3 { a( cis  e) } |
-\times 2/3 {  a,( d  fis) cis( e  g) } |
+d r \tuplet 3/2 { a( cis  e) } |
+\tuplet 3/2 {  a,( d  fis) cis( e  g) } |
 a r b r |
 
 %--Bar 279--%
 a r g r |
-g r \times 2/3 { fis g a } |
-d,4 ~ \tripletsShowOnce \times 2/3 { d8 \noBeam e cis } |
+g r \tuplet 3/2 { fis g a } |
+d,4 ~ \tripletsShowOnce \tuplet 3/2 { d8 \noBeam e cis } |
 \autoBeamOff d8. \autoBeamOn a'16 d8. a16 | % check beaming []
-\times 2/3 { b8 a g  fis g a |
+\tuplet 3/2 { b8 a g  fis g a |
 d, fis e d fis e | }
 d2~ |
 
 
 %--Bar 286--%
-\times 2/3 { d8 \noBeam a' g fis a g } |
+\tuplet 3/2 { d8 \noBeam a' g fis a g } |
 fis2 |
 e ~|
 e ~|
-e4 ~ \tripletsShow \times 2/3 { e8 \noBeam fis e } |
-d4 ~ \times 2/3 { d8 e d } |
-cis4 \times 2/3 { c8 d c } |
+e4 ~ \tripletsShow \tuplet 3/2 { e8 \noBeam fis e } |
+d4 ~ \tuplet 3/2 { d8 e d } |
+cis4 \tuplet 3/2 { c8 d c } |
 
 %--Bar 293--%
 b4 g'~|
-\times 2/3 { g8 cis, e fis g a } | \tripletsHide
+\tuplet 3/2 { g8 cis, e fis g a } | \tripletsHide
 d,8. e16 cis8. d16 |
 d4 c |
 b a |
-\times 2/3 { g8 a b a b cis^\fbna} |
+\tuplet 3/2 { g8 a b a b cis^\fbna} |
 fis,4 d' ~ |
 
 %--Bar 300--%
-\times 2/3 { d8 \noBeam fis e d fis e } |
+\tuplet 3/2 { d8 \noBeam fis e d fis e } |
 d2~ |
-\times 2/3 { d8 \noBeam b cis d b cis } |
+\tuplet 3/2 { d8 \noBeam b cis d b cis } |
 d4~ d8. e16 |
 cis2 |
 d |
@@ -389,7 +389,7 @@ e |
 fis8. \noBeam a16 d8. a16 |
 
 %--Bar 308-%
-\tripletsShowOnce \times 2/3 { b8( a) g fis(g) a } |
+\tripletsShowOnce \tuplet 3/2 { b8( a) g fis(g) a } |
 d,8. e16 cis8. d16 |
 d2-\fermata \bar "|." |
 

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute.ly
@@ -127,7 +127,7 @@ flute = \relative c'' {
   \alternative {
     {
       d2 |
-      r8 r16 fis -\cantabileB b8. fis16 | % \markup { }
+      r8 r16 fis-\cantabileB b8. fis16 | % \markup { }
       g2 ~ |
       g8. g16 \tuplet 3/2 { a8( fis) g } |
       fis2 ~ |
@@ -147,7 +147,7 @@ flute = \relative c'' {
         ais,8( cis e) e( d! e) |
       }
 
-      %--Bar 93-%
+      % --Bar 93-- %
       \tuplet 3/2 {
         b8( d fis) fis( e fis) |
         cis8( e g) g( fis g) |
@@ -157,11 +157,11 @@ flute = \relative c'' {
       cis8 r \tuplet 3/2 { b( a) b } |
       \tuplet 3/2 {
         cis8( b) a gis( fis) eis |
-        fis8( cis' fis) fis( e fis) | %99
-        a,8( cis fis) fis( eis fis) | % 100
+        fis8( cis' fis) fis( e fis) |
+        a,8( cis fis) fis( eis fis) |
       }
 
-      %101
+      % --Bar 101-- %
       \tuplet 3/2 {
         b,8( cis d) b( cis a) |
         gis8( b eis) eis( dis eis) |
@@ -175,8 +175,8 @@ flute = \relative c'' {
       \tuplet 3/2 { r8 gis, a b d cis | }
 
       %110
-      d2-\trill |
-      cis2-\trill |
+      d2\trill |
+      cis2\trill |
       b2 ~ |
       \tuplet 3/2 { b8 \noBeam gis a b( gis) a }
       b2 |
@@ -223,7 +223,7 @@ flute = \relative c'' {
         a8 gis fis b cis a |
         gis8( fis e)
       } a8. d,16 |
-      cis8 r b-\trill r |
+      cis8 r b\trill r |
       \tuplet 3/2 {
         a8(-\piano cis e) e( d e) |
         a,8( cis e) e( d e) |
@@ -270,7 +270,7 @@ flute = \relative c'' {
       b8. e,16 a4 ~ |
       a8. b16 gis4 ~ |
       gis8. a16 fis8. gis16 |
-      eis8. fis16 fis8.-\trill eis32 fis |
+      eis8. fis16 fis8.\trill eis32 fis |
       gis4 ~ gis8. cis,16 |
       a'2 ~ |
       \tuplet 3/2 { a8 gis fis gis a b } |
@@ -313,7 +313,7 @@ flute = \relative c'' {
       d4 e ~ |
       e8. g16 fis8. e16 |
       fis8. e16 fis8. g16 |
-      d8 r cis-\trill r |
+      d8 r cis\trill r |
       b4 r |
       %233
     }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute.ly
@@ -2,6 +2,7 @@
 \include "header.ly"
 
 flute = \relative c'' {
+  \tempo "Allegro."
   \clef treble
   \key d \major
   \time 2/4

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute.ly
@@ -36,7 +36,7 @@ flute = \relative c'' {
   e,8. e16 a8. e16 | \tripletsShowOnce
   \tuplet 3/2 {
     fis8 e d cis d e |
-    a, ( cis) b a ( cis) b |
+    a,( cis) b a( cis) b |
   }
   a2 ~ |
   \tuplet 3/2 { a8 cis b a( cis) b } |
@@ -129,7 +129,7 @@ flute = \relative c'' {
     d b cis d fis e |
     fis e d cis d b |
     ais cis fis e d cis | \tripletsShowOnce
-    b ^\piano (d fis) fis -\cantabileB ( e fis) |
+    b(^\piano d fis) fis(-\cantabileB e fis) |
     b,( d fis) fis( e fis) |
     b,( dis e) e( dis e) |
     ais,( cis e) e( d! e) |
@@ -137,16 +137,16 @@ flute = \relative c'' {
 
   %--Bar 93-%
   \tuplet 3/2 {
-    b (d fis) fis( e fis) |
-    cis( e g) g(fis g) |
-    ais,( fis) e' d(e) cis |
+    b( d fis) fis( e fis) |
+    cis( e g) g( fis g) |
+    ais,( fis) e' d( e) cis |
   }
   b r b r |
   cis r \tuplet 3/2 { b( a) b } |
   \tuplet 3/2 {
-    cis(b) a gis(fis)eis |
+    cis( b) a gis( fis) eis |
     fis( cis' fis) fis( e fis) | %99
-    a,( cis fis) fis (eis fis) | % 100
+    a,( cis fis) fis( eis fis) | % 100
   }
 
   %101
@@ -154,8 +154,8 @@ flute = \relative c'' {
     b,( cis d) b( cis a) |
     gis( b eis) eis( dis eis) |
     a,( cis fis) fis( eis fis) |
-    d!( b gis ) eis( gis fis) |
-    eis ( gis) fis eis( fis) gis |
+    d!( b gis) eis( gis fis) |
+    eis( gis) fis eis( fis) gis |
   }
   a r r4 |
   \tuplet 3/2 { r8 a-\forte b cis e d } |
@@ -190,7 +190,7 @@ flute = \relative c'' {
   \tuplet 3/2 {
     g!8( fis) e dis( e) fis |
     b,( e) g b( a) b |
-    e,(d) a
+    e,( d) a
   } d4 ~ |
   \tuplet 3/2 { d8 cis e } a8. e16 |
 
@@ -213,7 +213,7 @@ flute = \relative c'' {
   } a8. d,16 |
   cis8 r b-\trill r |
   \tuplet 3/2 {
-    a-\piano( cis e) e( d e) |
+    a(-\piano cis e) e( d e) |
     a,( cis e) e( d e) |
     a,( cis d) d( cis d) |
 
@@ -248,7 +248,7 @@ flute = \relative c'' {
   R2 * 5 |
 
   %189
-  \tuplet 3/2 { e'8-\piano ( cis) d e( cis) d } |
+  \tuplet 3/2 { e'8(-\piano cis) d e( cis) d } |
   e2 ~ |
   \tuplet 3/2 { e8 \noBeam g fis e( g) fis } |
   e r r4 |
@@ -284,7 +284,7 @@ flute = \relative c'' {
   b4 ~ \tuplet 3/2 { b8 cis b } |
   \tuplet 3/2 {
     ais( gis) ais b cis d |
-    e ( fis e) d( cis b) |
+    e( fis e) d( cis b) |
 
     %219
     %on triplets?
@@ -333,7 +333,7 @@ flute = \relative c'' {
   e,8. e16 a8. e16 |
   \tripletsShowOnce \tuplet 3/2 {
     fis8 e d cis d e |
-    a, ( cis) b a ( cis) b |
+    a,( cis) b a( cis) b |
   }
   a2 ~ |
   \tuplet 3/2 { a8 cis b a( cis) b } |
@@ -410,12 +410,8 @@ flute = \relative c'' {
   fis8. \noBeam a16 d8. a16 |
 
   %--Bar 308-%
-  \tripletsShowOnce \tuplet 3/2 { b8( a) g fis(g) a } |
+  \tripletsShowOnce \tuplet 3/2 { b8( a) g fis( g) a } |
   d,8. e16 cis8. d16 |
-  d2-\fermata \bar "|." |
-
-
-
-
+  d2\fermata \bar "|." |
 } %end flute notes
 

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute.ly
@@ -4,394 +4,417 @@
 \version "2.18.0"
 
 flute =  \relative c'' {
- \clef treble
- \key d \major
- \time 2/4
+  \clef treble
+  \key d \major
+  \time 2/4
 
- \commonSettings
+  \commonSettings
 
- % --Bar 1-- %
- R2|
- R2|
- r8 r16 d a'8. e16 |
- \tuplet 3/2 { fis8 e d } \tuplet 3/2 { cis d e } |
+  % --Bar 1-- %
+  R2|
+  R2|
+  r8 r16 d a'8. e16 |
+  \tuplet 3/2 { fis8 e d } \tuplet 3/2 { cis d e } |
 
- %--Bar 5-- %
- a, r fis r | 
- g r a r |
- \tuplet 3/2 { 
-  b d fis  \tripletsHide fis e fis |
-  d g fis   e a g |
-  fis( a) g   fis( a) g |
+  %--Bar 5-- %
+  a, r fis r |
+  g r a r |
+  \tuplet 3/2 {
+    b d fis  \tripletsHide fis e fis |
+    d g fis   e a g |
+    fis( a) g   fis( a) g |
   }
- 
-%--Bar 10--%
- fis8. b16 a8. g16 |
- fis 8. a,16 e'8. a,16 |
- fis'8 r gis r |
- a2 ~ |
- a ~ |
- a8 r gis r |
- a r b r |
 
-%--Bar 17--%
-e,8. e16 a8. e16 |  \tripletsShowOnce
- \tuplet 3/2 { fis8 e d   cis d e |
-  a, ( cis) b   a ( cis) b |  }
-a2 ~|
- \tuplet 3/2 { a8 cis b  a( cis) b } |
-a2~ |
-a~ |
-a |
+  %--Bar 10--%
+  fis8. b16 a8. g16 |
+  fis 8. a,16 e'8. a,16 |
+  fis'8 r gis r |
+  a2 ~ |
+  a ~ |
+  a8 r gis r |
+  a r b r |
 
-%--Bar 25--%
- \tripletsShowOnce \tuplet 3/2 { gis8 a b } cis4~ |
-\tuplet 3/2 { cis8 fis e } d4~ |
-d8. b'16 cis,8. fis16 |
-\tuplet 3/2 { e8 d cis  b cis d } |
-\tuplet 3/2 { cis b a } d4~|
-\tuplet 3/2 { d8 cis b } a8. g16|
- \tripletsShowOnce \tuplet 3/2 { fis8 e d } a' r|
-R2|
-
-%--Bar 33--%
-r8 r16 a' d8. a16 |
-\tuplet 3/2 { b8 a g   fis g a } |
-d, r cis r |
-d r e r |
-\tuplet 3/2 { d fis a   a g a } |
-\tuplet 3/2 { fis b a   gis cis b } |
-a4 ~ \tuplet 3/2 { a8 b cis } |
-\tuplet 3/2 { d cis b   a b g } |
-
-%--Bar 41--%
-fis r g r |
-a r c, r |
-b r cis! r |
-d r \tuplet 3/2 { a( cis  e) } |
-\tuplet 3/2 {  a,( d  fis) cis( e  g) } |
-a r b r |
-
-%--Bar 47--%
-a r g r |
-g r \tuplet 3/2 { fis g a } |
-d,4 ~  \tripletsShowOnce \tuplet 3/2 { d8 e cis } |
-\autoBeamOff d8. \autoBeamOn a'16 d8. a16 | % check beaming []
-\tuplet 3/2 { b8 a g  fis g a |
-d, fis e d fis e | }
-d2~ |
-
-
-%--Bar 54--%
-\tuplet 3/2 { d8 \noBeam a' g fis a g } |
-fis2 |
-e ~|
-e ~|
-e4 ~  \tripletsShow \tuplet 3/2 { e8 fis e } |
-d4 ~   \tuplet 3/2 { d8 e d } |
-cis4   \tuplet 3/2 { c8 d c } |
-
-%--Bar 61--%
-b4 g'~|
-\tuplet 3/2 { g8 cis, e fis g a } |  \tripletsHide
-d,8. e16 cis8. d16 |
-d4 c |
-b a |
-\tuplet 3/2 { g8 a b a b cis^\fbna} | 
-fis,4 d' ~ |
-
-%--Bar 68--%
-\tuplet 3/2 { d8 \noBeam fis e d fis e } |
-d2~ |
-\tuplet 3/2 { d8 \noBeam b cis d b cis } |
-d4~ d8. e16 |
-cis2 |
-d |
-e |
-fis8. \noBeam a16 d8. a16 |
-
-%--Bar 76-%
- \tripletsShowOnce \tuplet 3/2 { b8( a) g fis(g) a } |
-d,8. e16 cis8. d16 |
-d2 |
-r8 r16 fis -\cantabileB b8. fis16 | % \markup {  }
-g2 ~ |
-g8. g16 \tuplet 3/2 { a8( fis) g } |
-fis2~ |
-fis8. fis16 b8. g16|
-e2~ |
-
-%--Bar 85-%
- \tuplet 3/2 { e8 fis g fis g e |
-  d b cis d fis e |
-  fis e d cis d b |
-  ais cis fis e d cis | \tripletsShowOnce
-  b ^\piano (d fis) fis -\cantabileB ( e fis) | 
-  b,( d fis) fis( e fis) |
-  b,( dis e)  e( dis e) |
-  ais,( cis e)  e( d! e) |
- }
-
-%--Bar 93-%
-\tuplet 3/2 { b (d fis) fis( e fis) |
-	cis( e g) g(fis g) |
-	ais,( fis) e' d(e) cis | }
-	b r b r |
-	cis r \tuplet 3/2{ b( a) b }|
-\tuplet 3/2{cis(b) a gis(fis)eis|
-	fis( cis' fis) fis( e fis) | %99
-	a,( cis fis)  fis (eis fis) |% 100
-	}
-
-%101
-\tuplet 3/2 { b,( cis d) b( cis a) |
-gis( b eis)  eis( dis eis) |
-a,( cis fis)  fis( eis fis) |
-d!( b gis )  eis( gis fis) |
-eis ( gis) fis  eis( fis) gis | }
-a r r4 |
-\tuplet 3/2 { r8 a-\forte b cis e d } |
-e r r4 |
-\tuplet 3/2 { r8 gis, a b d cis | }
-
-%110
-d2-\trill |
-cis-\trill |
-b ~ |
-\tuplet 3/2 { b8 \noBeam gis a  b( gis) a }
-b2 |
-a4 a' ~ |
-a gis~ |
-gis cis ~ |
-cis b8. a16 |
-
-%119
-gis2 ~| 
-gis4 fis8. e16 |
-d2 ~ |
-d4 cis 8. b16|
-ais4 r |
-r8 r16 fis' cis'8. gis16 |
-\tuplet 3/2 { a8( gis) fis  eis( fis) gis }|
-cis,4 fis4~ |
-%127
-fis8. gis16 eis8. fis16 |
-fis2 ~ |
-fis |
-r8 r16 fis b8. fis16 |
-\tuplet 3/2 { g!8( fis) e  dis( e) fis|
-b,( e) g  b( a) b |
-e,(d) a } d4 ~ |
-\tuplet 3/2 { d8 cis e } a8. e16 |
-
-%135
-\tuplet 3/2 { fis8 e d cis d e } |
-a,8. gis16 \tuplet 3/2 { fis8 a d } |
-d8. \tuplet 3/2 { cis32 b a gis8 b e } |
-e8. \tuplet 3/2 { d32 cis b a8 cis fis } |
-fis8. \tuplet 3/2 { e32 d cis b8 d gis } |
-gis8. \tuplet 3/2 { fis32 e d cis8 e a } |
-a8. \tuplet 3/2 { gis32 fis e d8 fis b } |
-\tuplet 3/2 { e, fis gis } a4~ |
-
-%143
-a2 ~ |
-a ~ |
-\tuplet 3/2 { a8 gis fis b cis a |
-gis( fis e)} a8. d,16 |
-cis8 r b-\trill r |
-\tuplet 3/2 { a-\piano( cis e) e( d e)|
-a,( cis e) e( d e) |
-a,( cis d) d( cis d) |
-
-%151
-gis,( b d) d( cis d) |
-a( cis e) e( d e) |
-b( d fis) fis( e fis) |
-gis,( e) d'  cis( d) b |}
-a r r4 |
-R2 |
-r8 r16 b16-\pianoB e8. b16 |
-\tuplet 3/2 { c8 b a g a b } |
-
-%159
-e, r r4 | 
-R2 |
-r8 r16 fis16 b8. fis16 |
-\tuplet 3/2 { g8( fis) e d( e) fis | }
-b r r4 |
-R2*13 |
-
-
-%177
-r8 r16 cis fis8. cis16 |
-dis4 r |
-r8 r16 b e8. b16 |
-cis4 r |
-r8 r16 a d8. a16 |
-\tuplet 3/2 { b8( a) g fis( g) a } |
-d,4 r |
-R2 * 5 |
-
-%189
-\tuplet 3/2 { e'8-\piano ( cis) d  e( cis) d } |
-e2 ~ |
-\tuplet 3/2 { e8 \noBeam g fis e( g) fis } |
-e r r4 |
-
-%193
-r8 r16 fis b4 ~ |
-b8. e,16 a4 ~ |
-a8. b16 gis4 ~ |
-gis8. a16 fis8. gis16 |
-eis8. fis16 fis8.-\trill eis32 fis |
-gis4 ~ gis8. cis,16 |
-a'2 ~ |
-\tuplet 3/2 { a8 gis fis gis a b } |
-cis2 ~ |
-%202 
-
-\tuplet 3/2 { cis8 b a b cis d } |
-eis,4  e~ |
-\tuplet 3/2 { e8 d cis d e fis } |
-cis4 c ~ |
-\tuplet 3/2 { c8 b a g fis e  } |
-fis2 ~ |
-\tuplet 3/2 { fis8 e fis g a b } |
-c2~ |
-\tuplet 3/2 { c8 b c d e fis } |
-
-%211
-g4 ~ \tuplet 3/2 { g8 a g } |
-fis4 g ~ |
-\tuplet 3/2 { g8 fis e fis g e } |
-dis4 e ~ |
-\tuplet 3/2 { e8 d! cis d e cis } |
-b4 ~ \tuplet 3/2 { b8 cis b } |
-\tuplet 3/2 { ais( gis) ais b cis d |
-e ( fis e) d( cis b) |
-
-%219
-%on triplets?
-ais( gis ais) b( cis d) | }
-cis4 ~ \tuplet 3/2 { cis8( d e ) } |
-\tuplet 3/2 { d( e fis) } e4 ~ |
-e8. d16 cis4 ~ |
-\tuplet 3/2 { cis8 ais b } fis'8. cis16 |
-\tuplet 3/2 { d8( cis)b ais(b) cis  } |
-fis,4 b ~ |
-b cis ~ |
-cis d ~ |
-d e ~ |
-e8. g16 fis8. e16 |
-fis8. e16 fis8. g16 |
-d8 r cis-\trill r |
-b4 r |
-
-%233
-R2|
- R2|
- r8 r16 d a'8. e16 | \tripletsShowOnce
- \tuplet 3/2 { fis8 e d } \tuplet 3/2 { cis d e } |
-
- %--Bar 5-- %
- a, r fis r | 
- g r a r |
- \tuplet 3/2 { \tripletsShowOnce
-  b d fis   fis e fis |
-  d g fis   e a g |
-  fis( a) g   fis( a) g |
+  %--Bar 17--%
+  e,8. e16 a8. e16 |  \tripletsShowOnce
+  \tuplet 3/2 {
+    fis8 e d   cis d e |
+    a, ( cis) b   a ( cis) b |
   }
- 
-%--Bar 10--%
- fis8. b16 a8. g16 |
- fis 8. a,16 e'8. a,16 |
- fis'8 r gis r |
- a2 ~ |
- a ~ |
- a8 r gis r |
- a r b r |
+  a2 ~|
+  \tuplet 3/2 { a8 cis b  a( cis) b } |
+  a2~ |
+  a~ |
+  a |
 
-%--Bar 17--%
-e,8. e16 a8. e16|
- \tripletsShowOnce \tuplet 3/2 { fis8 e d   cis d e |
-  a, ( cis) b   a ( cis) b |  }
-a2 ~|
- \tuplet 3/2 { a8 cis b  a( cis) b } |
-a2~ |
-a~ |
-a |
+  %--Bar 25--%
+  \tripletsShowOnce \tuplet 3/2 { gis8 a b } cis4~ |
+  \tuplet 3/2 { cis8 fis e } d4~ |
+  d8. b'16 cis,8. fis16 |
+  \tuplet 3/2 { e8 d cis  b cis d } |
+  \tuplet 3/2 { cis b a } d4~|
+  \tuplet 3/2 { d8 cis b } a8. g16|
+  \tripletsShowOnce \tuplet 3/2 { fis8 e d } a' r|
+  R2|
 
-%--Bar 25--%
-\tripletsShowOnce \tuplet 3/2 { gis8 a b } cis4~ |
-\tuplet 3/2 { cis8 fis e } d4~ |
-d8. b'16 cis,8. fis16 |
-\tuplet 3/2 { e8 d cis  b cis d } |
-\tuplet 3/2 { cis b a } d4~|
-\tuplet 3/2 { d8 cis b } a8. g16|
-\tuplet 3/2 { fis8 e d } a' r|
-R2|
+  %--Bar 33--%
+  r8 r16 a' d8. a16 |
+  \tuplet 3/2 { b8 a g   fis g a } |
+  d, r cis r |
+  d r e r |
+  \tuplet 3/2 { d fis a   a g a } |
+  \tuplet 3/2 { fis b a   gis cis b } |
+  a4 ~ \tuplet 3/2 { a8 b cis } |
+  \tuplet 3/2 { d cis b   a b g } |
 
-%--Bar 265 --%
-r8 r16 a' d8. a16 |
-\tuplet 3/2 { b8 a g   fis g a } |
-d, r cis r |
-d r e r |
-\tuplet 3/2 { d fis a   a g a } |
-\tuplet 3/2 { fis b a   gis cis b } |
-a4 ~ \tuplet 3/2 { a8 b cis } |
-\tuplet 3/2 { d cis b   a b g } |
+  %--Bar 41--%
+  fis r g r |
+  a r c, r |
+  b r cis! r |
+  d r \tuplet 3/2 { a( cis  e) } |
+  \tuplet 3/2 {  a,( d  fis) cis( e  g) } |
+  a r b r |
 
-%--Bar 273--%
-fis r g r |
-a r c, r |
-b r cis! r |
-d r \tuplet 3/2 { a( cis  e) } |
-\tuplet 3/2 {  a,( d  fis) cis( e  g) } |
-a r b r |
-
-%--Bar 279--%
-a r g r |
-g r \tuplet 3/2 { fis g a } |
-d,4 ~ \tripletsShowOnce \tuplet 3/2 { d8 \noBeam e cis } |
-\autoBeamOff d8. \autoBeamOn a'16 d8. a16 | % check beaming []
-\tuplet 3/2 { b8 a g  fis g a |
-d, fis e d fis e | }
-d2~ |
+  %--Bar 47--%
+  a r g r |
+  g r \tuplet 3/2 { fis g a } |
+  d,4 ~  \tripletsShowOnce \tuplet 3/2 { d8 e cis } |
+  \autoBeamOff d8. \autoBeamOn a'16 d8. a16 | % check beaming []
+  \tuplet 3/2 {
+    b8 a g  fis g a |
+    d, fis e d fis e |
+  }
+  d2~ |
 
 
-%--Bar 286--%
-\tuplet 3/2 { d8 \noBeam a' g fis a g } |
-fis2 |
-e ~|
-e ~|
-e4 ~ \tripletsShow \tuplet 3/2 { e8 \noBeam fis e } |
-d4 ~ \tuplet 3/2 { d8 e d } |
-cis4 \tuplet 3/2 { c8 d c } |
+  %--Bar 54--%
+  \tuplet 3/2 { d8 \noBeam a' g fis a g } |
+  fis2 |
+  e ~|
+  e ~|
+  e4 ~  \tripletsShow \tuplet 3/2 { e8 fis e } |
+  d4 ~   \tuplet 3/2 { d8 e d } |
+  cis4   \tuplet 3/2 { c8 d c } |
 
-%--Bar 293--%
-b4 g'~|
-\tuplet 3/2 { g8 cis, e fis g a } | \tripletsHide
-d,8. e16 cis8. d16 |
-d4 c |
-b a |
-\tuplet 3/2 { g8 a b a b cis^\fbna} |
-fis,4 d' ~ |
+  %--Bar 61--%
+  b4 g'~|
+  \tuplet 3/2 { g8 cis, e fis g a } |  \tripletsHide
+  d,8. e16 cis8. d16 |
+  d4 c |
+  b a |
+  \tuplet 3/2 { g8 a b a b cis^\fbna} |
+  fis,4 d' ~ |
 
-%--Bar 300--%
-\tuplet 3/2 { d8 \noBeam fis e d fis e } |
-d2~ |
-\tuplet 3/2 { d8 \noBeam b cis d b cis } |
-d4~ d8. e16 |
-cis2 |
-d |
-e |
-fis8. \noBeam a16 d8. a16 |
+  %--Bar 68--%
+  \tuplet 3/2 { d8 \noBeam fis e d fis e } |
+  d2~ |
+  \tuplet 3/2 { d8 \noBeam b cis d b cis } |
+  d4~ d8. e16 |
+  cis2 |
+  d |
+  e |
+  fis8. \noBeam a16 d8. a16 |
 
-%--Bar 308-%
-\tripletsShowOnce \tuplet 3/2 { b8( a) g fis(g) a } |
-d,8. e16 cis8. d16 |
-d2-\fermata \bar "|." |
+  %--Bar 76-%
+  \tripletsShowOnce \tuplet 3/2 { b8( a) g fis(g) a } |
+  d,8. e16 cis8. d16 |
+  d2 |
+  r8 r16 fis -\cantabileB b8. fis16 | % \markup {  }
+  g2 ~ |
+  g8. g16 \tuplet 3/2 { a8( fis) g } |
+  fis2~ |
+  fis8. fis16 b8. g16|
+  e2~ |
+
+  %--Bar 85-%
+  \tuplet 3/2 {
+    e8 fis g fis g e |
+    d b cis d fis e |
+    fis e d cis d b |
+    ais cis fis e d cis | \tripletsShowOnce
+    b ^\piano (d fis) fis -\cantabileB ( e fis) |
+    b,( d fis) fis( e fis) |
+    b,( dis e)  e( dis e) |
+    ais,( cis e)  e( d! e) |
+  }
+
+  %--Bar 93-%
+  \tuplet 3/2 {
+    b (d fis) fis( e fis) |
+    cis( e g) g(fis g) |
+    ais,( fis) e' d(e) cis |
+  }
+  b r b r |
+  cis r \tuplet 3/2{ b( a) b }|
+  \tuplet 3/2{
+    cis(b) a gis(fis)eis|
+    fis( cis' fis) fis( e fis) | %99
+    a,( cis fis)  fis (eis fis) |% 100
+  }
+
+  %101
+  \tuplet 3/2 {
+    b,( cis d) b( cis a) |
+    gis( b eis)  eis( dis eis) |
+    a,( cis fis)  fis( eis fis) |
+    d!( b gis )  eis( gis fis) |
+    eis ( gis) fis  eis( fis) gis |
+  }
+  a r r4 |
+  \tuplet 3/2 { r8 a-\forte b cis e d } |
+  e r r4 |
+  \tuplet 3/2 { r8 gis, a b d cis | }
+
+  %110
+  d2-\trill |
+  cis-\trill |
+  b ~ |
+  \tuplet 3/2 { b8 \noBeam gis a  b( gis) a }
+  b2 |
+  a4 a' ~ |
+  a gis~ |
+  gis cis ~ |
+  cis b8. a16 |
+
+  %119
+  gis2 ~|
+  gis4 fis8. e16 |
+  d2 ~ |
+  d4 cis 8. b16|
+  ais4 r |
+  r8 r16 fis' cis'8. gis16 |
+  \tuplet 3/2 { a8( gis) fis  eis( fis) gis }|
+  cis,4 fis4~ |
+  %127
+  fis8. gis16 eis8. fis16 |
+  fis2 ~ |
+  fis |
+  r8 r16 fis b8. fis16 |
+  \tuplet 3/2 {
+    g!8( fis) e  dis( e) fis|
+    b,( e) g  b( a) b |
+    e,(d) a
+  } d4 ~ |
+  \tuplet 3/2 { d8 cis e } a8. e16 |
+
+  %135
+  \tuplet 3/2 { fis8 e d cis d e } |
+  a,8. gis16 \tuplet 3/2 { fis8 a d } |
+  d8. \tuplet 3/2 { cis32 b a gis8 b e } |
+  e8. \tuplet 3/2 { d32 cis b a8 cis fis } |
+  fis8. \tuplet 3/2 { e32 d cis b8 d gis } |
+  gis8. \tuplet 3/2 { fis32 e d cis8 e a } |
+  a8. \tuplet 3/2 { gis32 fis e d8 fis b } |
+  \tuplet 3/2 { e, fis gis } a4~ |
+
+  %143
+  a2 ~ |
+  a ~ |
+  \tuplet 3/2 {
+    a8 gis fis b cis a |
+    gis( fis e)
+  } a8. d,16 |
+  cis8 r b-\trill r |
+  \tuplet 3/2 {
+    a-\piano( cis e) e( d e)|
+    a,( cis e) e( d e) |
+    a,( cis d) d( cis d) |
+
+    %151
+    gis,( b d) d( cis d) |
+    a( cis e) e( d e) |
+    b( d fis) fis( e fis) |
+    gis,( e) d'  cis( d) b |
+  }
+  a r r4 |
+  R2 |
+  r8 r16 b16-\pianoB e8. b16 |
+  \tuplet 3/2 { c8 b a g a b } |
+
+  %159
+  e, r r4 |
+  R2 |
+  r8 r16 fis16 b8. fis16 |
+  \tuplet 3/2 { g8( fis) e d( e) fis | }
+  b r r4 |
+  R2*13 |
+
+
+  %177
+  r8 r16 cis fis8. cis16 |
+  dis4 r |
+  r8 r16 b e8. b16 |
+  cis4 r |
+  r8 r16 a d8. a16 |
+  \tuplet 3/2 { b8( a) g fis( g) a } |
+  d,4 r |
+  R2 * 5 |
+
+  %189
+  \tuplet 3/2 { e'8-\piano ( cis) d  e( cis) d } |
+  e2 ~ |
+  \tuplet 3/2 { e8 \noBeam g fis e( g) fis } |
+  e r r4 |
+
+  %193
+  r8 r16 fis b4 ~ |
+  b8. e,16 a4 ~ |
+  a8. b16 gis4 ~ |
+  gis8. a16 fis8. gis16 |
+  eis8. fis16 fis8.-\trill eis32 fis |
+  gis4 ~ gis8. cis,16 |
+  a'2 ~ |
+  \tuplet 3/2 { a8 gis fis gis a b } |
+  cis2 ~ |
+  %202
+
+  \tuplet 3/2 { cis8 b a b cis d } |
+  eis,4  e~ |
+  \tuplet 3/2 { e8 d cis d e fis } |
+  cis4 c ~ |
+  \tuplet 3/2 { c8 b a g fis e  } |
+  fis2 ~ |
+  \tuplet 3/2 { fis8 e fis g a b } |
+  c2~ |
+  \tuplet 3/2 { c8 b c d e fis } |
+
+  %211
+  g4 ~ \tuplet 3/2 { g8 a g } |
+  fis4 g ~ |
+  \tuplet 3/2 { g8 fis e fis g e } |
+  dis4 e ~ |
+  \tuplet 3/2 { e8 d! cis d e cis } |
+  b4 ~ \tuplet 3/2 { b8 cis b } |
+  \tuplet 3/2 {
+    ais( gis) ais b cis d |
+    e ( fis e) d( cis b) |
+
+    %219
+    %on triplets?
+    ais( gis ais) b( cis d) |
+  }
+  cis4 ~ \tuplet 3/2 { cis8( d e ) } |
+  \tuplet 3/2 { d( e fis) } e4 ~ |
+  e8. d16 cis4 ~ |
+  \tuplet 3/2 { cis8 ais b } fis'8. cis16 |
+  \tuplet 3/2 { d8( cis)b ais(b) cis  } |
+  fis,4 b ~ |
+  b cis ~ |
+  cis d ~ |
+  d e ~ |
+  e8. g16 fis8. e16 |
+  fis8. e16 fis8. g16 |
+  d8 r cis-\trill r |
+  b4 r |
+
+  %233
+  R2|
+  R2|
+  r8 r16 d a'8. e16 | \tripletsShowOnce
+  \tuplet 3/2 { fis8 e d } \tuplet 3/2 { cis d e } |
+
+  %--Bar 5-- %
+  a, r fis r |
+  g r a r |
+  \tuplet 3/2 {
+    \tripletsShowOnce
+    b d fis   fis e fis |
+    d g fis   e a g |
+    fis( a) g   fis( a) g |
+  }
+
+  %--Bar 10--%
+  fis8. b16 a8. g16 |
+  fis 8. a,16 e'8. a,16 |
+  fis'8 r gis r |
+  a2 ~ |
+  a ~ |
+  a8 r gis r |
+  a r b r |
+
+  %--Bar 17--%
+  e,8. e16 a8. e16|
+  \tripletsShowOnce \tuplet 3/2 {
+    fis8 e d   cis d e |
+    a, ( cis) b   a ( cis) b |
+  }
+  a2 ~|
+  \tuplet 3/2 { a8 cis b  a( cis) b } |
+  a2~ |
+  a~ |
+  a |
+
+  %--Bar 25--%
+  \tripletsShowOnce \tuplet 3/2 { gis8 a b } cis4~ |
+  \tuplet 3/2 { cis8 fis e } d4~ |
+  d8. b'16 cis,8. fis16 |
+  \tuplet 3/2 { e8 d cis  b cis d } |
+  \tuplet 3/2 { cis b a } d4~|
+  \tuplet 3/2 { d8 cis b } a8. g16|
+  \tuplet 3/2 { fis8 e d } a' r|
+  R2|
+
+  %--Bar 265 --%
+  r8 r16 a' d8. a16 |
+  \tuplet 3/2 { b8 a g   fis g a } |
+  d, r cis r |
+  d r e r |
+  \tuplet 3/2 { d fis a   a g a } |
+  \tuplet 3/2 { fis b a   gis cis b } |
+  a4 ~ \tuplet 3/2 { a8 b cis } |
+  \tuplet 3/2 { d cis b   a b g } |
+
+  %--Bar 273--%
+  fis r g r |
+  a r c, r |
+  b r cis! r |
+  d r \tuplet 3/2 { a( cis  e) } |
+  \tuplet 3/2 {  a,( d  fis) cis( e  g) } |
+  a r b r |
+
+  %--Bar 279--%
+  a r g r |
+  g r \tuplet 3/2 { fis g a } |
+  d,4 ~ \tripletsShowOnce \tuplet 3/2 { d8 \noBeam e cis } |
+  \autoBeamOff d8. \autoBeamOn a'16 d8. a16 | % check beaming []
+  \tuplet 3/2 {
+    b8 a g  fis g a |
+    d, fis e d fis e |
+  }
+  d2~ |
+
+
+  %--Bar 286--%
+  \tuplet 3/2 { d8 \noBeam a' g fis a g } |
+  fis2 |
+  e ~|
+  e ~|
+  e4 ~ \tripletsShow \tuplet 3/2 { e8 \noBeam fis e } |
+  d4 ~ \tuplet 3/2 { d8 e d } |
+  cis4 \tuplet 3/2 { c8 d c } |
+
+  %--Bar 293--%
+  b4 g'~|
+  \tuplet 3/2 { g8 cis, e fis g a } | \tripletsHide
+  d,8. e16 cis8. d16 |
+  d4 c |
+  b a |
+  \tuplet 3/2 { g8 a b a b cis^\fbna} |
+  fis,4 d' ~ |
+
+  %--Bar 300--%
+  \tuplet 3/2 { d8 \noBeam fis e d fis e } |
+  d2~ |
+  \tuplet 3/2 { d8 \noBeam b cis d b cis } |
+  d4~ d8. e16 |
+  cis2 |
+  d |
+  e |
+  fis8. \noBeam a16 d8. a16 |
+
+  %--Bar 308-%
+  \tripletsShowOnce \tuplet 3/2 { b8( a) g fis(g) a } |
+  d,8. e16 cis8. d16 |
+  d2-\fermata \bar "|." |
 
 
 

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute.ly
@@ -1,5 +1,3 @@
-#(ly:set-point-and-click 'line-column )
-
 \include "header.ly"
 \version "2.18.0"
 

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute.ly
@@ -1,7 +1,7 @@
 \include "header.ly"
 \version "2.18.0"
 
-flute =  \relative c'' {
+flute = \relative c'' {
   \clef treble
   \key d \major
   \time 2/4
@@ -9,8 +9,8 @@ flute =  \relative c'' {
   \commonSettings
 
   % --Bar 1-- %
-  R2|
-  R2|
+  R2 |
+  R2 |
   r8 r16 d a'8. e16 |
   \tuplet 3/2 { fis8 e d } \tuplet 3/2 { cis d e } |
 
@@ -18,9 +18,9 @@ flute =  \relative c'' {
   a, r fis r |
   g r a r |
   \tuplet 3/2 {
-    b d fis  \tripletsHide fis e fis |
-    d g fis   e a g |
-    fis( a) g   fis( a) g |
+    b d fis \tripletsHide fis e fis |
+    d g fis e a g |
+    fis( a) g fis( a) g |
   }
 
   %--Bar 10--%
@@ -33,69 +33,69 @@ flute =  \relative c'' {
   a r b r |
 
   %--Bar 17--%
-  e,8. e16 a8. e16 |  \tripletsShowOnce
+  e,8. e16 a8. e16 | \tripletsShowOnce
   \tuplet 3/2 {
-    fis8 e d   cis d e |
-    a, ( cis) b   a ( cis) b |
+    fis8 e d cis d e |
+    a, ( cis) b a ( cis) b |
   }
-  a2 ~|
-  \tuplet 3/2 { a8 cis b  a( cis) b } |
-  a2~ |
-  a~ |
+  a2 ~ |
+  \tuplet 3/2 { a8 cis b a( cis) b } |
+  a2 ~ |
+  a ~ |
   a |
 
   %--Bar 25--%
-  \tripletsShowOnce \tuplet 3/2 { gis8 a b } cis4~ |
-  \tuplet 3/2 { cis8 fis e } d4~ |
+  \tripletsShowOnce \tuplet 3/2 { gis8 a b } cis4 ~ |
+  \tuplet 3/2 { cis8 fis e } d4 ~ |
   d8. b'16 cis,8. fis16 |
-  \tuplet 3/2 { e8 d cis  b cis d } |
-  \tuplet 3/2 { cis b a } d4~|
-  \tuplet 3/2 { d8 cis b } a8. g16|
-  \tripletsShowOnce \tuplet 3/2 { fis8 e d } a' r|
-  R2|
+  \tuplet 3/2 { e8 d cis b cis d } |
+  \tuplet 3/2 { cis b a } d4 ~ |
+  \tuplet 3/2 { d8 cis b } a8. g16 |
+  \tripletsShowOnce \tuplet 3/2 { fis8 e d } a' r |
+  R2 |
 
   %--Bar 33--%
   r8 r16 a' d8. a16 |
-  \tuplet 3/2 { b8 a g   fis g a } |
+  \tuplet 3/2 { b8 a g fis g a } |
   d, r cis r |
   d r e r |
-  \tuplet 3/2 { d fis a   a g a } |
-  \tuplet 3/2 { fis b a   gis cis b } |
+  \tuplet 3/2 { d fis a a g a } |
+  \tuplet 3/2 { fis b a gis cis b } |
   a4 ~ \tuplet 3/2 { a8 b cis } |
-  \tuplet 3/2 { d cis b   a b g } |
+  \tuplet 3/2 { d cis b a b g } |
 
   %--Bar 41--%
   fis r g r |
   a r c, r |
   b r cis! r |
-  d r \tuplet 3/2 { a( cis  e) } |
-  \tuplet 3/2 {  a,( d  fis) cis( e  g) } |
+  d r \tuplet 3/2 { a( cis e) } |
+  \tuplet 3/2 { a,( d fis) cis( e g) } |
   a r b r |
 
   %--Bar 47--%
   a r g r |
   g r \tuplet 3/2 { fis g a } |
-  d,4 ~  \tripletsShowOnce \tuplet 3/2 { d8 e cis } |
+  d,4 ~ \tripletsShowOnce \tuplet 3/2 { d8 e cis } |
   \autoBeamOff d8. \autoBeamOn a'16 d8. a16 | % check beaming []
   \tuplet 3/2 {
-    b8 a g  fis g a |
+    b8 a g fis g a |
     d, fis e d fis e |
   }
-  d2~ |
+  d2 ~ |
 
 
   %--Bar 54--%
   \tuplet 3/2 { d8 \noBeam a' g fis a g } |
   fis2 |
-  e ~|
-  e ~|
-  e4 ~  \tripletsShow \tuplet 3/2 { e8 fis e } |
-  d4 ~   \tuplet 3/2 { d8 e d } |
-  cis4   \tuplet 3/2 { c8 d c } |
+  e ~ |
+  e ~ |
+  e4 ~ \tripletsShow \tuplet 3/2 { e8 fis e } |
+  d4 ~ \tuplet 3/2 { d8 e d } |
+  cis4 \tuplet 3/2 { c8 d c } |
 
   %--Bar 61--%
-  b4 g'~|
-  \tuplet 3/2 { g8 cis, e fis g a } |  \tripletsHide
+  b4 g' ~ |
+  \tuplet 3/2 { g8 cis, e fis g a } | \tripletsHide
   d,8. e16 cis8. d16 |
   d4 c |
   b a |
@@ -104,9 +104,9 @@ flute =  \relative c'' {
 
   %--Bar 68--%
   \tuplet 3/2 { d8 \noBeam fis e d fis e } |
-  d2~ |
+  d2 ~ |
   \tuplet 3/2 { d8 \noBeam b cis d b cis } |
-  d4~ d8. e16 |
+  d4 ~ d8. e16 |
   cis2 |
   d |
   e |
@@ -116,12 +116,12 @@ flute =  \relative c'' {
   \tripletsShowOnce \tuplet 3/2 { b8( a) g fis(g) a } |
   d,8. e16 cis8. d16 |
   d2 |
-  r8 r16 fis -\cantabileB b8. fis16 | % \markup {  }
+  r8 r16 fis -\cantabileB b8. fis16 | % \markup { }
   g2 ~ |
   g8. g16 \tuplet 3/2 { a8( fis) g } |
-  fis2~ |
-  fis8. fis16 b8. g16|
-  e2~ |
+  fis2 ~ |
+  fis8. fis16 b8. g16 |
+  e2 ~ |
 
   %--Bar 85-%
   \tuplet 3/2 {
@@ -131,8 +131,8 @@ flute =  \relative c'' {
     ais cis fis e d cis | \tripletsShowOnce
     b ^\piano (d fis) fis -\cantabileB ( e fis) |
     b,( d fis) fis( e fis) |
-    b,( dis e)  e( dis e) |
-    ais,( cis e)  e( d! e) |
+    b,( dis e) e( dis e) |
+    ais,( cis e) e( d! e) |
   }
 
   %--Bar 93-%
@@ -142,20 +142,20 @@ flute =  \relative c'' {
     ais,( fis) e' d(e) cis |
   }
   b r b r |
-  cis r \tuplet 3/2{ b( a) b }|
-  \tuplet 3/2{
-    cis(b) a gis(fis)eis|
+  cis r \tuplet 3/2 { b( a) b } |
+  \tuplet 3/2 {
+    cis(b) a gis(fis)eis |
     fis( cis' fis) fis( e fis) | %99
-    a,( cis fis)  fis (eis fis) |% 100
+    a,( cis fis) fis (eis fis) | % 100
   }
 
   %101
   \tuplet 3/2 {
     b,( cis d) b( cis a) |
-    gis( b eis)  eis( dis eis) |
-    a,( cis fis)  fis( eis fis) |
-    d!( b gis )  eis( gis fis) |
-    eis ( gis) fis  eis( fis) gis |
+    gis( b eis) eis( dis eis) |
+    a,( cis fis) fis( eis fis) |
+    d!( b gis ) eis( gis fis) |
+    eis ( gis) fis eis( fis) gis |
   }
   a r r4 |
   \tuplet 3/2 { r8 a-\forte b cis e d } |
@@ -166,30 +166,30 @@ flute =  \relative c'' {
   d2-\trill |
   cis-\trill |
   b ~ |
-  \tuplet 3/2 { b8 \noBeam gis a  b( gis) a }
+  \tuplet 3/2 { b8 \noBeam gis a b( gis) a }
   b2 |
   a4 a' ~ |
-  a gis~ |
+  a gis ~ |
   gis cis ~ |
   cis b8. a16 |
 
   %119
-  gis2 ~|
+  gis2 ~ |
   gis4 fis8. e16 |
   d2 ~ |
-  d4 cis 8. b16|
+  d4 cis 8. b16 |
   ais4 r |
   r8 r16 fis' cis'8. gis16 |
-  \tuplet 3/2 { a8( gis) fis  eis( fis) gis }|
-  cis,4 fis4~ |
+  \tuplet 3/2 { a8( gis) fis eis( fis) gis } |
+  cis,4 fis4 ~ |
   %127
   fis8. gis16 eis8. fis16 |
   fis2 ~ |
   fis |
   r8 r16 fis b8. fis16 |
   \tuplet 3/2 {
-    g!8( fis) e  dis( e) fis|
-    b,( e) g  b( a) b |
+    g!8( fis) e dis( e) fis |
+    b,( e) g b( a) b |
     e,(d) a
   } d4 ~ |
   \tuplet 3/2 { d8 cis e } a8. e16 |
@@ -202,7 +202,7 @@ flute =  \relative c'' {
   fis8. \tuplet 3/2 { e32 d cis b8 d gis } |
   gis8. \tuplet 3/2 { fis32 e d cis8 e a } |
   a8. \tuplet 3/2 { gis32 fis e d8 fis b } |
-  \tuplet 3/2 { e, fis gis } a4~ |
+  \tuplet 3/2 { e, fis gis } a4 ~ |
 
   %143
   a2 ~ |
@@ -213,7 +213,7 @@ flute =  \relative c'' {
   } a8. d,16 |
   cis8 r b-\trill r |
   \tuplet 3/2 {
-    a-\piano( cis e) e( d e)|
+    a-\piano( cis e) e( d e) |
     a,( cis e) e( d e) |
     a,( cis d) d( cis d) |
 
@@ -221,7 +221,7 @@ flute =  \relative c'' {
     gis,( b d) d( cis d) |
     a( cis e) e( d e) |
     b( d fis) fis( e fis) |
-    gis,( e) d'  cis( d) b |
+    gis,( e) d' cis( d) b |
   }
   a r r4 |
   R2 |
@@ -248,7 +248,7 @@ flute =  \relative c'' {
   R2 * 5 |
 
   %189
-  \tuplet 3/2 { e'8-\piano ( cis) d  e( cis) d } |
+  \tuplet 3/2 { e'8-\piano ( cis) d e( cis) d } |
   e2 ~ |
   \tuplet 3/2 { e8 \noBeam g fis e( g) fis } |
   e r r4 |
@@ -266,13 +266,13 @@ flute =  \relative c'' {
   %202
 
   \tuplet 3/2 { cis8 b a b cis d } |
-  eis,4  e~ |
+  eis,4 e ~ |
   \tuplet 3/2 { e8 d cis d e fis } |
   cis4 c ~ |
-  \tuplet 3/2 { c8 b a g fis e  } |
+  \tuplet 3/2 { c8 b a g fis e } |
   fis2 ~ |
   \tuplet 3/2 { fis8 e fis g a b } |
-  c2~ |
+  c2 ~ |
   \tuplet 3/2 { c8 b c d e fis } |
 
   %211
@@ -294,7 +294,7 @@ flute =  \relative c'' {
   \tuplet 3/2 { d( e fis) } e4 ~ |
   e8. d16 cis4 ~ |
   \tuplet 3/2 { cis8 ais b } fis'8. cis16 |
-  \tuplet 3/2 { d8( cis)b ais(b) cis  } |
+  \tuplet 3/2 { d8( cis)b ais(b) cis } |
   fis,4 b ~ |
   b cis ~ |
   cis d ~ |
@@ -305,8 +305,8 @@ flute =  \relative c'' {
   b4 r |
 
   %233
-  R2|
-  R2|
+  R2 |
+  R2 |
   r8 r16 d a'8. e16 | \tripletsShowOnce
   \tuplet 3/2 { fis8 e d } \tuplet 3/2 { cis d e } |
 
@@ -315,9 +315,9 @@ flute =  \relative c'' {
   g r a r |
   \tuplet 3/2 {
     \tripletsShowOnce
-    b d fis   fis e fis |
-    d g fis   e a g |
-    fis( a) g   fis( a) g |
+    b d fis fis e fis |
+    d g fis e a g |
+    fis( a) g fis( a) g |
   }
 
   %--Bar 10--%
@@ -330,43 +330,43 @@ flute =  \relative c'' {
   a r b r |
 
   %--Bar 17--%
-  e,8. e16 a8. e16|
+  e,8. e16 a8. e16 |
   \tripletsShowOnce \tuplet 3/2 {
-    fis8 e d   cis d e |
-    a, ( cis) b   a ( cis) b |
+    fis8 e d cis d e |
+    a, ( cis) b a ( cis) b |
   }
-  a2 ~|
-  \tuplet 3/2 { a8 cis b  a( cis) b } |
-  a2~ |
-  a~ |
+  a2 ~ |
+  \tuplet 3/2 { a8 cis b a( cis) b } |
+  a2 ~ |
+  a ~ |
   a |
 
   %--Bar 25--%
-  \tripletsShowOnce \tuplet 3/2 { gis8 a b } cis4~ |
-  \tuplet 3/2 { cis8 fis e } d4~ |
+  \tripletsShowOnce \tuplet 3/2 { gis8 a b } cis4 ~ |
+  \tuplet 3/2 { cis8 fis e } d4 ~ |
   d8. b'16 cis,8. fis16 |
-  \tuplet 3/2 { e8 d cis  b cis d } |
-  \tuplet 3/2 { cis b a } d4~|
-  \tuplet 3/2 { d8 cis b } a8. g16|
-  \tuplet 3/2 { fis8 e d } a' r|
-  R2|
+  \tuplet 3/2 { e8 d cis b cis d } |
+  \tuplet 3/2 { cis b a } d4 ~ |
+  \tuplet 3/2 { d8 cis b } a8. g16 |
+  \tuplet 3/2 { fis8 e d } a' r |
+  R2 |
 
   %--Bar 265 --%
   r8 r16 a' d8. a16 |
-  \tuplet 3/2 { b8 a g   fis g a } |
+  \tuplet 3/2 { b8 a g fis g a } |
   d, r cis r |
   d r e r |
-  \tuplet 3/2 { d fis a   a g a } |
-  \tuplet 3/2 { fis b a   gis cis b } |
+  \tuplet 3/2 { d fis a a g a } |
+  \tuplet 3/2 { fis b a gis cis b } |
   a4 ~ \tuplet 3/2 { a8 b cis } |
-  \tuplet 3/2 { d cis b   a b g } |
+  \tuplet 3/2 { d cis b a b g } |
 
   %--Bar 273--%
   fis r g r |
   a r c, r |
   b r cis! r |
-  d r \tuplet 3/2 { a( cis  e) } |
-  \tuplet 3/2 {  a,( d  fis) cis( e  g) } |
+  d r \tuplet 3/2 { a( cis e) } |
+  \tuplet 3/2 { a,( d fis) cis( e g) } |
   a r b r |
 
   %--Bar 279--%
@@ -375,23 +375,23 @@ flute =  \relative c'' {
   d,4 ~ \tripletsShowOnce \tuplet 3/2 { d8 \noBeam e cis } |
   \autoBeamOff d8. \autoBeamOn a'16 d8. a16 | % check beaming []
   \tuplet 3/2 {
-    b8 a g  fis g a |
+    b8 a g fis g a |
     d, fis e d fis e |
   }
-  d2~ |
+  d2 ~ |
 
 
   %--Bar 286--%
   \tuplet 3/2 { d8 \noBeam a' g fis a g } |
   fis2 |
-  e ~|
-  e ~|
+  e ~ |
+  e ~ |
   e4 ~ \tripletsShow \tuplet 3/2 { e8 \noBeam fis e } |
   d4 ~ \tuplet 3/2 { d8 e d } |
   cis4 \tuplet 3/2 { c8 d c } |
 
   %--Bar 293--%
-  b4 g'~|
+  b4 g' ~ |
   \tuplet 3/2 { g8 cis, e fis g a } | \tripletsHide
   d,8. e16 cis8. d16 |
   d4 c |
@@ -401,9 +401,9 @@ flute =  \relative c'' {
 
   %--Bar 300--%
   \tuplet 3/2 { d8 \noBeam fis e d fis e } |
-  d2~ |
+  d2 ~ |
   \tuplet 3/2 { d8 \noBeam b cis d b cis } |
-  d4~ d8. e16 |
+  d4 ~ d8. e16 |
   cis2 |
   d |
   e |

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/flute.ly
@@ -1,5 +1,5 @@
-\include "header.ly"
 \version "2.18.0"
+\include "header.ly"
 
 flute = \relative c'' {
   \clef treble

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord-score.ly
@@ -1,9 +1,12 @@
 \version "2.18.0"
-
 \include "harpsichord.ly"
 
+\header {
+  instrument = "Cembalo concertato"
+}
+
 \score {
-  \harpsichordTa
+  \harpsichordStaff
   \midi {}
   \layout {}
 }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord-score.ly
@@ -1,15 +1,9 @@
 \version "2.18.0"
+
 \include "harpsichord.ly"
 
-\score
-{
-  %
+\score {
   \harpsichordTa
   \midi {}
-  \layout
-  {
-  }
-  \header
-  {
-  }
+  \layout {}
 }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord-score.ly
@@ -1,15 +1,15 @@
 \version "2.18.0"
 \include "harpsichord.ly"
 
-\score 
+\score
 {
-	% 
-	\harpsichordTa
-	\midi {}
- 	\layout 
-	{
-	}
-	\header
-	{
-	}
+  %
+  \harpsichordTa
+  \midi {}
+  \layout
+  {
+  }
+  \header
+  {
+  }
 }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord-score.ly
@@ -1,4 +1,4 @@
-\version "2.4.0"
+\version "2.18.0"
 \include "harpsichord.ly"
 
 \score 

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord.ly
@@ -2,637 +2,335 @@
 
 \include "header.ly"
 
-harpsichordTrebleI = \relative c'' {
-  % --Bar 11-- %
-  r8 r16 d a'8. e16 |
-  \tuplet 3/2 { 
-    fis8 e d cis d e |
-    a, cis b a b cis |
-    fis, b a gis cis b |
-    a16 gis a b cis d e fis e d cis b |
-    a cis b a gis fis e fis e d cis b |
-  }
-  % --Bar 17-- %
-  \change Staff = harpsichordDown
-  \once \voiceOne 
-  a8 
-  \change Staff = harpsichordUp 
-  r a' r |
-  a r \voiceOne gis r |
-  a2 \trill ~ |
-  \tuplet 3/2 { a8 \noBeam cis b a gis! fis | }
-  e2 \trill ~ |
-  \tuplet 3/2 {
-    e8 \noBeam cis d e d e |
-    fis a gis fis a gis |
-    fis dis! e fis e fis |
-  }
-  gis r <e' cis b> r |
-  \oneVoice
-  % --Bar 26-- %
-  <a, cis e > r < fis b d> r |
-  <gis b d > r
-  <<
-    { cis8. d16 | e8. fis16 } \\
-    { a,4 ~ | a }
-  >>
-  b8. a16 |
-  a8 r s^"accomp." s
-  % --Bar 30
-  s2*8 |
-  % --Bar 38-- %
-  R2 |
-  R2 |
-  r8 r16 d a'8. e16 |
-
-  % --Bar 41-- %
-  \tuplet 3/2 {
-    fis8 e d cis d e |
-    a,16 fis g a b cis d e d cis b a |
-    b d cis b a g fis e fis g a fis |
-    d cis d e fis g a b a g fis e |
-    fis a g fis e d cis b cis d e cis |
-    a d e fis e d b e fis g fis e |
-  }
-
-  % --Bar 47-- %
-  \tuplet 3/2 {
-    cis16 fis g a g fis d g a b a g |
-    e g a b a g fis g a b cis a |
-    d8 cis b a b g |
-  }
-  fis r d' r |
-  d r cis r |
-  d2-\trill ~
-  \tuplet 3/2 { d8 \noBeam fis e d cis b }
-
-  % --Bar 54- %
-  a2-\trill ~ |
-  \tuplet 3/2 {
-    a8 \noBeam fis g a g a |
-    b d cis b d cis |
-    b gis a b a b |
-  }
-  \voiceOne
-  cis r \tuplet 3/2 { r16 g' fis e d cis | }
-  d8 r \tuplet 3/2 { r16 fis e d cis b| }
-  cis8 r \tuplet 3/2 { r16 e d c b a | }
-  \tuplet 3/2 { b c b a g fis } r8 r16 <e g b> | %<c e g> or <g e c>?
-  \oneVoice
-  <e g a cis>8 r <fis a d> r |
-  <fis b d>8. <e b' d>16 <e a cis>8. <e g cis>16 |
-  <d fis a d>8 r ^"accomp." r4 |
-  s2*2 |
-  r8 r16 g d'8. a16 |
-
-  % --Bar 68- %
-  b2-\trill ~ |
-  \tuplet 3/2 { b8 \noBeam d cis b d cis | }
-  b2^\trillB ~ |
-  \tuplet 3/2 {
-    b8 \noBeam d cis b a gis |
-    cis e d cis b a |
-    d fis e d cis b |
-    e g fis e d cis |
-  }
-  fis8 r s4 ^"accomp." | 
-}
-
-harpsichordTrebleII = \relative c'' {
-
-  % --Bar 76- %
-  s2*3 |
-  \tuplet 3/2 {
-    fis,8-\pianoB( b d) d( cis d) |
-    fis,( b d) d( cis d) |
-    g,!( ais b) cis( ais b) |
-    e,( ais cis) cis( b cis) |
-    fis,( b d) d( cis d) |
-    e,( g cis) cis( ais b)
-
-    %85
-    cis( ais) b( fis b) ais |
-  }
-  b8 r r4 |
-  s2*2 |
-  \tuplet 3/2 {
-    b8(-\pianoB fis' b) b( ais b) |
-    d,( fis b) b( ais b) |
-    e,( fis g) e( fis d) |
-    cis( e ais) ais( gis ais) |
-  }
-
-  %93
-  \tuplet 3/2 {
-    d,8( fis b) b( ais b) |
-    g!( e cis) ais( cis b) |
-    ais( cis) b ais( b) cis |
-  }
-  d r r4 |
-  s2*2 |
-
-  r8 r16 cis_\cantabileB fis8. cis16 |
-  d2 ~ |
-
-  %101
-  d8. d16 \tuplet 3/2 { e8( cis) d | }
-  cis2 ~ |
-  cis8. cis16 fis8. d16 |
-  b2-\trill ~ |
-  \tuplet 3/2 {
-    b8 cis d cis d b |
-    a \noBeam fis_\forteI gis a cis b |
-  }
-  cis r r4 |
-  \tuplet 3/2 { r8 e, fis gis b a | }
-  b r r4 |
-
-  %110
-  \tuplet 3/2 {
-    r8 d, e fis a gis |
-    a cis, dis eis gis fis |
-    gis b a gis b a |
-  }
-  gis2-\trill ~ |
-  \tuplet 3/2 {
-    gis!8 \noBeam eis fis gis fis gis |
-    a fis gis a gis a |
-    b gis a b ais b |
-    cis a b cis b cis |
-    d b cis d cis d |
-
-    %119
-    gis, b a gis fis gis |
-    a a, b cis b cis |
-    d b cis d cis d |
-    gis, a b
-  } cis4 ~ |
-  \tuplet 3/2 { cis8 d e } fis4 ~ |
-  fis8. fis16 \tuplet 3/2 { eis8 fis gis | }
-  cis,8. cis'16 \tuplet 3/2 { b8 cis d | }
-  eis,8.-\trill dis32 eis \tuplet 3/2 { fis8 gis a | }
-
-  %127
-  \tuplet 3/2 {
-    b cis d cis d b |
-    a gis fis
-  } r4^"accomp" |
-  s2 * 19 |
-
-  %148
-  \tuplet 3/2 {
-    cis'8_\pianoB( e a) a( gis a) |
-    cis,( e a) a( gis a) |
-    d,( e fis) d( e cis) |
-
-    %151
-    b( d gis) gis( fis gis) |
-    cis,( e a) a( gis a) |
-    fis( d b) gis( b a) |
-    gis( b) a gis( a) b |
-    cis \noBeam a_\forteI b cis e d |
-    e cis d e g fis |
-  }
-  g2-\trill ~ |
-  g |
-
-  %159
-  \tuplet 3/2 {
-    g8 \noBeam g, a b d cis |
-    d b cis d fis e |
-  }
-  fis2-\trill ~ |
-  fis ~ |
-  fis8. \noBeam fis16 b8. fis16 |
-  \stemUp \tuplet 3/2 { g8 fis e d e fis | }
-  b,8. fis16 \tuplet 3/2 {
-    b8 d cis |
-    \stemNeutral d b cis d fis e |
-  }
-  fis8. b,16 fis'8. cis16 |
-
-  %168
-  \tuplet 3/2 { d8 cis b ais b cis | }
-  fis,4 e' ~ |
-  \tuplet 3/2 {
-    e8 d cis b cis ais |
-    g' fis e d e cis |
-  }
-  b8. fis16 b8. fis16 |
-  \tuplet 3/2 { g8 fis e d e fis | }
-  b,8. fis16 \tuplet 3/2 {
-    b8 d cis |
-    d b cis d fis e |
-    fis d e fis a gis |
-  }
-
-  %177
-  a2-\trill ~ |
-  \tuplet 3/2 { a8 \noBeam c b a g fis | }
-  g2-\trill ~ |
-  \tuplet 3/2 { g8 \noBeam b a g fis e | }
-  fis2^\trillB ~ |
-  fis |
-  \tuplet 3/2 {
-    fis8 \noBeam d e fis a g |
-    a fis g a cis b
-  | }
-  cis2-\trill ~ |
-
-  %186
-  cis ~ |
-  \tuplet 3/2 {
-    cis8 \noBeam a b cis e d |
-    e cis d e g fis |
-  }
-  g2-\trill ~ |
-  \tuplet 3/2 { g8 \noBeam e fis g e fis | }
-  g2-\trill ~ |
-  \tuplet 3/2 {
-    g8 b a g fis e |
-    fis a g fis e d |
-    e g fis e d cis |
-  }
-
-  %195
-  \tuplet 3/2 {
-    d fis e d cis b |
-    cis e d cis d cis |
-    b a b cis d16 cis b a |
-  }
-  gis8. fis16 \tuplet 3/2 { eis8 gis b | }
-  \tuplet 3/2 {
-    a cis b a cis fis |
-    b, d cis b fis' eis |
-    fis a, b cis d e |
-    d fis e d fis b |
-
-    %203
-    gis eis fis
-  } g4 ~ |
-  \tuplet 3/2 {
-    g8 fis e! d cis b |
-    cis fis e dis e fis |
-    b, e fis g a b |
-    c! dis, e b e dis |
-    e b a g fis g |
-    e a g fis g a |
-    d, g a b c a |
-
-    %211
-    g a b
-  } e,8. e'16 |
-  \tuplet 3/2 { a8 d, c b a g | }
-  a4 ~ \tuplet 3/2 { a16 g fis e dis e | }
-  \tuplet 3/2 {
-    fis8 b a g fis e |
-    fis b ais b fis' ais, |
-  }
-  b r r4 |
-  r8 r16 cis \tuplet 3/2 { fis8( ais,) b | }
-  cis8. fis,16 \tuplet 3/2 { b8 gis eis | }
-
-  %219
-  fis8. cis16 \tuplet 3/2 { d8 \change Staff = harpsichordDown ais b | }
-  \change Staff = harpsichordUp \oneVoice
-  s2*2 |
-  s2^"accomp." |
-  s2*2 |
-  \tuplet 3/2 {
-    r8 d e fis gis a |
-    gis e fis gis ais b |
-
-    %227
-    ais fis gis ais b cis |
-    b gis a! b cis d |
-    cis ais b cis d e |
-    fis( d) b fis'( d) b |
-    fis'( d) b fis( b ais) |
-  }
-  b4 r |
-  << { \voiceOne d } \new Voice { \voiceThree <d, fis a> } >> \oneVoice r |
-}
-
 harpsichordTreble = \relative c'' {
   \omit TupletNumber
-  
+
   \time 2/4
   \clef treble
   \key d \major
-  
+
   % --Bar 1-- %
   R2*10 |
-  \harpsichordTrebleI
-  \harpsichordTrebleII
-  R2*9 |
-  \harpsichordTrebleI
-  s2*3 |
+  \repeat unfold 2 {
+    % --Bar 11-- %
+    r8 r16 d a'8. e16 |
+    \tuplet 3/2 {
+      fis8 e d cis d e |
+      a, cis b a b cis |
+      fis, b a gis cis b |
+      a16 gis a b cis d e fis e d cis b |
+      a cis b a gis fis e fis e d cis b |
+    }
+    % --Bar 17-- %
+    \change Staff = harpsichordDown
+    \once \voiceOne
+    a8
+    \change Staff = harpsichordUp
+    r a' r |
+    a r \voiceOne gis r |
+    a2 \trill ~ |
+    \tuplet 3/2 { a8 \noBeam cis b a gis! fis | }
+    e2 \trill ~ |
+    \tuplet 3/2 {
+      e8 \noBeam cis d e d e |
+      fis a gis fis a gis |
+      fis dis! e fis e fis |
+    }
+    gis r <e' cis b> r |
+    \oneVoice
+    % --Bar 26-- %
+    <a, cis e > r < fis b d> r |
+    <gis b d > r
+    <<
+      { cis8. d16 | e8. fis16 } \\
+      { a,4 ~ | a }
+    >>
+    b8. a16 |
+    a8 r s^"accomp." s
+    % --Bar 30
+    s2*8 |
+    % --Bar 38-- %
+    R2 |
+    R2 |
+    r8 r16 d a'8. e16 |
+
+    % --Bar 41-- %
+    \tuplet 3/2 {
+      fis8 e d cis d e |
+      a,16 fis g a b cis d e d cis b a |
+      b d cis b a g fis e fis g a fis |
+      d cis d e fis g a b a g fis e |
+      fis a g fis e d cis b cis d e cis |
+      a d e fis e d b e fis g fis e |
+    }
+
+    % --Bar 47-- %
+    \tuplet 3/2 {
+      cis16 fis g a g fis d g a b a g |
+      e g a b a g fis g a b cis a |
+      d8 cis b a b g |
+    }
+    fis r d' r |
+    d r cis r |
+    d2-\trill ~
+    \tuplet 3/2 { d8 \noBeam fis e d cis b }
+
+    % --Bar 54- %
+    a2-\trill ~ |
+    \tuplet 3/2 {
+      a8 \noBeam fis g a g a |
+      b d cis b d cis |
+      b gis a b a b |
+    }
+    \voiceOne
+    cis r \tuplet 3/2 { r16 g' fis e d cis | }
+    d8 r \tuplet 3/2 { r16 fis e d cis b| }
+    cis8 r \tuplet 3/2 { r16 e d c b a | }
+    \tuplet 3/2 { b c b a g fis } r8 r16 <e g b> | %<c e g> or <g e c>?
+    \oneVoice
+    <e g a cis>8 r <fis a d> r |
+    <fis b d>8. <e b' d>16 <e a cis>8. <e g cis>16 |
+    <d fis a d>8 r ^"accomp." r4 |
+    s2*2 |
+    r8 r16 g d'8. a16 |
+
+    % --Bar 68- %
+    b2-\trill ~ |
+    \tuplet 3/2 { b8 \noBeam d cis b d cis | }
+    b2^\trillB ~ |
+    \tuplet 3/2 {
+      b8 \noBeam d cis b a gis |
+      cis e d cis b a |
+      d fis e d cis b |
+      e g fis e d cis |
+    }
+    fis8 r s4 ^"accomp." |
+  }
+
+  \alternative {
+    {
+
+      % --Bar 76- %
+      s2*3 |
+      \tuplet 3/2 {
+        fis,8-\pianoB( b d) d( cis d) |
+        fis,( b d) d( cis d) |
+        g,!( ais b) cis( ais b) |
+        e,( ais cis) cis( b cis) |
+        fis,( b d) d( cis d) |
+        e,( g cis) cis( ais b)
+
+        %85
+        cis( ais) b( fis b) ais |
+      }
+      b8 r r4 |
+      s2*2 |
+      \tuplet 3/2 {
+        b8(-\pianoB fis' b) b( ais b) |
+        d,( fis b) b( ais b) |
+        e,( fis g) e( fis d) |
+        cis( e ais) ais( gis ais) |
+      }
+
+      %93
+      \tuplet 3/2 {
+        d,8( fis b) b( ais b) |
+        g!( e cis) ais( cis b) |
+        ais( cis) b ais( b) cis |
+      }
+      d r r4 |
+      s2*2 |
+
+      r8 r16 cis_\cantabileB fis8. cis16 |
+      d2 ~ |
+
+      %101
+      d8. d16 \tuplet 3/2 { e8( cis) d | }
+      cis2 ~ |
+      cis8. cis16 fis8. d16 |
+      b2-\trill ~ |
+      \tuplet 3/2 {
+        b8 cis d cis d b |
+        a \noBeam fis_\forteI gis a cis b |
+      }
+      cis r r4 |
+      \tuplet 3/2 { r8 e, fis gis b a | }
+      b r r4 |
+
+      %110
+      \tuplet 3/2 {
+        r8 d, e fis a gis |
+        a cis, dis eis gis fis |
+        gis b a gis b a |
+      }
+      gis2-\trill ~ |
+      \tuplet 3/2 {
+        gis!8 \noBeam eis fis gis fis gis |
+        a fis gis a gis a |
+        b gis a b ais b |
+        cis a b cis b cis |
+        d b cis d cis d |
+
+        %119
+        gis, b a gis fis gis |
+        a a, b cis b cis |
+        d b cis d cis d |
+        gis, a b
+      } cis4 ~ |
+      \tuplet 3/2 { cis8 d e } fis4 ~ |
+      fis8. fis16 \tuplet 3/2 { eis8 fis gis | }
+      cis,8. cis'16 \tuplet 3/2 { b8 cis d | }
+      eis,8.-\trill dis32 eis \tuplet 3/2 { fis8 gis a | }
+
+      %127
+      \tuplet 3/2 {
+        b cis d cis d b |
+        a gis fis
+      } r4^"accomp" |
+      s2 * 19 |
+
+      %148
+      \tuplet 3/2 {
+        cis'8_\pianoB( e a) a( gis a) |
+        cis,( e a) a( gis a) |
+        d,( e fis) d( e cis) |
+
+        %151
+        b( d gis) gis( fis gis) |
+        cis,( e a) a( gis a) |
+        fis( d b) gis( b a) |
+        gis( b) a gis( a) b |
+        cis \noBeam a_\forteI b cis e d |
+        e cis d e g fis |
+      }
+      g2-\trill ~ |
+      g |
+
+      %159
+      \tuplet 3/2 {
+        g8 \noBeam g, a b d cis |
+        d b cis d fis e |
+      }
+      fis2-\trill ~ |
+      fis ~ |
+      fis8. \noBeam fis16 b8. fis16 |
+      \stemUp \tuplet 3/2 { g8 fis e d e fis | }
+      b,8. fis16 \tuplet 3/2 {
+        b8 d cis |
+        \stemNeutral d b cis d fis e |
+      }
+      fis8. b,16 fis'8. cis16 |
+
+      %168
+      \tuplet 3/2 { d8 cis b ais b cis | }
+      fis,4 e' ~ |
+      \tuplet 3/2 {
+        e8 d cis b cis ais |
+        g' fis e d e cis |
+      }
+      b8. fis16 b8. fis16 |
+      \tuplet 3/2 { g8 fis e d e fis | }
+      b,8. fis16 \tuplet 3/2 {
+        b8 d cis |
+        d b cis d fis e |
+        fis d e fis a gis |
+      }
+
+      %177
+      a2-\trill ~ |
+      \tuplet 3/2 { a8 \noBeam c b a g fis | }
+      g2-\trill ~ |
+      \tuplet 3/2 { g8 \noBeam b a g fis e | }
+      fis2^\trillB ~ |
+      fis |
+      \tuplet 3/2 {
+        fis8 \noBeam d e fis a g |
+        a fis g a cis b
+        |
+      }
+      cis2-\trill ~ |
+
+      %186
+      cis ~ |
+      \tuplet 3/2 {
+        cis8 \noBeam a b cis e d |
+        e cis d e g fis |
+      }
+      g2-\trill ~ |
+      \tuplet 3/2 { g8 \noBeam e fis g e fis | }
+      g2-\trill ~ |
+      \tuplet 3/2 {
+        g8 b a g fis e |
+        fis a g fis e d |
+        e g fis e d cis |
+      }
+
+      %195
+      \tuplet 3/2 {
+        d fis e d cis b |
+        cis e d cis d cis |
+        b a b cis d16 cis b a |
+      }
+      gis8. fis16 \tuplet 3/2 { eis8 gis b | }
+      \tuplet 3/2 {
+        a cis b a cis fis |
+        b, d cis b fis' eis |
+        fis a, b cis d e |
+        d fis e d fis b |
+
+        %203
+        gis eis fis
+      } g4 ~ |
+      \tuplet 3/2 {
+        g8 fis e! d cis b |
+        cis fis e dis e fis |
+        b, e fis g a b |
+        c! dis, e b e dis |
+        e b a g fis g |
+        e a g fis g a |
+        d, g a b c a |
+
+        %211
+        g a b
+      } e,8. e'16 |
+      \tuplet 3/2 { a8 d, c b a g | }
+      a4 ~ \tuplet 3/2 { a16 g fis e dis e | }
+      \tuplet 3/2 {
+        fis8 b a g fis e |
+        fis b ais b fis' ais, |
+      }
+      b r r4 |
+      r8 r16 cis \tuplet 3/2 { fis8( ais,) b | }
+      cis8. fis,16 \tuplet 3/2 { b8 gis eis | }
+
+      %219
+      fis8. cis16 \tuplet 3/2 { d8 \change Staff = harpsichordDown ais b | }
+      \change Staff = harpsichordUp \oneVoice
+      s2*2 |
+      s2^"accomp." |
+      s2*2 |
+      \tuplet 3/2 {
+        r8 d e fis gis a |
+        gis e fis gis ais b |
+
+        %227
+        ais fis gis ais b cis |
+        b gis a! b cis d |
+        cis ais b cis d e |
+        fis( d) b fis'( d) b |
+        fis'( d) b fis( b ais) |
+      }
+      b4 r |
+      << { \voiceOne d } \new Voice { \voiceThree <d, fis a> } >> \oneVoice r |
+      R2*9 |
+    }
+    {
+      s2*3 |
+    }
+
+  }
 } % ~ ~ end harpsichordTreble ~ ~ %
 
-
-harpsichordBassI = \relative c' {
-    % --Bar 9-- %
-  r8 r16 a d8. a16 |
-  \tuplet 3/2 { b8 a g fis g a | }
-  d, r cis r |
-  d r e r |
-  fis r cis r |
-  d r e r |
-  fis r e r |
-  fis r gis r |
-
-
-  % --Bar 17-- %
-  \tuplet 3/2 { a cis b a b cis | }
-  d r \staffUp e r | 
-  fis2_\trill ~ |
-  \tuplet 3/2 { fis8 \noBeam a gis fis e d | }
-  cis2_\trill ~ |
-  \tuplet 3/2 { cis8 \noBeam a b cis b cis | }
-  \tuplet 3/2 { dis fis e dis fis e | }
-  \tuplet 3/2 { dis b cis dis cis dis | }
-  \tuplet 3/2 { e16 d! e fis e d cis d cis \staffDown b a gis | }
-
-  % --Bar 26-- %
-  \tuplet 3/2 {
-    fis e fis gis a fis b cis b a gis fis |
-    e d e fis gis e fis a gis fis e d |
-    cis8 b a
-  } e'8. e,16 |
-  a8 r fis r |
-  g r a r |
-  b r cis r |
-  d r e r |
-
-  % --Bar 33-- %
-  fis r fis r |
-  g r a r |
-  b r a r |
-  b r cis r |
-  d r r4 |
-  R2 |
-  r8 r16 a d8. a16 |
-  \tuplet 3/2 { b8 a g fis g a | }
-
-  % --Bar 41-- %
-  d, r e r |
-  fis r fis, r |
-  g r a r |
-  b r cis r |
-  d r e r |
-  fis r g r |
-
-  % --Bar 47-- %
-  a8 r b r |
-  cis8. \noBeam a16 d8. a16 |
-  \tuplet 3/2 { b8 a g fis g a | }
-  \tuplet 3/2 { d, fis e d e fis | }
-  g r a r |
-  b2-\trill ~ |
-  \tuplet 3/2 { b8 \noBeam d cis b a g | }
-  fis2-\trill ~ |
-  \tuplet 3/2 { fis8 \noBeam d e fis e fis | }
-  \tuplet 3/2 { gis b a gis b a | }
-  \tuplet 3/2 { gis e fis gis fis gis | }
-  \voiceTwo
-  \tuplet 3/2 { a16 cis \staffUp d e fis g! } a8 r \staffDown \stemDown |
-  \tuplet 3/2 { r16 b, cis d \staffUp e fis } g8 r \staffDown \stemDown |
-  \tuplet 3/2 { r16 a, b cis d \staffUp e } fis8 r \staffDown  |
-
-  % --Bar 61-- %
-  g, r \staffUp \tuplet 3/2 { e'16 fis e d cis! \staffDown \once \stemDown b | }
-  \oneVoice
-  \tuplet 3/2 {
-    a b a g fis e d e d cis b a |
-    b8 a g
-  } a8. a16 |
-  d,8 r fis r | % 6 3?
-  g r c r | % <2 4 6>
-  b8. \noBeam g'16 d'8. a16 |
-  \tuplet 3/2 { b8 a g fis gis a | }
-
-  % --Bar 68-- %
-  gis2-\trill ~ |
-  \tuplet 3/2 { gis8 \noBeam b a gis b a | }
-  gis2^\trillB ~ |
-  \tuplet 3/2 {
-    gis8 \noBeam b a gis fis e |
-    a cis b a g! fis |
-    b d cis b a g |
-    cis e d cis b a |
-  }
-  d r fis, r |
-  g r a r |
-  \tuplet 3/2 { b a g } a8. a,16 |
-}
-
-harpsichordBassII = \relative c {
-  %78
-  \tuplet 3/2 { d8 fis e d e fis | }
-  b,8 r r4 |
-  %80
-  \repeat unfold 5 { b8 r r4 | }
-
-  %85
-  b8 r r4 |
-  b8. \noBeam fis'16 \tuplet 3/2 {
-    b8 d cis |
-    d cis b ais b cis |
-  }
-  fis,4 ~ \tuplet 3/2 {
-    fis8 g e |
-    d cis b
-  } r4 |
-  %90
-  \repeat unfold 6 { b8 r r4 | }
-  %96
-  b8. \noBeam fis'16 \tuplet 3/2 {
-    b8 a gis |
-    a gis fis eis fis gis |
-  }
-  cis,4 ~ \tuplet 3/2 {
-    cis8 d b |
-    a gis fis
-  } r4 |
-  %100
-  \repeat unfold 6 { fis8 r r4 | }
-  %106
-  fis8.\noBeam cis'16 \tuplet 3/2 { fis8 a gis | }
-  a8 r r4 |
-  %108
-  \tuplet 3/2 { r8 cis, d e gis fis | }
-  gis r r4 |
-  \tuplet 3/2 {
-    r8 b, cis d fis eis |
-    fis a, b cis eis dis |
-    eis gis fis eis gis fis |
-  }
-  eis2-\trill ~ |
-  \tuplet 3/2 {
-    eis!8 \noBeam cis dis eis! dis eis |
-    %115
-    fis d! e! fis e fis |
-    gis e fis gis fis gis |
-    a fis gis a gis a |
-    b gis a b a b |
-    %119
-    eis, gis fis eis dis eis |
-    fis fis, gis a gis a |
-    b gis a b a b |
-  }
-  cis4 ~ \tuplet 3/2 { cis8 d e | }
-  fis4 ~ \tuplet 3/2 {
-    fis8 gis ais |
-    b cis d cis dis eis |
-    fis, gis a gis a b |
-    a b cis
-  } d, r |
-
-  %127
-  b r cis r |
-
-  % --Bar 128 -- %
-  fis, r a r |
-  b r cis r |
-  d r dis r |
-  e r fis r |
-  g r gis r |
-  a r b r |
-  cis r cis, r |
-
-  % --Bar 135 -- %
-  d r e r |
-  fis r fis, r |
-  gis r gis' r |
-  a r a, r |
-  b r b' r |
-  cis r cis, r |
-  d r d' r |
-  d r cis r |
-
-  % --Bar 143 -- %
-  d r e r |
-  \tuplet 3/2 { fis e d cis dis e }
-  dis4 r8 b |
-  e8. d!16 cis8. fis,16 |
-  e8. d16 e8. e,16 |
-  a8 r a' r |
-  \repeat unfold 6 { a, r a ' r | }
-
-  % --Bar 155 -- %
-  \tuplet 3/2 {
-    a, \noBeam cis e a cis b |
-    cis a b cis e dis |
-  }
-  e2-\trill ~ |
-  e2 ~ |
-
-  % --Bar 159 -- %
-  \tuplet 3/2 {
-    e8 \noBeam e, fis g b a |
-    b g a b d cis |
-  }
-  d2-\trill ~ |
-  d2 ~ |
-  d8 r r4 |
-  \staffUp
-  r8 r16 fis b8. fis16 |
-  \tuplet 3/2 { g8 fis e d e fis | }
-  \staffDown
-  b,8. fis16 \tuplet 3/2 { b8 d cis | }
-  \tuplet 3/2 { d b cis d fis e | }
-
-  %168
-  fis8. b,16 fis'8. cis16 |
-  \tuplet 3/2 { d8 cis b ais b cis | }
-  fis,4 e' ~ |
-  \tuplet 3/2 { e8 d cis b cis ais | }
-  \tuplet 3/2 { g' fis e d e cis | }
-  b8. fis16 b8. fis16 |
-  \tuplet 3/2 { g8 fis e d e fis | }
-  b,8. fis16 \tuplet 3/2 { b8 d cis | }
-  \tuplet 3/2 { d b cis d fis eis | }
-
-  %177
-  fis2-\trill ~ |
-  \tuplet 3/2 { fis8 \noBeam a g fis e dis | }
-  e2-\trill ~ |
-  \tuplet 3/2 { e8 \noBeam g fis e d cis | }
-  d2-\trillB ~ |
-  d ~ |
-  \tuplet 3/2 { d8 \noBeam fis, a d fis e | }
-  \tuplet 3/2 { fis d e fis a gis | }
-  a2^\trillB ~ |
-  %186
-  a2 ~ |
-  \tuplet 3/2 {
-    a8 \noBeam cis, e a cis b |
-    cis a b cis e d
-  | }
-  e2-\trill ~
-  \tuplet 3/2 { e8 \noBeam cis d e cis d | }
-  e2-\trill ~ |
-  \tuplet 3/2 {
-    e8 g fis e d cis |
-    d fis e d cis b |
-    cis e d cis b a |
-  %195
-    b d cis b a gis |
-    a cis b a b a |
-    gis a gis fis eis fis |
-    cis eis dis cis dis eis |
-    fis a gis fis eis fis |
-    gis b a gis fis gis |
-    a cis b a gis fis |
-    b d cis b a gis |
-  }
-
-  % --Bar 203 -- %
-  cis8 r cis, r |
-  fis8 r r4 |
-  fis8 r fis, r |
-  g8 r r4 |
-  a8 r b r |
-  e,8 r r4 |
-  a8 r d r |
-  b r g r |
-
-
-  % --Bar 211 -- %
-  \tuplet 3/2 { e fis g a b c | }
-  d, r g r |
-  d' r c r |
-  b2 ~ |
-  b8. \noBeam fis'16 b8. fis16 |
-  g8. fis16 g8. e16 |
-  <fis, fis'>2 ~ |
-  q ~ |
-  q |
-
-  % --Bar 220 -- %
-  <fis fis'>2^\markup { \bold "tasto solo"} ~ |
-  q ~ q8.\noBeam b16 fis'8. a,16 |
-  %should beam down
-  \tuplet 3/2 { b8 a g ais b cis | }
-  fis,4 ~ \tuplet 3/2 { fis8 fis' e | }
-  \tuplet 3/2 {
-    d b cis d e fis |
-    e cis d e fis g |
-  %227
-    fis d e fis g a |
-    g e fis gis a b |
-    a fis gis ais b cis |
-  }
-  b8. g!16 d8. e16 |
-  fis8. e16 fis8. fis,16 |
-  b4 r |
-  %233
-  << 
-    { \voiceOne a' }
-    \new Voice { \voiceThree fis }
-    \new Voice { \voiceTwo d }
-  >> \oneVoice r |
-}
 
 harpsichordBass = \relative c' {
   \omit TupletNumber
@@ -642,98 +340,402 @@ harpsichordBass = \relative c' {
 
   % --Bar 1-- %
   R2*8 |
-  \harpsichordBassI
-  \harpsichordBassII
-  %234
-  R2*7 |
-  %241
-  \harpsichordBassI
-  d,2\fermata \bar "|."
+
+  \repeat unfold 2{
+    r8 r16 a d8. a16 |
+    \tuplet 3/2 { b8 a g fis g a | }
+    d, r cis r |
+    d r e r |
+    fis r cis r |
+    d r e r |
+    fis r e r |
+    fis r gis r |
+
+
+    % --Bar 17-- %
+    \tuplet 3/2 { a cis b a b cis | }
+    d r \staffUp e r |
+    fis2_\trill ~ |
+    \tuplet 3/2 { fis8 \noBeam a gis fis e d | }
+    cis2_\trill ~ |
+    \tuplet 3/2 { cis8 \noBeam a b cis b cis | }
+    \tuplet 3/2 { dis fis e dis fis e | }
+    \tuplet 3/2 { dis b cis dis cis dis | }
+    \tuplet 3/2 { e16 d! e fis e d cis d cis \staffDown b a gis | }
+
+    % --Bar 26-- %
+    \tuplet 3/2 {
+      fis e fis gis a fis b cis b a gis fis |
+      e d e fis gis e fis a gis fis e d |
+      cis8 b a
+    } e'8. e,16 |
+    a8 r fis r |
+    g r a r |
+    b r cis r |
+    d r e r |
+
+    % --Bar 33-- %
+    fis r fis r |
+    g r a r |
+    b r a r |
+    b r cis r |
+    d r r4 |
+    R2 |
+    r8 r16 a d8. a16 |
+    \tuplet 3/2 { b8 a g fis g a | }
+
+    % --Bar 41-- %
+    d, r e r |
+    fis r fis, r |
+    g r a r |
+    b r cis r |
+    d r e r |
+    fis r g r |
+
+    % --Bar 47-- %
+    a8 r b r |
+    cis8. \noBeam a16 d8. a16 |
+    \tuplet 3/2 { b8 a g fis g a | }
+    \tuplet 3/2 { d, fis e d e fis | }
+    g r a r |
+    b2-\trill ~ |
+    \tuplet 3/2 { b8 \noBeam d cis b a g | }
+    fis2-\trill ~ |
+    \tuplet 3/2 { fis8 \noBeam d e fis e fis | }
+    \tuplet 3/2 { gis b a gis b a | }
+    \tuplet 3/2 { gis e fis gis fis gis | }
+    \voiceTwo
+    \tuplet 3/2 { a16 cis \staffUp d e fis g! } a8 r \staffDown \stemDown |
+    \tuplet 3/2 { r16 b, cis d \staffUp e fis } g8 r \staffDown \stemDown |
+    \tuplet 3/2 { r16 a, b cis d \staffUp e } fis8 r \staffDown  |
+
+    % --Bar 61-- %
+    g, r \staffUp \tuplet 3/2 { e'16 fis e d cis! \staffDown \once \stemDown b | }
+    \oneVoice
+    \tuplet 3/2 {
+      a b a g fis e d e d cis b a |
+      b8 a g
+    } a8. a16 |
+    d,8 r fis r | % 6 3?
+    g r c r | % <2 4 6>
+    b8. \noBeam g'16 d'8. a16 |
+    \tuplet 3/2 { b8 a g fis gis a | }
+
+    % --Bar 68-- %
+    gis2-\trill ~ |
+    \tuplet 3/2 { gis8 \noBeam b a gis b a | }
+    gis2^\trillB ~ |
+    \tuplet 3/2 {
+      gis8 \noBeam b a gis fis e |
+      a cis b a g! fis |
+      b d cis b a g |
+      cis e d cis b a |
+    }
+    d r fis, r |
+    g r a r |
+    \tuplet 3/2 { b a g } a8. a,16 |
+  }
+
+  \alternative {
+    {
+      %78
+      \tuplet 3/2 { d8 fis e d e fis | }
+      b,8 r r4 |
+      %80
+      \repeat unfold 5 { b8 r r4 | }
+
+      %85
+      b8 r r4 |
+      b8. \noBeam fis'16 \tuplet 3/2 {
+        b8 d cis |
+        d cis b ais b cis |
+      }
+      fis,4 ~ \tuplet 3/2 {
+        fis8 g e |
+        d cis b
+      } r4 |
+      %90
+      \repeat unfold 6 { b8 r r4 | }
+      %96
+      b8. \noBeam fis'16 \tuplet 3/2 {
+        b8 a gis |
+        a gis fis eis fis gis |
+      }
+      cis,4 ~ \tuplet 3/2 {
+        cis8 d b |
+        a gis fis
+      } r4 |
+      %100
+      \repeat unfold 6 { fis8 r r4 | }
+      %106
+      fis8.\noBeam cis'16 \tuplet 3/2 { fis8 a gis | }
+      a8 r r4 |
+      %108
+      \tuplet 3/2 { r8 cis, d e gis fis | }
+      gis r r4 |
+      \tuplet 3/2 {
+        r8 b, cis d fis eis |
+        fis a, b cis eis dis |
+        eis gis fis eis gis fis |
+      }
+      eis2-\trill ~ |
+      \tuplet 3/2 {
+        eis!8 \noBeam cis dis eis! dis eis |
+        %115
+        fis d! e! fis e fis |
+        gis e fis gis fis gis |
+        a fis gis a gis a |
+        b gis a b a b |
+        %119
+        eis, gis fis eis dis eis |
+        fis fis, gis a gis a |
+        b gis a b a b |
+      }
+      cis4 ~ \tuplet 3/2 { cis8 d e | }
+      fis4 ~ \tuplet 3/2 {
+        fis8 gis ais |
+        b cis d cis dis eis |
+        fis, gis a gis a b |
+        a b cis
+      } d, r |
+
+      %127
+      b r cis r |
+
+      % --Bar 128 -- %
+      fis, r a r |
+      b r cis r |
+      d r dis r |
+      e r fis r |
+      g r gis r |
+      a r b r |
+      cis r cis, r |
+
+      % --Bar 135 -- %
+      d r e r |
+      fis r fis, r |
+      gis r gis' r |
+      a r a, r |
+      b r b' r |
+      cis r cis, r |
+      d r d' r |
+      d r cis r |
+
+      % --Bar 143 -- %
+      d r e r |
+      \tuplet 3/2 { fis e d cis dis e }
+      dis4 r8 b |
+      e8. d!16 cis8. fis,16 |
+      e8. d16 e8. e,16 |
+      a8 r a' r |
+      \repeat unfold 6 { a, r a ' r | }
+
+      % --Bar 155 -- %
+      \tuplet 3/2 {
+        a, \noBeam cis e a cis b |
+        cis a b cis e dis |
+      }
+      e2-\trill ~ |
+      e2 ~ |
+
+      % --Bar 159 -- %
+      \tuplet 3/2 {
+        e8 \noBeam e, fis g b a |
+        b g a b d cis |
+      }
+      d2-\trill ~ |
+      d2 ~ |
+      d8 r r4 |
+      \staffUp
+      r8 r16 fis b8. fis16 |
+      \tuplet 3/2 { g8 fis e d e fis | }
+      \staffDown
+      b,8. fis16 \tuplet 3/2 { b8 d cis | }
+      \tuplet 3/2 { d b cis d fis e | }
+
+      %168
+      fis8. b,16 fis'8. cis16 |
+      \tuplet 3/2 { d8 cis b ais b cis | }
+      fis,4 e' ~ |
+      \tuplet 3/2 { e8 d cis b cis ais | }
+      \tuplet 3/2 { g' fis e d e cis | }
+      b8. fis16 b8. fis16 |
+      \tuplet 3/2 { g8 fis e d e fis | }
+      b,8. fis16 \tuplet 3/2 { b8 d cis | }
+      \tuplet 3/2 { d b cis d fis eis | }
+
+      %177
+      fis2-\trill ~ |
+      \tuplet 3/2 { fis8 \noBeam a g fis e dis | }
+      e2-\trill ~ |
+      \tuplet 3/2 { e8 \noBeam g fis e d cis | }
+      d2-\trillB ~ |
+      d ~ |
+      \tuplet 3/2 { d8 \noBeam fis, a d fis e | }
+      \tuplet 3/2 { fis d e fis a gis | }
+      a2^\trillB ~ |
+      %186
+      a2 ~ |
+      \tuplet 3/2 {
+        a8 \noBeam cis, e a cis b |
+        cis a b cis e d
+        |
+      }
+      e2-\trill ~
+      \tuplet 3/2 { e8 \noBeam cis d e cis d | }
+      e2-\trill ~ |
+      \tuplet 3/2 {
+        e8 g fis e d cis |
+        d fis e d cis b |
+        cis e d cis b a |
+        %195
+        b d cis b a gis |
+        a cis b a b a |
+        gis a gis fis eis fis |
+        cis eis dis cis dis eis |
+        fis a gis fis eis fis |
+        gis b a gis fis gis |
+        a cis b a gis fis |
+        b d cis b a gis |
+      }
+
+      % --Bar 203 -- %
+      cis8 r cis, r |
+      fis8 r r4 |
+      fis8 r fis, r |
+      g8 r r4 |
+      a8 r b r |
+      e,8 r r4 |
+      a8 r d r |
+      b r g r |
+
+
+      % --Bar 211 -- %
+      \tuplet 3/2 { e fis g a b c | }
+      d, r g r |
+      d' r c r |
+      b2 ~ |
+      b8. \noBeam fis'16 b8. fis16 |
+      g8. fis16 g8. e16 |
+      <fis, fis'>2 ~ |
+      q ~ |
+      q |
+
+      % --Bar 220 -- %
+      <fis fis'>2^\markup { \bold "tasto solo"} ~ |
+      q ~ q8.\noBeam b16 fis'8. a,16 |
+      %should beam down
+      \tuplet 3/2 { b8 a g ais b cis | }
+      fis,4 ~ \tuplet 3/2 { fis8 fis' e | }
+      \tuplet 3/2 {
+        d b cis d e fis |
+        e cis d e fis g |
+        %227
+        fis d e fis g a |
+        g e fis gis a b |
+        a fis gis ais b cis |
+      }
+      b8. g!16 d8. e16 |
+      fis8. e16 fis8. fis,16 |
+      b4 r |
+      %233
+      <<
+        { \voiceOne a' }
+        \new Voice { \voiceThree fis }
+        \new Voice { \voiceTwo d }
+      >> \oneVoice r |
+      %234
+      R2*7 |
+    }
+    { d,2\fermata \bar "|." }
+  }
 
 } % end for notes
 
-harpsichordFiguresI = \figuremode {
-  R2*8 |
-  s4 s8. <7 5>16 |
-  <5>4 <6> |
-  R2*18 |
-  s4 <6>8 s |
-  \bassFigureExtendersOn
-  \tuplet 3/2 { <6 5>8 s s <6 5> <6 4> <5 3> | }
-  \bassFigureExtendersOff
-  s4 <6>8 s |
-  s4 <6>8 s |
-  <5>8 s <6> s |
-  s4 <6>8 s |
-  s4 <6>8 s |
-  <6 5>8 s <6 5> s |
-  R2*27 |
-  s4 <6 5!>8 s |
-  s4 <6 4 2>8 s |
-  <6>4 s8. <7 5>16 |
-  <5>4 s |
-  R2*7 |
-  s4 <6>8 s |
-  s4 <6>8 s |
-  \tuplet 3/2 { <5>8 s <6 5> } s4 |
-  R2 |
-}
-
-harpsichordFiguresII = \figuremode {
-    R2*7 |
-  s4 \tuplet 3/2 { s8 s <6\\> | 
-    <6>8 s s <6> s <7> |
-    \bassFigureExtendersOn
-    <6 _+>4 <6 4>8 <5 _+> s s |
-    \bassFigureExtendersOff
-  }
-  R2*7 |
-  s4 \tuplet 3/2 { s8 s <6\\> | 
-    <6>8 s s <6> s <7> |
-    \bassFigureExtendersOn
-    <6 _+>4 <6 4>8 <5 _+> s s |
-    \bassFigureExtendersOff
-  }
-  <6>4 s |
-  R2*28 |
-  s4 <6> |
-  <5>8 s <6\\> s |
-  \bassFigureExtendersOn
-  \tuplet 3/2 { <6 9>8 <6 8> s <6> s s }
-  <_!>4 <6\\> |
-  \tuplet 3/2 { <6 9>8 <6 8> s <6> s s }
-  s4 <6\\> |
-  \tuplet 3/2 { <6 9>8 <6 8> s <6> s s }
-  s4 <6\\> |
-  \tuplet 3/2 { <5 9\\>8 <5 8> s } <6>4 |
-  <5!>4 <6> |
-  \bassFigureExtendersOff
-  <5> <6> |
-  <5> <6\\> |
-  <5> <6> |
-  <5> <6> |
-  <4 2>8 s <6>8 s |
-  <6 5>8 s <6 4 _+> s |
-  <5>8 s <6> s |
-  <6 5>4 s8 <7 _+> |
-  <_+>8. <6 4>16 <6>8. <6>16 |
-  <6 4>4 <5 _+> |
-  R2*74 | 
-  s4 <_+>8. <6\\>16 |
-  \bassFigureExtendersOn
-  \tuplet 3/2 {<6>4 s8 <6>4 <7>8 |
-    <6 _+>4 <6 4>8 <5 _+> s s |
-  }
-  \bassFigureExtendersOff
-  R2*8 |
-}
-
 
 harpsichordFigures = \figuremode {
-  \harpsichordFiguresI
-  \harpsichordFiguresII
-  \harpsichordFiguresI
+  \repeat unfold 2 {
+    R2*8 |
+    s4 s8. <7 5>16 |
+    <5>4 <6> |
+    R2*18 |
+    s4 <6>8 s |
+    \bassFigureExtendersOn
+    \tuplet 3/2 { <6 5>8 s s <6 5> <6 4> <5 3> | }
+    \bassFigureExtendersOff
+    s4 <6>8 s |
+    s4 <6>8 s |
+    <5>8 s <6> s |
+    s4 <6>8 s |
+    s4 <6>8 s |
+    <6 5>8 s <6 5> s |
+    R2*27 |
+    s4 <6 5!>8 s |
+    s4 <6 4 2>8 s |
+    <6>4 s8. <7 5>16 |
+    <5>4 s |
+    R2*7 |
+    s4 <6>8 s |
+    s4 <6>8 s |
+    \tuplet 3/2 { <5>8 s <6 5> } s4 |
+    R2 |
+  }
+  \alternative {
+    {
+      R2*7 |
+      s4 \tuplet 3/2 {
+        s8 s <6\\> |
+        <6>8 s s <6> s <7> |
+        \bassFigureExtendersOn
+        <6 _+>4 <6 4>8 <5 _+> s s |
+        \bassFigureExtendersOff
+      }
+      R2*7 |
+      s4 \tuplet 3/2 {
+        s8 s <6\\> |
+        <6>8 s s <6> s <7> |
+        \bassFigureExtendersOn
+        <6 _+>4 <6 4>8 <5 _+> s s |
+        \bassFigureExtendersOff
+      }
+      <6>4 s |
+      R2*28 |
+      s4 <6> |
+      <5>8 s <6\\> s |
+      \bassFigureExtendersOn
+      \tuplet 3/2 { <6 9>8 <6 8> s <6> s s }
+      <_!>4 <6\\> |
+      \tuplet 3/2 { <6 9>8 <6 8> s <6> s s }
+      s4 <6\\> |
+      \tuplet 3/2 { <6 9>8 <6 8> s <6> s s }
+      s4 <6\\> |
+      \tuplet 3/2 { <5 9\\>8 <5 8> s } <6>4 |
+      <5!>4 <6> |
+      \bassFigureExtendersOff
+      <5> <6> |
+      <5> <6\\> |
+      <5> <6> |
+      <5> <6> |
+      <4 2>8 s <6>8 s |
+      <6 5>8 s <6 4 _+> s |
+      <5>8 s <6> s |
+      <6 5>4 s8 <7 _+> |
+      <_+>8. <6 4>16 <6>8. <6>16 |
+      <6 4>4 <5 _+> |
+      R2*74 |
+      s4 <_+>8. <6\\>16 |
+      \bassFigureExtendersOn
+      \tuplet 3/2 {
+        <6>4 s8 <6>4 <7>8 |
+        <6 _+>4 <6 4>8 <5 _+> s s |
+      }
+      \bassFigureExtendersOff
+      R2*8 |
+    }
+    { }
+  }
 }
+
 
 harpsichordStaff = \new PianoStaff \with {
   instrumentName = \markup \smaller \center-column { "Cembalo" "concertato." }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord.ly
@@ -1,34 +1,34 @@
 \include "header.ly"
 
 \version "2.18.0"
-harpsichordTreble =  \relative c'' {
+harpsichordTreble = \relative c'' {
 
   \commonSettings
   \triplets \tripletsHide
 
   % --Bar 1-- %
-  \repeat unfold 10 R2|
+  \repeat unfold 10 R2 |
 
   % --Bar 11-- %
   r8 r16 d a'8. e16 |
-  \tuplet 3/2 { fis8 e d  cis d e } |
-  \tuplet 3/2 { a, cis b  a b cis } |
-  \tuplet 3/2 { fis, b a  gis cis b } |
-  \tuplet 3/2 { a16 gis a b cis d   e fis e d cis b } |
-  \tuplet 3/2 { a cis b a gis fis   e fis e d cis b } |
+  \tuplet 3/2 { fis8 e d cis d e } |
+  \tuplet 3/2 { a, cis b a b cis } |
+  \tuplet 3/2 { fis, b a gis cis b } |
+  \tuplet 3/2 { a16 gis a b cis d e fis e d cis b } |
+  \tuplet 3/2 { a cis b a gis fis e fis e d cis b } |
 
   % --Bar 17-- %
-  \change Staff = harpsichordDown \stemUp  a8  \change Staff = harpsichordUp  r a' r |
+  \change Staff = harpsichordDown \stemUp a8 \change Staff = harpsichordUp r a' r |
   a r gis d'\rest | \tieUp
   a2 \trill ~ |
-  \tuplet 3/2 { a8 \noBeam cis b  a gis! fis } |
-  e2 \trill ~|
+  \tuplet 3/2 { a8 \noBeam cis b a gis! fis } |
+  e2 \trill ~ |
   \tuplet 3/2 {
-    e8 \noBeam cis d   e d e  |
-    fis a gis  fis a gis |
-    fis dis! e   fis e fis  |
+    e8 \noBeam cis d e d e |
+    fis a gis fis a gis |
+    fis dis! e fis e fis |
   }
-  gis r <e' cis b> r|
+  gis r <e' cis b> r |
   \tieNeutral
   % --Bar 26-- %
   <a, cis e > r < fis b d> r |
@@ -36,23 +36,23 @@ harpsichordTreble =  \relative c'' {
   <<
     { cis8. d16 | e8. fis16 }
     \\
-    {  a,4~ |a }
+    { a,4 ~ | a }
   >> %\stemDown
   \stemNeutral b8. a16 |
-  a8 r  s ^"accomp." s
+  a8 r s ^"accomp." s
   s2 s s
   % --Bar 33-- %
   s s s s s
-  R2|
+  R2 |
   R |
   r8 r16 d a'8. e16 |
 
   % --Bar 41-- %
   \tuplet 3/2 {
-    fis8 e d cis d e  |
+    fis8 e d cis d e |
     a,16 fis g a b cis d e d cis b a |
     b d cis b a g fis e fis g a fis |
-    d cis d e fis g a b a g fis e|
+    d cis d e fis g a b a g fis e |
     fis a g fis e d cis b cis d e cis |
     a d e fis e d b e fis g fis e |
   }
@@ -60,13 +60,13 @@ harpsichordTreble =  \relative c'' {
   % --Bar 47-- %
   \tuplet 3/2 {
     cis16 fis g a g fis d g a b a g |
-    e g a b a g  fis g a b cis a |
+    e g a b a g fis g a b cis a |
     d8 cis b a b g |
   }
   fis r d' r |
   d r cis r |
   d2-\trill ~
-  \tuplet 3/2 { d8 \noBeam fis e d cis b  }
+  \tuplet 3/2 { d8 \noBeam fis e d cis b }
 
   % --Bar 54- %
   a2-\trill ~ |
@@ -78,16 +78,16 @@ harpsichordTreble =  \relative c'' {
   \stemUp cis r \tuplet 3/2 { r16 g' fis e d cis } |
   d8 r \tuplet 3/2 { r16 fis e d cis b} |
   cis8 r \tuplet 3/2 { r16 e d c b a } |
-  \tuplet 3/2 { b c b a g fis } r8 r16 <e g b> | %<c e g>  or <g e c>?
+  \tuplet 3/2 { b c b a g fis } r8 r16 <e g b> | %<c e g> or <g e c>?
   <e g a cis>8 r <fis a d> r |
   <fis b d>8. <e b' d>16 <e a cis>8. <e g cis>16 |
   <d fis a d>8 r ^"accomp." r4 | \stemNeutral
-  s2 | s2| % 2 completely emtpy bars
+  s2 | s2 | % 2 completely emtpy bars
   r8 r16 g d'8. a16 |
 
   % --Bar 68- %
   b2-\trill ~ |
-  \tuplet 3/2 {b8 \noBeam d cis b d cis } |
+  \tuplet 3/2 { b8 \noBeam d cis b d cis } |
   b2^\trillB ~ |
   \tuplet 3/2 {
     b8 \noBeam d cis b a gis |
@@ -98,31 +98,31 @@ harpsichordTreble =  \relative c'' {
   fis8 r s4 ^"accomp." |
 
   % --Bar 76- %
-  s2*3|
-  \tuplet 3/2{
-    fis,8-\pianoB( b d) d( cis d)|
-    fis,( b d) d( cis d)|
-    g,! (ais b) cis(ais b)|
-    e,( ais cis)  cis(b cis)|
-    fis,(b d) d (cis d)|
+  s2*3 |
+  \tuplet 3/2 {
+    fis,8-\pianoB( b d) d( cis d) |
+    fis,( b d) d( cis d) |
+    g,! (ais b) cis(ais b) |
+    e,( ais cis) cis(b cis) |
+    fis,(b d) d (cis d) |
     e,(g cis) cis(ais b)
 
     %85
     cis( ais) b (fis b) ais |
   }
   b8 r r4 |
-  s2*2|
+  s2*2 |
   \tuplet 3/2 {
     b8(-\pianoB fis' b) b( ais b) |
     d,( fis b) b(ais b) |
-    e, (fis g)  e(fis d) |
+    e, (fis g) e(fis d) |
     cis ( e ais) ais(gis ais) |
   }
 
   %93
   \tuplet 3/2 {
     d,8( fis b) b( ais b) |
-    g!( e cis)  ais( cis b) |
+    g!( e cis) ais( cis b) |
     ais( cis) b ais(b) cis |
   }
   d r r4 |
@@ -141,7 +141,7 @@ harpsichordTreble =  \relative c'' {
     a \noBeam fis_\forteI gis a cis b |
   }
   cis r r4 |
-  \tuplet 3/2 { r8 e, fis gis b a  } |
+  \tuplet 3/2 { r8 e, fis gis b a } |
   b r r4 |
 
   %110
@@ -179,15 +179,15 @@ harpsichordTreble =  \relative c'' {
   %148
   \tuplet 3/2 {
     cis'8_\pianoB( e a) a( gis a) |
-    cis,( e a) a( gis a)  |
-    d,( e fis)  d( e cis) |
+    cis,( e a) a( gis a) |
+    d,( e fis) d( e cis) |
 
     %151
     b( d gis) gis( fis gis) |
     cis,( e a) a( gis a) |
     fis( d b) gis( b a) |
     gis( b) a gis( a) b |
-    cis \noBeam a_\forteI b  cis e d |
+    cis \noBeam a_\forteI b cis e d |
     e cis d e g fis |
   }
   g2-\trill ~ |
@@ -199,7 +199,7 @@ harpsichordTreble =  \relative c'' {
     d b cis d fis e |
   }
   fis2-\trill ~ |
-  fis ~|
+  fis ~ |
   fis8. \noBeam fis16 b8. fis16 |
   \stemUp \tuplet 3/2 { g8 fis e d e fis | }
   b,8. fis16 \tuplet 3/2 {
@@ -243,7 +243,7 @@ harpsichordTreble =  \relative c'' {
     e cis d e g fis
   } |
   g2-\trill ~ |
-  \tuplet 3/2 { g8 \noBeam  e fis g e fis } |
+  \tuplet 3/2 { g8 \noBeam e fis g e fis } |
   g2-\trill ~ |
   \tuplet 3/2 {
     g8 b a g fis e |
@@ -307,7 +307,7 @@ harpsichordTreble =  \relative c'' {
     fis'( d) b fis( b ais)
   } |
   b4 r |
-  << \shiftOn \stemUp { < d, fis a > } \\ { \stemUp d' }   >>r | %
+  << \shiftOn \stemUp { < d, fis a > } \\ { \stemUp d' } >>r | %
   \stemNeutral \shiftOff
   %repeat bar 1 to 76
   % --Bar 1-- %
@@ -315,24 +315,24 @@ harpsichordTreble =  \relative c'' {
 
   % --Bar 11-- %
   r8 r16 d a'8. e16 |
-  \tuplet 3/2 { fis8 e d  cis d e } |
-  \tuplet 3/2 { a, cis b  a b cis } |
-  \tuplet 3/2 { fis, b a  gis cis b } |
-  \tuplet 3/2 { a16 gis a b cis d   e fis e d cis b } |
-  \tuplet 3/2 { a cis b a gis fis   e fis e d cis b } |
+  \tuplet 3/2 { fis8 e d cis d e } |
+  \tuplet 3/2 { a, cis b a b cis } |
+  \tuplet 3/2 { fis, b a gis cis b } |
+  \tuplet 3/2 { a16 gis a b cis d e fis e d cis b } |
+  \tuplet 3/2 { a cis b a gis fis e fis e d cis b } |
 
   % --Bar 17-- %
-  \change Staff = harpsichordDown \stemUp  a8  \change Staff = harpsichordUp  r a' r |
+  \change Staff = harpsichordDown \stemUp a8 \change Staff = harpsichordUp r a' r |
   a r gis r |
   \tieUp a2 \trill ~ |
-  \tuplet 3/2 { a8 \noBeam cis b  a gis! fis } |
-  e2 \trill ~|
+  \tuplet 3/2 { a8 \noBeam cis b a gis! fis } |
+  e2 \trill ~ |
   \tuplet 3/2 {
-    e8 \noBeam cis d   e d e  | \tieNeutral
-    fis a gis  fis a gis |
-    fis dis! e   fis e fis  |
+    e8 \noBeam cis d e d e | \tieNeutral
+    fis a gis fis a gis |
+    fis dis! e fis e fis |
   }
-  gis r <e' cis b> r|
+  gis r <e' cis b> r |
 
   % --Bar 26-- %
   <a, cis e > r < fis b d> r |
@@ -340,23 +340,23 @@ harpsichordTreble =  \relative c'' {
   <<
     { cis8. d16 | e8. fis16 }
     \\
-    {  a,4~ |a }
+    { a,4 ~ | a }
   >> %\stemDown
   \stemNeutral b8. a16 |
-  a8 r  s ^"accomp." s
+  a8 r s ^"accomp." s
   s2 s s
   % --Bar 33-- %
   s s s s s
-  R2|
+  R2 |
   R |
   r8 r16 d a'8. e16 |
 
   % --Bar 41-- %
   \tuplet 3/2 {
-    fis8 e d cis d e  |
+    fis8 e d cis d e |
     a,16 fis g a b cis d e d cis b a |
     b d cis b a g fis e fis g a fis |
-    d cis d e fis g a b a g fis e|
+    d cis d e fis g a b a g fis e |
     fis a g fis e d cis b cis d e cis |
     a d e fis e d b e fis g fis e |
   }
@@ -364,13 +364,13 @@ harpsichordTreble =  \relative c'' {
   % --Bar 47-- %
   \tuplet 3/2 {
     cis16 fis g a g fis d g a b a g |
-    e g a b a g  fis g a b cis a |
+    e g a b a g fis g a b cis a |
     d8 cis b a b g |
   }
   fis r d' r |
   d r cis r |
   d2-\trill ~
-  \tuplet 3/2 { d8 \noBeam fis e d cis b  }
+  \tuplet 3/2 { d8 \noBeam fis e d cis b }
 
   % --Bar 54- %
   a2-\trill ~ |
@@ -382,16 +382,16 @@ harpsichordTreble =  \relative c'' {
   \stemUp cis r \tuplet 3/2 { r16 g' fis e d cis } |
   d8 r \tuplet 3/2 { r16 fis e d cis b} |
   cis8 r \tuplet 3/2 { r16 e d c b a } |
-  \tuplet 3/2 { b c b a g fis } r8 r16 <e g b> | %<c e g>  or <g e c>?
+  \tuplet 3/2 { b c b a g fis } r8 r16 <e g b> | %<c e g> or <g e c>?
   <e g a cis>8 r <fis a d> r |
   <fis b d>8. <e b' d>16 <e a cis>8. <e g cis>16 |
   <d fis a d>8 r ^"accomp." r4 | \stemNeutral
-  s2 | s2| % 2 completely emtpy bars
+  s2 | s2 | % 2 completely emtpy bars
   r8 r16 g d'8. a16 |
 
   % --Bar 68- %
   b2-\trill ~ |
-  \tuplet 3/2 {b8 \noBeam d cis b d cis } |
+  \tuplet 3/2 { b8 \noBeam d cis b d cis } |
   b2^\trillB ~ | %(tr)?
   \tuplet 3/2 {
     b8 \noBeam d cis b a gis |
@@ -402,13 +402,13 @@ harpsichordTreble =  \relative c'' {
   fis8 r s4 ^"accomp." |
 
   % --Bar 76- %
-  s2*3|
+  s2*3 |
 
 
-}   %~~end harpsichordTreble~~%
+} % ~ ~ end harpsichordTreble ~ ~ %
 
 
-harpsichordBass =  \relative c' {
+harpsichordBass = \relative c' {
   \set Score.skipTypesetting = ##t
   \set Score.skipTypesetting = ##f
   \commonSettings
@@ -417,18 +417,18 @@ harpsichordBass =  \relative c' {
 
 
   % --Bar 1-- %
-  R2|
-  R2|
-  R2|
-  R2|
-  R2|
-  R2|
-  R2|
-  R2|
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
 
   % --Bar 9-- %
   r8 r16 a d8. a16_\fbRootVII |
-  \tuplet 3/2 { b8_\fbRootV a g  fis_\fbIinv g a } |
+  \tuplet 3/2 { b8_\fbRootV a g fis_\fbIinv g a } |
   d, r cis r |
   d r e r |
   fis r cis r |
@@ -441,18 +441,18 @@ harpsichordBass =  \relative c' {
   \tuplet 3/2 { a cis b a b cis } |
   d r \change Staff = harpsichordUp \stemDown e c\rest | \tieDown %\voiceTwo
   fis2_\trill ~ |
-  \tuplet 3/2 { fis8 \noBeam a gis  fis e d } |
-  cis2_\trill ~|
-  \tuplet 3/2 { cis8 \noBeam a b   cis b cis } | \tieNeutral
-  \tuplet 3/2 { dis fis e  dis fis e } |
-  \tuplet 3/2 { dis b cis  dis cis dis } |
-  \tuplet 3/2 { e16 d! e  fis e d   cis d cis \change Staff = harpsichordDown \stemUp  b a gis | }
+  \tuplet 3/2 { fis8 \noBeam a gis fis e d } |
+  cis2_\trill ~ |
+  \tuplet 3/2 { cis8 \noBeam a b cis b cis } | \tieNeutral
+  \tuplet 3/2 { dis fis e dis fis e } |
+  \tuplet 3/2 { dis b cis dis cis dis } |
+  \tuplet 3/2 { e16 d! e fis e d cis d cis \change Staff = harpsichordDown \stemUp b a gis | }
 
   \stemNeutral
   % --Bar 26-- %
   \tuplet 3/2 {
-    fis e fis  gis a fis   b cis b  a gis fis |
-    e d e  fis gis e   fis a gis fis e d |
+    fis e fis gis a fis b cis b a gis fis |
+    e d e fis gis e fis a gis fis e d |
     cis8 b a
   } e'8. e,16 |
   a8 r fis_\fbIinv r |
@@ -480,7 +480,7 @@ harpsichordBass =  \relative c' {
   d r r4 |
   R2 |
   r8 r16 a d8. a16 |
-  \tuplet 3/2 { b8 a g  fis g a } |
+  \tuplet 3/2 { b8 a g fis g a } |
 
   % --Bar 41-- %
   d, r e r |
@@ -493,7 +493,7 @@ harpsichordBass =  \relative c' {
   % --Bar 47-- %
   a8 r b r |
   cis8. \noBeam a16 d8. a16 |
-  \tuplet 3/2 { b8 a g fis g  a } |
+  \tuplet 3/2 { b8 a g fis g a } |
   \tuplet 3/2 { d, fis e d e fis } |
   g r a r |
   b2-\trill ~ |
@@ -504,7 +504,7 @@ harpsichordBass =  \relative c' {
   \tuplet 3/2 { gis e fis gis fis gis } |
   \stemDown \tuplet 3/2 { a16 cis \change Staff = harpsichordUp d e fis g! } a8 r |
   \change Staff = harpsichordDown \tuplet 3/2 { r16 b, cis d \change Staff = harpsichordUp e fis } g8 r |
-  \change Staff = harpsichordDown \tuplet 3/2 { r16 a, b cis d \change Staff = harpsichordUp e  }fis8 r |
+  \change Staff = harpsichordDown \tuplet 3/2 { r16 a, b cis d \change Staff = harpsichordUp e }fis8 r |
 
   % --Bar 61-- %
   \change Staff = harpsichordDown g, r \change Staff = harpsichordUp \tuplet 3/2 { e'16 fis e d cis! \change Staff = harpsichordDown \stemNeutral b} |
@@ -515,11 +515,11 @@ harpsichordBass =  \relative c' {
   d,8 r fis r | % 6 3?
   g r c r | % <2 4 6>
   b8. \noBeam g'16 d'8. a16 |
-  \tuplet 3/2 {b8 a g fis gis a |}
+  \tuplet 3/2 { b8 a g fis gis a | }
 
   % --Bar 68-- %
   gis2-\trill ~ |
-  \tuplet 3/2 {gis8 \noBeam b a gis b a }|
+  \tuplet 3/2 { gis8 \noBeam b a gis b a } |
   gis2^\trillB ~ |
   \tuplet 3/2 {
     gis8 \noBeam b a gis fis e |
@@ -529,11 +529,11 @@ harpsichordBass =  \relative c' {
   }
   d r fis, r |
   g r a r |
-  \tuplet 3/2 {b a g} a8. a,16 |
-  \tuplet 3/2 {d8 fis e d e fis}|
+  \tuplet 3/2 { b a g} a8. a,16 |
+  \tuplet 3/2 { d8 fis e d e fis} |
   b,8 r r4 |
   %79
-  \repeat unfold 5{ b8 r r4 |}
+  \repeat unfold 5 { b8 r r4 | }
 
   %85
   b8 r r4 |
@@ -574,18 +574,18 @@ harpsichordBass =  \relative c' {
     eis!8 \noBeam cis dis eis! dis eis |
     %115
     fis d! e! fis e fis |
-    gis e fis  gis fis gis |
+    gis e fis gis fis gis |
     a fis gis a gis a |
     b gis a b a b |
     %119
-    eis, gis fis eis dis eis|
+    eis, gis fis eis dis eis |
     fis fis, gis a gis a |
     b gis a b a b |
   }
   cis4 ~ \tuplet 3/2 { cis8 d e } |
   fis4 ~ \tuplet 3/2 {
     fis8 gis ais |
-    b  cis d cis dis eis |
+    b cis d cis dis eis |
     fis, gis a gis a b |
     a b cis
   } d, r |
@@ -600,7 +600,7 @@ harpsichordBass =  \relative c' {
   e r fis r |
   g r gis r |
   a r b r |
-  cis r cis, r  |
+  cis r cis, r |
 
   % --Bar 135 -- %
   d r e r |
@@ -619,7 +619,7 @@ harpsichordBass =  \relative c' {
   e8. d!16 cis8. fis,16 |
   e8. d16 e8. e,16 |
   a8 r a' r |
-  \repeat unfold 6 { a, r a ' r |}
+  \repeat unfold 6 { a, r a ' r | }
 
   % --Bar 155 -- %
   \tuplet 3/2 {
@@ -632,7 +632,7 @@ harpsichordBass =  \relative c' {
   % --Bar 159 -- %
   \tuplet 3/2 {
     e8 \noBeam e, fis g b a |
-    b g a  b d cis |
+    b g a b d cis |
   }
   d2-\trill ~ |
   d2 ~ |
@@ -640,7 +640,7 @@ harpsichordBass =  \relative c' {
   \change Staff = harpsichordUp
   \stemDown
   r8 r16 fis b8. fis16 |
-  \tuplet 3/2 { g8 fis e  d e fis |}
+  \tuplet 3/2 { g8 fis e d e fis | }
   \stemNeutral \change Staff = harpsichordDown
   b,8. fis16 \tuplet 3/2 { b8 d cis } |
   \tuplet 3/2 { d b cis d fis e } |
@@ -650,7 +650,7 @@ harpsichordBass =  \relative c' {
   \tuplet 3/2 { d8 cis b ais b cis } |
   fis,4 e' ~ |
   \tuplet 3/2 { e8 d cis b cis ais } |
-  \tuplet 3/2 { g' fis e d e cis  } |
+  \tuplet 3/2 { g' fis e d e cis } |
   b8. fis16 b8. fis16 |
   \tuplet 3/2 { g8 fis e d e fis } |
   b,8. fis16 \tuplet 3/2 { b8 d cis } |
@@ -673,7 +673,7 @@ harpsichordBass =  \relative c' {
     cis a b cis e d
   } |
   e2-\trill ~
-  \tuplet 3/2 { e8 \noBeam cis d e cis d  } |
+  \tuplet 3/2 { e8 \noBeam cis d e cis d } |
   e2-\trill ~ |
   \tuplet 3/2 {
     e8 g fis e d cis |
@@ -687,10 +687,10 @@ harpsichordBass =  \relative c' {
     a cis b a b a |
     gis a gis fis eis fis |
     cis eis dis cis dis eis |
-    fis a gis  fis eis fis |
-    gis b a  gis fis gis |
-    a cis b  a gis fis |
-    b d cis  b a gis |
+    fis a gis fis eis fis |
+    gis b a gis fis gis |
+    a cis b a gis fis |
+    b d cis b a gis |
   }
 
   % --Bar 203 -- %
@@ -708,25 +708,25 @@ harpsichordBass =  \relative c' {
   \tuplet 3/2 { e fis g a b c } |
   d, r g r |
   d' r c r |
-  b2~ |
+  b2 ~ |
   b8. \noBeam fis'16 b8. fis16 |
   g8. fis16 g8. e16 |
   <<
-    { \tieDown fis,2 ~ | fis ~ | fis  } \\
-    { \tieUp \stemUp fis' ~ |  fis~ |  fis }
-  >>  |
+    { \tieDown fis,2 ~ | fis ~ | fis } \\
+    { \tieUp \stemUp fis' ~ | fis ~ | fis }
+  >> |
 
   % --Bar 220 -- %
   <<
-    { \tieDown fis,^\markup {\bold "tasto solo"} ~ | fis ~ | fis8.  } \\
-    { \tieUp \stemUp fis'2 ~|  fis ~|  fis8. }
+    { \tieDown fis,^\markup { \bold "tasto solo"} ~ | fis ~ | fis8. } \\
+    { \tieUp \stemUp fis'2 ~ | fis ~ | fis8. }
   >>
   \stemNeutral \tieNeutral
   % --Bar 222 -- %
   \voiceOne b,16 fis'8. a,16 |
   %should beam down
-  \tuplet 3/2 {b8 a g  ais b cis }|
-  fis,4 ~ \tuplet 3/2 {fis8 fis' e } |
+  \tuplet 3/2 { b8 a g ais b cis } |
+  fis,4 ~ \tuplet 3/2 { fis8 fis' e } |
   \tuplet 3/2 {
     d b cis d e fis |
     e cis d e fis g |
@@ -752,7 +752,7 @@ harpsichordBass =  \relative c' {
 
   % --Bar 9-- %
   r8 r16 a d8. a16_\fbRootVII |
-  \tuplet 3/2 { b8_\fbRootV a g  fis_\fbIinv g a } |
+  \tuplet 3/2 { b8_\fbRootV a g fis_\fbIinv g a } |
   d, r cis r |
   d r e r |
   fis r cis r |
@@ -765,18 +765,18 @@ harpsichordBass =  \relative c' {
   \tuplet 3/2 { a cis b a b cis } |
   d r \change Staff = harpsichordUp \stemDown e r | \tieUp %\voiceTwo
   fis2_\trill ~ |
-  \tuplet 3/2 { fis8 \noBeam a gis  fis e d } |
-  cis2_\trill ~|
-  \tuplet 3/2 { cis8 \noBeam a b   cis b cis } | \tieNeutral
-  \tuplet 3/2 { dis fis e  dis fis e } |
-  \tuplet 3/2 { dis b cis  dis cis dis } |
-  \tuplet 3/2 { e16 d! e  fis e d   cis d cis \change Staff = harpsichordDown \stemUp  b a gis | }
+  \tuplet 3/2 { fis8 \noBeam a gis fis e d } |
+  cis2_\trill ~ |
+  \tuplet 3/2 { cis8 \noBeam a b cis b cis } | \tieNeutral
+  \tuplet 3/2 { dis fis e dis fis e } |
+  \tuplet 3/2 { dis b cis dis cis dis } |
+  \tuplet 3/2 { e16 d! e fis e d cis d cis \change Staff = harpsichordDown \stemUp b a gis | }
 
   \stemNeutral
   % --Bar 26-- %
   \tuplet 3/2 {
-    fis e fis  gis a fis   b cis b  a gis fis |
-    e d e  fis gis e   fis a gis fis e d |
+    fis e fis gis a fis b cis b a gis fis |
+    e d e fis gis e fis a gis fis e d |
     cis8 b a
   } e'8. e,16 |
   a8 r fis_\fbIinv r |
@@ -802,7 +802,7 @@ harpsichordBass =  \relative c' {
   d r r4 |
   R2 |
   r8 r16 a d8. a16 |
-  \tuplet 3/2 { b8 a g  fis g a } |
+  \tuplet 3/2 { b8 a g fis g a } |
 
   % --Bar 41-- %
   d, r e r |
@@ -815,7 +815,7 @@ harpsichordBass =  \relative c' {
   % --Bar 47-- %
   a8 r b r |
   cis8. \noBeam a16 d8. a16 |
-  \tuplet 3/2 { b8 a g fis g  a } |
+  \tuplet 3/2 { b8 a g fis g a } |
   \tuplet 3/2 { d, fis e d e fis } |
   g r a r |
   b2-\trill ~ |
@@ -826,7 +826,7 @@ harpsichordBass =  \relative c' {
   \tuplet 3/2 { gis e fis gis fis gis } |
   \stemDown \tuplet 3/2 { a16 cis \change Staff = harpsichordUp d e fis g! } a8 r |
   \change Staff = harpsichordDown \tuplet 3/2 { r16 b, cis d \change Staff = harpsichordUp e fis } g8 r |
-  \change Staff = harpsichordDown \tuplet 3/2 { r16 a, b cis d \change Staff = harpsichordUp e  }fis8 r |
+  \change Staff = harpsichordDown \tuplet 3/2 { r16 a, b cis d \change Staff = harpsichordUp e }fis8 r |
 
   % --Bar 61-- %
   \change Staff = harpsichordDown g, r \change Staff = harpsichordUp \tuplet 3/2 { e'16 fis e d cis! \change Staff = harpsichordDown \stemNeutral b} |
@@ -838,11 +838,11 @@ harpsichordBass =  \relative c' {
   d,8 r fis r | % 6 3?
   g r c r | % <2 4 6>
   b8. \noBeam g'16 d'8. a16 |
-  \tuplet 3/2 {b8 a g fis gis a |}
+  \tuplet 3/2 { b8 a g fis gis a | }
 
   % --Bar 68-- %
   gis2-\trill ~ |
-  \tuplet 3/2 {gis8 \noBeam b a gis b a }|
+  \tuplet 3/2 { gis8 \noBeam b a gis b a } |
   gis2-\trill ~ | %(tr)
   \tuplet 3/2 {
     gis8 b a gis fis e |
@@ -853,7 +853,7 @@ harpsichordBass =  \relative c' {
 
   d r fis, r |
   g r a r |
-  \tuplet 3/2 {b a g} a8. a,16 |
+  \tuplet 3/2 { b a g} a8. a,16 |
   d2-\fermata \bar "||"
 
 } % end for Notes Bass
@@ -863,7 +863,7 @@ harpsichordBass =  \relative c' {
 
 harpsichordTa =
 
-\context PianoStaff  <<
+\context PianoStaff <<
 
   \context Staff = harpsichordUp <<
     \time 2/4 \clef treble \key d \major
@@ -872,7 +872,7 @@ harpsichordTa =
   >>
 
   \context Staff = harpsichordDown <<
-    \time 2/4 \clef bass  \key d \major
+    \time 2/4 \clef bass \key d \major
     \set Staff.instrumentName = \markup \smaller {
       \column {
         "Cembalo"

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord.ly
@@ -1,8 +1,8 @@
+\version "2.18.0"
+
 \include "header.ly"
 
-\version "2.18.0"
 harpsichordTreble = \relative c'' {
-
   \commonSettings
   \triplets \tripletsHide
 
@@ -34,8 +34,7 @@ harpsichordTreble = \relative c'' {
   <a, cis e > r < fis b d> r |
   <gis b d > r
   <<
-    { cis8. d16 | e8. fis16 }
-    \\
+    { cis8. d16 | e8. fis16 } \\
     { a,4 ~ | a }
   >> %\stemDown
   \stemNeutral b8. a16 |
@@ -102,28 +101,28 @@ harpsichordTreble = \relative c'' {
   \tuplet 3/2 {
     fis,8-\pianoB( b d) d( cis d) |
     fis,( b d) d( cis d) |
-    g,! (ais b) cis(ais b) |
+    g,!( ais b) cis(ais b) |
     e,( ais cis) cis(b cis) |
-    fis,(b d) d (cis d) |
+    fis,(b d) d( cis d) |
     e,(g cis) cis(ais b)
 
     %85
-    cis( ais) b (fis b) ais |
+    cis( ais) b( fis b) ais |
   }
   b8 r r4 |
   s2*2 |
   \tuplet 3/2 {
     b8(-\pianoB fis' b) b( ais b) |
-    d,( fis b) b(ais b) |
-    e, (fis g) e(fis d) |
-    cis ( e ais) ais(gis ais) |
+    d,( fis b) b( ais b) |
+    e,( fis g) e( fis d) |
+    cis( e ais) ais( gis ais) |
   }
 
   %93
   \tuplet 3/2 {
     d,8( fis b) b( ais b) |
     g!( e cis) ais( cis b) |
-    ais( cis) b ais(b) cis |
+    ais( cis) b ais( b) cis |
   }
   d r r4 |
   s2 * 2 |
@@ -862,7 +861,6 @@ harpsichordBass = \relative c' {
 % end for notes
 
 harpsichordTa =
-
 \context PianoStaff <<
 
   \context Staff = harpsichordUp <<

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord.ly
@@ -16,31 +16,31 @@ harpsichordTreble = \relative c'' {
     r8 r16 d a'8. e16 |
     \tuplet 3/2 {
       fis8 e d cis d e |
-      a, cis b a b cis |
-      fis, b a gis cis b |
+      a,8 cis b a b cis |
+      fis,8 b a gis cis b |
       a16 gis a b cis d e fis e d cis b |
-      a cis b a gis fis e fis e d cis b |
+      a16 cis b a gis fis e fis e d cis b |
     }
     % --Bar 17-- %
     \change Staff = harpsichordDown
     \once \voiceOne
     a8
     \change Staff = harpsichordUp
-    r a' r |
-    a r \voiceOne gis r |
+    r8 a' r |
+    a8 r \voiceOne gis r |
     a2 \trill ~ |
     \tuplet 3/2 { a8 \noBeam cis b a gis! fis | }
     e2 \trill ~ |
     \tuplet 3/2 {
       e8 \noBeam cis d e d e |
-      fis a gis fis a gis |
-      fis dis! e fis e fis |
+      fis8 a gis fis a gis |
+      fis8 dis! e fis e fis |
     }
-    gis r <e' cis b> r |
+    gis8 r <e' cis b> r |
     \oneVoice
     % --Bar 26-- %
-    <a, cis e > r < fis b d> r |
-    <gis b d > r
+    <a, cis e >8 r < fis b d> r |
+    <gis b d >8 r
     <<
       { cis8. d16 | e8. fis16 } \\
       { a,4 ~ | a }
@@ -58,20 +58,20 @@ harpsichordTreble = \relative c'' {
     \tuplet 3/2 {
       fis8 e d cis d e |
       a,16 fis g a b cis d e d cis b a |
-      b d cis b a g fis e fis g a fis |
-      d cis d e fis g a b a g fis e |
-      fis a g fis e d cis b cis d e cis |
-      a d e fis e d b e fis g fis e |
+      b16 d cis b a g fis e fis g a fis |
+      d16 cis d e fis g a b a g fis e |
+      fis16 a g fis e d cis b cis d e cis |
+      a16 d e fis e d b e fis g fis e |
     }
 
     % --Bar 47-- %
     \tuplet 3/2 {
       cis16 fis g a g fis d g a b a g |
-      e g a b a g fis g a b cis a |
+      e16 g a b a g fis g a b cis a |
       d8 cis b a b g |
     }
-    fis r d' r |
-    d r cis r |
+    fis8 r d' r |
+    d8 r cis r |
     d2-\trill ~
     \tuplet 3/2 { d8 \noBeam fis e d cis b }
 
@@ -79,14 +79,14 @@ harpsichordTreble = \relative c'' {
     a2-\trill ~ |
     \tuplet 3/2 {
       a8 \noBeam fis g a g a |
-      b d cis b d cis |
-      b gis a b a b |
+      b8 d cis b d cis |
+      b8 gis a b a b |
     }
     \voiceOne
-    cis r \tuplet 3/2 { r16 g' fis e d cis | }
+    cis8 r \tuplet 3/2 { r16 g' fis e d cis | }
     d8 r \tuplet 3/2 { r16 fis e d cis b| }
     cis8 r \tuplet 3/2 { r16 e d c b a | }
-    \tuplet 3/2 { b c b a g fis } r8 r16 <e g b> | %<c e g> or <g e c>?
+    \tuplet 3/2 { b16 c b a g fis } r8 r16 <e g b> | %<c e g> or <g e c>?
     \oneVoice
     <e g a cis>8 r <fis a d> r |
     <fis b d>8. <e b' d>16 <e a cis>8. <e g cis>16 |
@@ -100,9 +100,9 @@ harpsichordTreble = \relative c'' {
     b2^\trillB ~ |
     \tuplet 3/2 {
       b8 \noBeam d cis b a gis |
-      cis e d cis b a |
-      d fis e d cis b |
-      e g fis e d cis |
+      cis8 e d cis b a |
+      d8 fis e d cis b |
+      e8 g fis e d cis |
     }
     fis8 r s4 ^"accomp." |
   }
@@ -114,31 +114,31 @@ harpsichordTreble = \relative c'' {
       s2*3 |
       \tuplet 3/2 {
         fis,8-\pianoB( b d) d( cis d) |
-        fis,( b d) d( cis d) |
-        g,!( ais b) cis( ais b) |
-        e,( ais cis) cis( b cis) |
-        fis,( b d) d( cis d) |
-        e,( g cis) cis( ais b)
+        fis,8( b d) d( cis d) |
+        g,!8( ais b) cis( ais b) |
+        e,8( ais cis) cis( b cis) |
+        fis,8( b d) d( cis d) |
+        e,8( g cis) cis( ais b)
 
         %85
-        cis( ais) b( fis b) ais |
+        cis8( ais) b( fis b) ais |
       }
       b8 r r4 |
       s2*2 |
       \tuplet 3/2 {
         b8(-\pianoB fis' b) b( ais b) |
-        d,( fis b) b( ais b) |
-        e,( fis g) e( fis d) |
-        cis( e ais) ais( gis ais) |
+        d,8( fis b) b( ais b) |
+        e,8( fis g) e( fis d) |
+        cis8( e ais) ais( gis ais) |
       }
 
       %93
       \tuplet 3/2 {
         d,8( fis b) b( ais b) |
-        g!( e cis) ais( cis b) |
-        ais( cis) b ais( b) cis |
+        g!8( e cis) ais( cis b) |
+        ais8( cis) b ais( b) cis |
       }
-      d r r4 |
+      d8 r r4 |
       s2*2 |
 
       r8 r16 cis_\cantabileB fis8. cis16 |
@@ -151,31 +151,31 @@ harpsichordTreble = \relative c'' {
       b2-\trill ~ |
       \tuplet 3/2 {
         b8 cis d cis d b |
-        a \noBeam fis_\forteI gis a cis b |
+        a8 \noBeam fis_\forteI gis a cis b |
       }
-      cis r r4 |
+      cis8 r r4 |
       \tuplet 3/2 { r8 e, fis gis b a | }
-      b r r4 |
+      b8 r r4 |
 
       %110
       \tuplet 3/2 {
         r8 d, e fis a gis |
-        a cis, dis eis gis fis |
-        gis b a gis b a |
+        a8 cis, dis eis gis fis |
+        gis8 b a gis b a |
       }
       gis2-\trill ~ |
       \tuplet 3/2 {
         gis!8 \noBeam eis fis gis fis gis |
-        a fis gis a gis a |
-        b gis a b ais b |
-        cis a b cis b cis |
-        d b cis d cis d |
+        a8 fis gis a gis a |
+        b8 gis a b ais b |
+        cis8 a b cis b cis |
+        d8 b cis d cis d |
 
         %119
-        gis, b a gis fis gis |
-        a a, b cis b cis |
-        d b cis d cis d |
-        gis, a b
+        gis,8 b a gis fis gis |
+        a8 a, b cis b cis |
+        d8 b cis d cis d |
+        gis,8 a b
       } cis4 ~ |
       \tuplet 3/2 { cis8 d e } fis4 ~ |
       fis8. fis16 \tuplet 3/2 { eis8 fis gis | }
@@ -184,40 +184,40 @@ harpsichordTreble = \relative c'' {
 
       %127
       \tuplet 3/2 {
-        b cis d cis d b |
-        a gis fis
+        b8 cis d cis d b |
+        a8 gis fis
       } r4^"accomp" |
       s2 * 19 |
 
       %148
       \tuplet 3/2 {
         cis'8_\pianoB( e a) a( gis a) |
-        cis,( e a) a( gis a) |
-        d,( e fis) d( e cis) |
+        cis,8( e a) a( gis a) |
+        d,8( e fis) d( e cis) |
 
         %151
-        b( d gis) gis( fis gis) |
-        cis,( e a) a( gis a) |
-        fis( d b) gis( b a) |
-        gis( b) a gis( a) b |
-        cis \noBeam a_\forteI b cis e d |
-        e cis d e g fis |
+        b8( d gis) gis( fis gis) |
+        cis,8( e a) a( gis a) |
+        fis8( d b) gis( b a) |
+        gis8( b) a gis( a) b |
+        cis8 \noBeam a_\forteI b cis e d |
+        e8 cis d e g fis |
       }
       g2-\trill ~ |
-      g |
+      g2 |
 
       %159
       \tuplet 3/2 {
         g8 \noBeam g, a b d cis |
-        d b cis d fis e |
+        d8 b cis d fis e |
       }
       fis2-\trill ~ |
-      fis ~ |
+      fis2 ~ |
       fis8. \noBeam fis16 b8. fis16 |
       \stemUp \tuplet 3/2 { g8 fis e d e fis | }
       b,8. fis16 \tuplet 3/2 {
         b8 d cis |
-        \stemNeutral d b cis d fis e |
+        \stemNeutral d8 b cis d fis e |
       }
       fis8. b,16 fis'8. cis16 |
 
@@ -226,14 +226,14 @@ harpsichordTreble = \relative c'' {
       fis,4 e' ~ |
       \tuplet 3/2 {
         e8 d cis b cis ais |
-        g' fis e d e cis |
+        g'8 fis e d e cis |
       }
       b8. fis16 b8. fis16 |
       \tuplet 3/2 { g8 fis e d e fis | }
       b,8. fis16 \tuplet 3/2 {
         b8 d cis |
-        d b cis d fis e |
-        fis d e fis a gis |
+        d8 b cis d fis e |
+        fis8 d e fis a gis |
       }
 
       %177
@@ -242,64 +242,64 @@ harpsichordTreble = \relative c'' {
       g2-\trill ~ |
       \tuplet 3/2 { g8 \noBeam b a g fis e | }
       fis2^\trillB ~ |
-      fis |
+      fis2 |
       \tuplet 3/2 {
         fis8 \noBeam d e fis a g |
-        a fis g a cis b
+        a8 fis g a cis b
         |
       }
       cis2-\trill ~ |
 
       %186
-      cis ~ |
+      cis2 ~ |
       \tuplet 3/2 {
         cis8 \noBeam a b cis e d |
-        e cis d e g fis |
+        e8 cis d e g fis |
       }
       g2-\trill ~ |
       \tuplet 3/2 { g8 \noBeam e fis g e fis | }
       g2-\trill ~ |
       \tuplet 3/2 {
         g8 b a g fis e |
-        fis a g fis e d |
-        e g fis e d cis |
+        fis8 a g fis e d |
+        e8 g fis e d cis |
       }
 
       %195
       \tuplet 3/2 {
-        d fis e d cis b |
-        cis e d cis d cis |
-        b a b cis d16 cis b a |
+        d8 fis e d cis b |
+        cis8 e d cis d cis |
+        b8 a b cis d16 cis b a |
       }
       gis8. fis16 \tuplet 3/2 { eis8 gis b | }
       \tuplet 3/2 {
-        a cis b a cis fis |
-        b, d cis b fis' eis |
-        fis a, b cis d e |
-        d fis e d fis b |
+        a8 cis b a cis fis |
+        b,8 d cis b fis' eis |
+        fis8 a, b cis d e |
+        d8 fis e d fis b |
 
         %203
-        gis eis fis
+        gis8 eis fis
       } g4 ~ |
       \tuplet 3/2 {
         g8 fis e! d cis b |
-        cis fis e dis e fis |
-        b, e fis g a b |
-        c! dis, e b e dis |
-        e b a g fis g |
-        e a g fis g a |
-        d, g a b c a |
+        cis8 fis e dis e fis |
+        b,8 e fis g a b |
+        c!8 dis, e b e dis |
+        e8 b a g fis g |
+        e8 a g fis g a |
+        d,8 g a b c a |
 
         %211
-        g a b
+        g8 a b
       } e,8. e'16 |
       \tuplet 3/2 { a8 d, c b a g | }
       a4 ~ \tuplet 3/2 { a16 g fis e dis e | }
       \tuplet 3/2 {
         fis8 b a g fis e |
-        fis b ais b fis' ais, |
+        fis8 b ais b fis' ais, |
       }
-      b r r4 |
+      b8 r r4 |
       r8 r16 cis \tuplet 3/2 { fis8( ais,) b | }
       cis8. fis,16 \tuplet 3/2 { b8 gis eis | }
 
@@ -311,17 +311,17 @@ harpsichordTreble = \relative c'' {
       s2*2 |
       \tuplet 3/2 {
         r8 d e fis gis a |
-        gis e fis gis ais b |
+        gis8 e fis gis ais b |
 
         %227
-        ais fis gis ais b cis |
-        b gis a! b cis d |
-        cis ais b cis d e |
-        fis( d) b fis'( d) b |
-        fis'( d) b fis( b ais) |
+        ais8 fis gis ais b cis |
+        b8 gis a! b cis d |
+        cis8 ais b cis d e |
+        fis8( d) b fis'( d) b |
+        fis'8( d) b fis( b ais) |
       }
       b4 r |
-      << { \voiceOne d } \new Voice { \voiceThree <d, fis a> } >> \oneVoice r |
+      << { \voiceOne d4 } \new Voice { \voiceThree <d, fis a> } >> \oneVoice r |
       R2*9 |
     }
     {
@@ -345,80 +345,80 @@ harpsichordBass = \relative c' {
   \repeat unfold 2{
     r8 r16 a d8. a16 |
     \tuplet 3/2 { b8 a g fis g a | }
-    d, r cis r |
-    d r e r |
-    fis r cis r |
-    d r e r |
-    fis r e r |
-    fis r gis r |
+    d,8 r cis r |
+    d8 r e r |
+    fis8 r cis r |
+    d8 r e r |
+    fis8 r e r |
+    fis8 r gis r |
 
 
     % --Bar 17-- %
-    \tuplet 3/2 { a cis b a b cis | }
-    d r \staffUp e r |
+    \tuplet 3/2 { a8 cis b a b cis | }
+    d8 r \staffUp e r |
     fis2_\trill ~ |
     \tuplet 3/2 { fis8 \noBeam a gis fis e d | }
     cis2_\trill ~ |
     \tuplet 3/2 { cis8 \noBeam a b cis b cis | }
-    \tuplet 3/2 { dis fis e dis fis e | }
-    \tuplet 3/2 { dis b cis dis cis dis | }
+    \tuplet 3/2 { dis8 fis e dis fis e | }
+    \tuplet 3/2 { dis8 b cis dis cis dis | }
     \tuplet 3/2 { e16 d! e fis e d cis d cis \staffDown b a gis | }
 
     % --Bar 26-- %
     \tuplet 3/2 {
-      fis e fis gis a fis b cis b a gis fis |
-      e d e fis gis e fis a gis fis e d |
+      fis16 e fis gis a fis b cis b a gis fis |
+      e16 d e fis gis e fis a gis fis e d |
       cis8 b a
     } e'8. e,16 |
     a8 r fis r |
-    g r a r |
-    b r cis r |
-    d r e r |
+    g8 r a r |
+    b8 r cis r |
+    d8 r e r |
 
     % --Bar 33-- %
-    fis r fis r |
-    g r a r |
-    b r a r |
-    b r cis r |
-    d r r4 |
+    fis8 r fis r |
+    g8 r a r |
+    b8 r a r |
+    b8 r cis r |
+    d8 r r4 |
     R2 |
     r8 r16 a d8. a16 |
     \tuplet 3/2 { b8 a g fis g a | }
 
     % --Bar 41-- %
-    d, r e r |
-    fis r fis, r |
-    g r a r |
-    b r cis r |
-    d r e r |
-    fis r g r |
+    d,8 r e r |
+    fis8 r fis, r |
+    g8 r a r |
+    b8 r cis r |
+    d8 r e r |
+    fis8 r g r |
 
     % --Bar 47-- %
     a8 r b r |
     cis8. \noBeam a16 d8. a16 |
     \tuplet 3/2 { b8 a g fis g a | }
-    \tuplet 3/2 { d, fis e d e fis | }
-    g r a r |
+    \tuplet 3/2 { d,8 fis e d e fis | }
+    g8 r a r |
     b2-\trill ~ |
     \tuplet 3/2 { b8 \noBeam d cis b a g | }
     fis2-\trill ~ |
     \tuplet 3/2 { fis8 \noBeam d e fis e fis | }
-    \tuplet 3/2 { gis b a gis b a | }
-    \tuplet 3/2 { gis e fis gis fis gis | }
+    \tuplet 3/2 { gis8 b a gis b a | }
+    \tuplet 3/2 { gis8 e fis gis fis gis | }
     \voiceTwo
     \tuplet 3/2 { a16 cis \staffUp d e fis g! } a8 r \staffDown \stemDown |
     \tuplet 3/2 { r16 b, cis d \staffUp e fis } g8 r \staffDown \stemDown |
     \tuplet 3/2 { r16 a, b cis d \staffUp e } fis8 r \staffDown  |
 
     % --Bar 61-- %
-    g, r \staffUp \tuplet 3/2 { e'16 fis e d cis! \staffDown \once \stemDown b | }
+    g,8 r \staffUp \tuplet 3/2 { e'16 fis e d cis! \staffDown \once \stemDown b | }
     \oneVoice
     \tuplet 3/2 {
-      a b a g fis e d e d cis b a |
+      a16 b a g fis e d e d cis b a |
       b8 a g
     } a8. a16 |
     d,8 r fis r | % 6 3?
-    g r c r | % <2 4 6>
+    g8 r c r | % <2 4 6>
     b8. \noBeam g'16 d'8. a16 |
     \tuplet 3/2 { b8 a g fis gis a | }
 
@@ -428,13 +428,13 @@ harpsichordBass = \relative c' {
     gis2^\trillB ~ |
     \tuplet 3/2 {
       gis8 \noBeam b a gis fis e |
-      a cis b a g! fis |
-      b d cis b a g |
-      cis e d cis b a |
+      a8 cis b a g! fis |
+      b8 d cis b a g |
+      cis8 e d cis b a |
     }
-    d r fis, r |
-    g r a r |
-    \tuplet 3/2 { b a g } a8. a,16 |
+    d8 r fis, r |
+    g8 r a r |
+    \tuplet 3/2 { b8 a g } a8. a,16 |
   }
 
   \alternative {
@@ -449,22 +449,22 @@ harpsichordBass = \relative c' {
       b8 r r4 |
       b8. \noBeam fis'16 \tuplet 3/2 {
         b8 d cis |
-        d cis b ais b cis |
+        d8 cis b ais b cis |
       }
       fis,4 ~ \tuplet 3/2 {
         fis8 g e |
-        d cis b
+        d8 cis b
       } r4 |
       %90
       \repeat unfold 6 { b8 r r4 | }
       %96
       b8. \noBeam fis'16 \tuplet 3/2 {
         b8 a gis |
-        a gis fis eis fis gis |
+        a8 gis fis eis fis gis |
       }
       cis,4 ~ \tuplet 3/2 {
         cis8 d b |
-        a gis fis
+        a8 gis fis
       } r4 |
       %100
       \repeat unfold 6 { fis8 r r4 | }
@@ -473,68 +473,68 @@ harpsichordBass = \relative c' {
       a8 r r4 |
       %108
       \tuplet 3/2 { r8 cis, d e gis fis | }
-      gis r r4 |
+      gis8 r r4 |
       \tuplet 3/2 {
         r8 b, cis d fis eis |
-        fis a, b cis eis dis |
-        eis gis fis eis gis fis |
+        fis8 a, b cis eis dis |
+        eis8 gis fis eis gis fis |
       }
       eis2-\trill ~ |
       \tuplet 3/2 {
         eis!8 \noBeam cis dis eis! dis eis |
         %115
-        fis d! e! fis e fis |
-        gis e fis gis fis gis |
-        a fis gis a gis a |
-        b gis a b a b |
+        fis8 d! e! fis e fis |
+        gis8 e fis gis fis gis |
+        a8 fis gis a gis a |
+        b8 gis a b a b |
         %119
-        eis, gis fis eis dis eis |
-        fis fis, gis a gis a |
-        b gis a b a b |
+        eis,8 gis fis eis dis eis |
+        fis8 fis, gis a gis a |
+        b8 gis a b a b |
       }
       cis4 ~ \tuplet 3/2 { cis8 d e | }
       fis4 ~ \tuplet 3/2 {
         fis8 gis ais |
-        b cis d cis dis eis |
-        fis, gis a gis a b |
-        a b cis
-      } d, r |
+        b8 cis d cis dis eis |
+        fis,8 gis a gis a b |
+        a8 b cis
+      } d,8 r |
 
       %127
-      b r cis r |
+      b8 r cis r |
 
       % --Bar 128 -- %
-      fis, r a r |
-      b r cis r |
-      d r dis r |
-      e r fis r |
-      g r gis r |
-      a r b r |
-      cis r cis, r |
+      fis,8 r a r |
+      b8 r cis r |
+      d8 r dis r |
+      e8 r fis r |
+      g8 r gis r |
+      a8 r b r |
+      cis8 r cis, r |
 
       % --Bar 135 -- %
-      d r e r |
-      fis r fis, r |
-      gis r gis' r |
-      a r a, r |
-      b r b' r |
-      cis r cis, r |
-      d r d' r |
-      d r cis r |
+      d8 r e r |
+      fis8 r fis, r |
+      gis8 r gis' r |
+      a8 r a, r |
+      b8 r b' r |
+      cis8 r cis, r |
+      d8 r d' r |
+      d8 r cis r |
 
       % --Bar 143 -- %
-      d r e r |
-      \tuplet 3/2 { fis e d cis dis e }
+      d8 r e r |
+      \tuplet 3/2 { fis8 e d cis dis e }
       dis4 r8 b |
       e8. d!16 cis8. fis,16 |
       e8. d16 e8. e,16 |
       a8 r a' r |
-      \repeat unfold 6 { a, r a ' r | }
+      \repeat unfold 6 { a,8 r a ' r | }
 
       % --Bar 155 -- %
       \tuplet 3/2 {
-        a, \noBeam cis e a cis b |
-        cis a b cis e dis |
+        a,8 \noBeam cis e a cis b |
+        cis8 a b cis e dis |
       }
       e2-\trill ~ |
       e2 ~ |
@@ -542,7 +542,7 @@ harpsichordBass = \relative c' {
       % --Bar 159 -- %
       \tuplet 3/2 {
         e8 \noBeam e, fis g b a |
-        b g a b d cis |
+        b8 g a b d cis |
       }
       d2-\trill ~ |
       d2 ~ |
@@ -552,18 +552,18 @@ harpsichordBass = \relative c' {
       \tuplet 3/2 { g8 fis e d e fis | }
       \staffDown
       b,8. fis16 \tuplet 3/2 { b8 d cis | }
-      \tuplet 3/2 { d b cis d fis e | }
+      \tuplet 3/2 { d8 b cis d fis e | }
 
       %168
       fis8. b,16 fis'8. cis16 |
       \tuplet 3/2 { d8 cis b ais b cis | }
       fis,4 e' ~ |
       \tuplet 3/2 { e8 d cis b cis ais | }
-      \tuplet 3/2 { g' fis e d e cis | }
+      \tuplet 3/2 { g'8 fis e d e cis | }
       b8. fis16 b8. fis16 |
       \tuplet 3/2 { g8 fis e d e fis | }
       b,8. fis16 \tuplet 3/2 { b8 d cis | }
-      \tuplet 3/2 { d b cis d fis eis | }
+      \tuplet 3/2 { d8 b cis d fis eis | }
 
       %177
       fis2-\trill ~ |
@@ -571,15 +571,15 @@ harpsichordBass = \relative c' {
       e2-\trill ~ |
       \tuplet 3/2 { e8 \noBeam g fis e d cis | }
       d2-\trillB ~ |
-      d ~ |
+      d2 ~ |
       \tuplet 3/2 { d8 \noBeam fis, a d fis e | }
-      \tuplet 3/2 { fis d e fis a gis | }
+      \tuplet 3/2 { fis8 d e fis a gis | }
       a2^\trillB ~ |
       %186
       a2 ~ |
       \tuplet 3/2 {
         a8 \noBeam cis, e a cis b |
-        cis a b cis e d
+        cis8 a b cis e d
         |
       }
       e2-\trill ~
@@ -587,17 +587,17 @@ harpsichordBass = \relative c' {
       e2-\trill ~ |
       \tuplet 3/2 {
         e8 g fis e d cis |
-        d fis e d cis b |
-        cis e d cis b a |
+        d8 fis e d cis b |
+        cis8 e d cis b a |
         %195
-        b d cis b a gis |
-        a cis b a b a |
-        gis a gis fis eis fis |
-        cis eis dis cis dis eis |
-        fis a gis fis eis fis |
-        gis b a gis fis gis |
-        a cis b a gis fis |
-        b d cis b a gis |
+        b8 d cis b a gis |
+        a8 cis b a b a |
+        gis8 a gis fis eis fis |
+        cis8 eis dis cis dis eis |
+        fis8 a gis fis eis fis |
+        gis8 b a gis fis gis |
+        a8 cis b a gis fis |
+        b8 d cis b a gis |
       }
 
       % --Bar 203 -- %
@@ -608,43 +608,43 @@ harpsichordBass = \relative c' {
       a8 r b r |
       e,8 r r4 |
       a8 r d r |
-      b r g r |
+      b8 r g r |
 
 
       % --Bar 211 -- %
-      \tuplet 3/2 { e fis g a b c | }
-      d, r g r |
-      d' r c r |
+      \tuplet 3/2 { e8 fis g a b c | }
+      d,8 r g r |
+      d'8 r c r |
       b2 ~ |
       b8. \noBeam fis'16 b8. fis16 |
       g8. fis16 g8. e16 |
       <fis, fis'>2 ~ |
-      q ~ |
-      q |
+      q2 ~ |
+      q2 |
 
       % --Bar 220 -- %
       <fis fis'>2^\markup { \bold "tasto solo"} ~ |
-      q ~ q8.\noBeam b16 fis'8. a,16 |
+      q2 ~ q8.\noBeam b16 fis'8. a,16 |
       %should beam down
       \tuplet 3/2 { b8 a g ais b cis | }
       fis,4 ~ \tuplet 3/2 { fis8 fis' e | }
       \tuplet 3/2 {
-        d b cis d e fis |
-        e cis d e fis g |
+        d8 b cis d e fis |
+        e8 cis d e fis g |
         %227
-        fis d e fis g a |
-        g e fis gis a b |
-        a fis gis ais b cis |
+        fis8 d e fis g a |
+        g8 e fis gis a b |
+        a8 fis gis ais b cis |
       }
       b8. g!16 d8. e16 |
       fis8. e16 fis8. fis,16 |
       b4 r |
       %233
       <<
-        { \voiceOne a' }
-        \new Voice { \voiceThree fis }
-        \new Voice { \voiceTwo d }
-      >> \oneVoice r |
+        { \voiceOne a'4 }
+        \new Voice { \voiceThree fis4 }
+        \new Voice { \voiceTwo d4 }
+      >> \oneVoice r4 |
       %234
       R2*7 |
     }
@@ -717,7 +717,7 @@ harpsichordFigures = \figuremode {
       <5> <6\\> |
       <5> <6> |
       <5> <6> |
-      <4 2>8 s <6>8 s |
+      <4 2>8 s <6> s |
       <6 5>8 s <6 4 _+> s |
       <5>8 s <6> s |
       <6 5>4 s8 <7 _+> |

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord.ly
@@ -2,7 +2,7 @@
 
 \include "header.ly"
 
-\version "2.4.0"
+\version "2.18.0"
 harpsichordTreble =  \relative c'' {
 
 \commonSettings
@@ -13,19 +13,19 @@ harpsichordTreble =  \relative c'' {
 
 % --Bar 11-- %
     r8 r16 d a'8. e16 |
-    \times 2/3 { fis8 e d  cis d e } |
-    \times 2/3 { a, cis b  a b cis } |
-    \times 2/3 { fis, b a  gis cis b } |
-    \times 2/3 { a16 gis a b cis d   e fis e d cis b } |
-    \times 2/3 { a cis b a gis fis   e fis e d cis b } |
+    \tuplet 3/2 { fis8 e d  cis d e } |
+    \tuplet 3/2 { a, cis b  a b cis } |
+    \tuplet 3/2 { fis, b a  gis cis b } |
+    \tuplet 3/2 { a16 gis a b cis d   e fis e d cis b } |
+    \tuplet 3/2 { a cis b a gis fis   e fis e d cis b } |
 
 % --Bar 17-- %
 \change Staff = harpsichordDown \stemUp  a8  \change Staff = harpsichordUp  r a' r |
    a r gis d'\rest | \tieUp
    a2 \trill ~ |
-   \times 2/3 { a8 \noBeam cis b  a gis! fis } |
+   \tuplet 3/2 { a8 \noBeam cis b  a gis! fis } |
    e2 \trill ~| 
-   \times 2/3 { e8 \noBeam cis d   e d e  |
+   \tuplet 3/2 { e8 \noBeam cis d   e d e  |
         fis a gis  fis a gis |
         fis dis! e   fis e fis  | }
    gis r <e' cis b> r|
@@ -46,7 +46,7 @@ R |
 r8 r16 d a'8. e16 |
 
 % --Bar 41-- %
-\times 2/3 {fis8 e d cis d e  |
+\tuplet 3/2 {fis8 e d cis d e  |
   a,16 fis g a b cis d e d cis b a |
   b d cis b a g fis e fis g a fis |
   d cis d e fis g a b a g fis e|
@@ -54,24 +54,24 @@ r8 r16 d a'8. e16 |
   a d e fis e d b e fis g fis e | }
 
 % --Bar 47-- %
-\times 2/3 { cis16 fis g a g fis d g a b a g |
+\tuplet 3/2 { cis16 fis g a g fis d g a b a g |
 e g a b a g  fis g a b cis a |
 d8 cis b a b g |
 }
 fis r d' r |
 d r cis r |
 d2-\trill ~ 
-\times 2/3 { d8 \noBeam fis e d cis b  }
+\tuplet 3/2 { d8 \noBeam fis e d cis b  }
 
 % --Bar 54- %
 a2-\trill ~ |
-\times 2/3 { a8 \noBeam fis g a g a |
+\tuplet 3/2 { a8 \noBeam fis g a g a |
 b d cis b d cis |
 b gis a b a b | }
-\stemUp cis r \times 2/3 { r16 g' fis e d cis } |
-d8 r \times 2/3 { r16 fis e d cis b} |
-cis8 r \times 2/3 { r16 e d c b a } |
-\times 2/3 { b c b a g fis } r8 r16 <e g b> | %<c e g>  or <g e c>?
+\stemUp cis r \tuplet 3/2 { r16 g' fis e d cis } |
+d8 r \tuplet 3/2 { r16 fis e d cis b} |
+cis8 r \tuplet 3/2 { r16 e d c b a } |
+\tuplet 3/2 { b c b a g fis } r8 r16 <e g b> | %<c e g>  or <g e c>?
 <e g a cis>8 r <fis a d> r |
 <fis b d>8. <e b' d>16 <e a cis>8. <e g cis>16 |
 <d fis a d>8 r ^"accomp." r4 | \stemNeutral
@@ -80,9 +80,9 @@ r8 r16 g d'8. a16 |
 
 % --Bar 68- %
 b2-\trill ~ |
-\times 2/3 {b8 \noBeam d cis b d cis } |
+\tuplet 3/2 {b8 \noBeam d cis b d cis } |
 b2^\trillB ~ | 
-\times 2/3 {b8 \noBeam d cis b a gis | 
+\tuplet 3/2 {b8 \noBeam d cis b a gis | 
 cis e d cis b a |
 d fis e d cis b |
 e g fis e d cis |}
@@ -90,7 +90,7 @@ fis8 r s4 ^"accomp." |
 
 % --Bar 76- %
 s2*3|
-\times 2/3{
+\tuplet 3/2{
 fis,8-\pianoB( b d) d( cis d)|
 fis,( b d) d( cis d)|
 g,! (ais b) cis(ais b)|
@@ -102,13 +102,13 @@ e,(g cis) cis(ais b)
 cis( ais) b (fis b) ais |}
 b8 r r4 |
 s2*2|
-\times 2/3 { b8(-\pianoB fis' b) b( ais b) |
+\tuplet 3/2 { b8(-\pianoB fis' b) b( ais b) |
 d,( fis b) b(ais b) |
 e, (fis g)  e(fis d) |
 cis ( e ais) ais(gis ais) |}
 
 %93
-\times 2/3 { d,8( fis b) b( ais b) |
+\tuplet 3/2 { d,8( fis b) b( ais b) |
 g!( e cis)  ais( cis b) |
 ais( cis) b ais(b) cis | }
 d r r4 |
@@ -118,22 +118,22 @@ r8 r16 cis_\cantabileB fis8. cis16 |
 d2 ~ |
 
 %101
-d8. d16 \times 2/3 { e8( cis) d } |
+d8. d16 \tuplet 3/2 { e8( cis) d } |
 cis2 ~ |
 cis8. cis16 fis8. d16 |
 b2-\trill ~ |
-\times 2/3 { b8 cis d cis d b |
+\tuplet 3/2 { b8 cis d cis d b |
 a \noBeam fis_\forteI gis a cis b | } 
 cis r r4 |
-\times 2/3 { r8 e, fis gis b a  } |
+\tuplet 3/2 { r8 e, fis gis b a  } |
 b r r4 |
 
 %110
-\times 2/3 { r8 d, e fis a gis |
+\tuplet 3/2 { r8 d, e fis a gis |
 a cis, dis eis gis fis |
 gis b a gis b a | }
 gis2-\trill ~ |
-\times 2/3 { gis!8 \noBeam eis fis gis fis gis |
+\tuplet 3/2 { gis!8 \noBeam eis fis gis fis gis |
 a fis gis a gis a |
 b gis a b ais b |
 cis a b cis b cis |
@@ -144,18 +144,18 @@ gis, b a gis fis gis |
 a a, b cis b cis |
 d b cis d cis d |
 gis, a b } cis4 ~ |
-\times 2/3 { cis8 d e } fis4 ~ |
-fis8. fis16 \times 2/3 { eis8 fis gis } |
-cis,8. cis'16 \times 2/3 { b8 cis d } |
-eis,8.-\trill dis32 eis \times 2/3 { fis8 gis a } |
+\tuplet 3/2 { cis8 d e } fis4 ~ |
+fis8. fis16 \tuplet 3/2 { eis8 fis gis } |
+cis,8. cis'16 \tuplet 3/2 { b8 cis d } |
+eis,8.-\trill dis32 eis \tuplet 3/2 { fis8 gis a } |
 
 %127
-\times 2/3 { b cis d cis d b |
+\tuplet 3/2 { b cis d cis d b |
 a gis fis } r4^"accomp" |
 s2 * 19 |
 
 %148
-\times 2/3 { cis'8_\pianoB( e a) a( gis a) |
+\tuplet 3/2 { cis'8_\pianoB( e a) a( gis a) |
 cis,( e a) a( gis a)  |
 d,( e fis)  d( e cis) |
 
@@ -170,62 +170,62 @@ g2-\trill ~ |
 g |
 
 %159
-\times 2/3 { g8 \noBeam g, a b d cis |
+\tuplet 3/2 { g8 \noBeam g, a b d cis |
 d b cis d fis e | }
 fis2-\trill ~ |
 fis ~|
 fis8. \noBeam fis16 b8. fis16 |
-\stemUp \times 2/3 { g8 fis e d e fis | }
-b,8. fis16 \times 2/3 { b8 d cis |
+\stemUp \tuplet 3/2 { g8 fis e d e fis | }
+b,8. fis16 \tuplet 3/2 { b8 d cis |
 \stemNeutral d b cis d fis e |}
 fis8. b,16 fis'8. cis16 |
 
 %168
-\times 2/3 { d8 cis b ais b cis } |
+\tuplet 3/2 { d8 cis b ais b cis } |
 fis,4 e' ~ |
-\times 2/3 { e8 d cis b cis ais |
+\tuplet 3/2 { e8 d cis b cis ais |
 g' fis e d e cis | }
 b8. fis16 b8. fis16 |
-\times 2/3 { g8 fis e d e fis } |
-b,8. fis16 \times 2/3 { b8 d cis |
+\tuplet 3/2 { g8 fis e d e fis } |
+b,8. fis16 \tuplet 3/2 { b8 d cis |
 d b cis d fis e |
 fis d e fis a gis | }
 
 %177
 a2-\trill ~ |
-\times 2/3 { a8 \noBeam c b a g fis } |
+\tuplet 3/2 { a8 \noBeam c b a g fis } |
 g2-\trill ~ |
-\times 2/3 { g8 \noBeam b a g fis e } |
+\tuplet 3/2 { g8 \noBeam b a g fis e } |
 fis2^\trillB ~ |
 fis |
-\times 2/3 { fis8 \noBeam d e fis a g |
+\tuplet 3/2 { fis8 \noBeam d e fis a g |
 a fis g a cis b } |
 cis2-\trill ~ |
 
 %186
 cis ~ |
-\times 2/3 { cis8 \noBeam a b cis e d |
+\tuplet 3/2 { cis8 \noBeam a b cis e d |
 e cis d e g fis } |
 g2-\trill ~ |
-\times 2/3 { g8 \noBeam  e fis g e fis } |
+\tuplet 3/2 { g8 \noBeam  e fis g e fis } |
 g2-\trill ~ |
-\times 2/3 { g8 b a g fis e |
+\tuplet 3/2 { g8 b a g fis e |
 fis a g fis e d |
 e g fis e d cis } |
 
 %195
-\times 2/3 { d fis e d cis b |
+\tuplet 3/2 { d fis e d cis b |
 cis e d cis d cis |
 b a b cis d16 cis b a | }
-gis8. fis16 \times 2/3 { eis8 gis b } |
-\times 2/3 { a cis b a cis fis |
+gis8. fis16 \tuplet 3/2 { eis8 gis b } |
+\tuplet 3/2 { a cis b a cis fis |
 b, d cis b fis' eis |
 fis a, b cis d e |
 d fis e d fis b |
 
 %203
 gis eis fis } g4 ~ |
-\times 2/3 { g8 fis e! d cis b |
+\tuplet 3/2 { g8 fis e! d cis b |
 cis fis e dis e fis |
 b, e fis g a b |
 c! dis, e b e dis |
@@ -235,21 +235,21 @@ d, g a b c a |
 
 %211
 g a b } e,8. e'16 |
-\times 2/3 { a8 d, c b a g } |
-a4 ~ \times 2/3 { a16 g fis e dis e } |
-\times 2/3 { fis8 b a g fis e |
+\tuplet 3/2 { a8 d, c b a g } |
+a4 ~ \tuplet 3/2 { a16 g fis e dis e } |
+\tuplet 3/2 { fis8 b a g fis e |
 fis b ais b fis' ais, | }
 b r r4 |
-r8 r16 cis \times 2/3 { fis8( ais,) b } |
-cis8. fis,16 \times 2/3 { b8 gis eis } |
+r8 r16 cis \tuplet 3/2 { fis8( ais,) b } |
+cis8. fis,16 \tuplet 3/2 { b8 gis eis } |
 
 %219
-fis8. cis16 \times 2/3 { d8 \change Staff = harpsichordDown \stemUp ais b } | 
+fis8. cis16 \tuplet 3/2 { d8 \change Staff = harpsichordDown \stemUp ais b } | 
 \change Staff = harpsichordUp \stemNeutral 
 s2 * 2 |
 s2^"accomp." | 
 s2 *2 |
-\times 2/3 { r8 d e fis gis a |
+\tuplet 3/2 { r8 d e fis gis a |
 gis e fis gis ais b |
 
 %227
@@ -267,19 +267,19 @@ b4 r |
     
 % --Bar 11-- %
     r8 r16 d a'8. e16 |
-    \times 2/3 { fis8 e d  cis d e } |
-    \times 2/3 { a, cis b  a b cis } |
-    \times 2/3 { fis, b a  gis cis b } |
-    \times 2/3 { a16 gis a b cis d   e fis e d cis b } |
-    \times 2/3 { a cis b a gis fis   e fis e d cis b } |
+    \tuplet 3/2 { fis8 e d  cis d e } |
+    \tuplet 3/2 { a, cis b  a b cis } |
+    \tuplet 3/2 { fis, b a  gis cis b } |
+    \tuplet 3/2 { a16 gis a b cis d   e fis e d cis b } |
+    \tuplet 3/2 { a cis b a gis fis   e fis e d cis b } |
 
 % --Bar 17-- %
 \change Staff = harpsichordDown \stemUp  a8  \change Staff = harpsichordUp  r a' r |
    a r gis r |
    \tieUp a2 \trill ~ |
-   \times 2/3 { a8 \noBeam cis b  a gis! fis } |
+   \tuplet 3/2 { a8 \noBeam cis b  a gis! fis } |
    e2 \trill ~| 
-   \times 2/3 { e8 \noBeam cis d   e d e  | \tieNeutral
+   \tuplet 3/2 { e8 \noBeam cis d   e d e  | \tieNeutral
         fis a gis  fis a gis |
         fis dis! e   fis e fis  | }
    gis r <e' cis b> r|
@@ -300,7 +300,7 @@ R |
 r8 r16 d a'8. e16 |
 
 % --Bar 41-- %
-\times 2/3 {fis8 e d cis d e  |
+\tuplet 3/2 {fis8 e d cis d e  |
   a,16 fis g a b cis d e d cis b a |
   b d cis b a g fis e fis g a fis |
   d cis d e fis g a b a g fis e|
@@ -308,24 +308,24 @@ r8 r16 d a'8. e16 |
   a d e fis e d b e fis g fis e | }
 
 % --Bar 47-- %
-\times 2/3 { cis16 fis g a g fis d g a b a g |
+\tuplet 3/2 { cis16 fis g a g fis d g a b a g |
 e g a b a g  fis g a b cis a |
 d8 cis b a b g |
 }
 fis r d' r |
 d r cis r |
 d2-\trill ~ 
-\times 2/3 { d8 \noBeam fis e d cis b  }
+\tuplet 3/2 { d8 \noBeam fis e d cis b  }
 
 % --Bar 54- %
 a2-\trill ~ |
-\times 2/3 { a8 \noBeam fis g a g a |
+\tuplet 3/2 { a8 \noBeam fis g a g a |
 b d cis b d cis |
 b gis a b a b | }
-\stemUp cis r \times 2/3 { r16 g' fis e d cis } |
-d8 r \times 2/3 { r16 fis e d cis b} |
-cis8 r \times 2/3 { r16 e d c b a } |
-\times 2/3 { b c b a g fis } r8 r16 <e g b> | %<c e g>  or <g e c>?
+\stemUp cis r \tuplet 3/2 { r16 g' fis e d cis } |
+d8 r \tuplet 3/2 { r16 fis e d cis b} |
+cis8 r \tuplet 3/2 { r16 e d c b a } |
+\tuplet 3/2 { b c b a g fis } r8 r16 <e g b> | %<c e g>  or <g e c>?
 <e g a cis>8 r <fis a d> r |
 <fis b d>8. <e b' d>16 <e a cis>8. <e g cis>16 |
 <d fis a d>8 r ^"accomp." r4 | \stemNeutral
@@ -334,9 +334,9 @@ r8 r16 g d'8. a16 |
 
 % --Bar 68- %
 b2-\trill ~ |
-\times 2/3 {b8 \noBeam d cis b d cis } |
+\tuplet 3/2 {b8 \noBeam d cis b d cis } |
 b2^\trillB ~ | %(tr)?
-\times 2/3 {b8 \noBeam d cis b a gis | 
+\tuplet 3/2 {b8 \noBeam d cis b a gis | 
 cis e d cis b a |
 d fis e d cis b |
 e g fis e d cis |}
@@ -369,7 +369,7 @@ harpsichordBass =  \relative c' {
 
  % --Bar 9-- %
  r8 r16 a d8. a16_\fbRootVII |
- \times 2/3 { b8_\fbRootV a g  fis_\fbIinv g a } |
+ \tuplet 3/2 { b8_\fbRootV a g  fis_\fbIinv g a } |
  d, r cis r |
  d r e r |
  fis r cis r |
@@ -379,19 +379,19 @@ fis r gis r |
 
 
  % --Bar 17-- %
-\times 2/3 { a cis b a b cis } |
+\tuplet 3/2 { a cis b a b cis } |
 d r \change Staff = harpsichordUp \stemDown e c\rest | \tieDown %\voiceTwo
 fis2_\trill ~ | 
-\times 2/3 { fis8 \noBeam a gis  fis e d } |
+\tuplet 3/2 { fis8 \noBeam a gis  fis e d } |
 cis2_\trill ~|
-\times 2/3 { cis8 \noBeam a b   cis b cis } | \tieNeutral
-\times 2/3 { dis fis e  dis fis e } |
-\times 2/3 { dis b cis  dis cis dis } |
-\times 2/3 { e16 d! e  fis e d   cis d cis \change Staff = harpsichordDown \stemUp  b a gis | }
+\tuplet 3/2 { cis8 \noBeam a b   cis b cis } | \tieNeutral
+\tuplet 3/2 { dis fis e  dis fis e } |
+\tuplet 3/2 { dis b cis  dis cis dis } |
+\tuplet 3/2 { e16 d! e  fis e d   cis d cis \change Staff = harpsichordDown \stemUp  b a gis | }
 
 \stemNeutral 
 % --Bar 26-- %
-\times 2/3 { fis e fis  gis a fis   b cis b  a gis fis |
+\tuplet 3/2 { fis e fis  gis a fis   b cis b  a gis fis |
 e d e  fis gis e   fis a gis fis e d |
 cis8 b a } e'8. e,16 |
 a8 r fis_\fbIinv r |
@@ -399,7 +399,7 @@ g_\fbIinvVII r
 <<	
 	 { \voiceOne a d\rest } \\ 
 { 
-\times 2/3 { s_\fbIinvVII s_\fbIVMv s_\fbVnIII } 
+\tuplet 3/2 { s_\fbIinvVII s_\fbIVMv s_\fbVnIII } 
 }
 
 
@@ -419,7 +419,7 @@ b_\fbIinvVII r cis_\fbIinvVII r |
 d r r4 |
 R2 |
 r8 r16 a d8. a16 |
- \times 2/3 { b8 a g  fis g a } |
+ \tuplet 3/2 { b8 a g  fis g a } |
 
 % --Bar 41-- %
 d, r e r |
@@ -432,70 +432,70 @@ fis r g r |
 % --Bar 47-- %
 a8 r b r |
 cis8. \noBeam a16 d8. a16 |
-\times 2/3 { b8 a g fis g  a } |
-\times 2/3 { d, fis e d e fis } |
+\tuplet 3/2 { b8 a g fis g  a } |
+\tuplet 3/2 { d, fis e d e fis } |
 g r a r |
 b2-\trill ~ |
-\times 2/3 { b8 \noBeam d cis b a g} |
+\tuplet 3/2 { b8 \noBeam d cis b a g} |
 fis2-\trill ~ |
-\times 2/3 { fis8 \noBeam d e fis e fis} |
-\times 2/3 { gis b a gis b a } |
-\times 2/3 { gis e fis gis fis gis } |
-\stemDown \times 2/3 { a16 cis \change Staff = harpsichordUp d e fis g! } a8 r |
-\change Staff = harpsichordDown \times 2/3 { r16 b, cis d \change Staff = harpsichordUp e fis } g8 r |
-\change Staff = harpsichordDown \times 2/3 { r16 a, b cis d \change Staff = harpsichordUp e  }fis8 r |
+\tuplet 3/2 { fis8 \noBeam d e fis e fis} |
+\tuplet 3/2 { gis b a gis b a } |
+\tuplet 3/2 { gis e fis gis fis gis } |
+\stemDown \tuplet 3/2 { a16 cis \change Staff = harpsichordUp d e fis g! } a8 r |
+\change Staff = harpsichordDown \tuplet 3/2 { r16 b, cis d \change Staff = harpsichordUp e fis } g8 r |
+\change Staff = harpsichordDown \tuplet 3/2 { r16 a, b cis d \change Staff = harpsichordUp e  }fis8 r |
 
 % --Bar 61-- %
-\change Staff = harpsichordDown g, r \change Staff = harpsichordUp \times 2/3 { e'16 fis e d cis! \change Staff = harpsichordDown \stemNeutral b} |
-\times 2/3 { a b a g fis e d e d cis b a |
+\change Staff = harpsichordDown g, r \change Staff = harpsichordUp \tuplet 3/2 { e'16 fis e d cis! \change Staff = harpsichordDown \stemNeutral b} |
+\tuplet 3/2 { a b a g fis e d e d cis b a |
 b8 a g } a8. a16 |
 d,8 r fis r | % 6 3?
 g r c r | % <2 4 6>
 b8. \noBeam g'16 d'8. a16 |
-\times 2/3 {b8 a g fis gis a |}
+\tuplet 3/2 {b8 a g fis gis a |}
 
 % --Bar 68-- %
 gis2-\trill ~ |
-\times 2/3 {gis8 \noBeam b a gis b a }|
+\tuplet 3/2 {gis8 \noBeam b a gis b a }|
 gis2^\trillB ~ | 
-\times 2/3 {gis8 \noBeam b a gis fis e |
+\tuplet 3/2 {gis8 \noBeam b a gis fis e |
 a cis b a g! fis |
 b d cis b a g |
 cis e d cis b a |}
 d r fis, r |
 g r a r |
-\times 2/3 {b a g} a8. a,16 |
-\times 2/3 {d8 fis e d e fis}|
+\tuplet 3/2 {b a g} a8. a,16 |
+\tuplet 3/2 {d8 fis e d e fis}|
 b,8 r r4 |
 %79
 \repeat unfold 5{ b8 r r4 |}
 
 %85
 b8 r r4 |
-b8. \noBeam fis'16 \times 2/3 { b8 d cis |
+b8. \noBeam fis'16 \tuplet 3/2 { b8 d cis |
 d cis b ais b cis |}
-fis,4 ~ \times 2/3 { fis8 g e |
+fis,4 ~ \tuplet 3/2 { fis8 g e |
 d cis b } r4 |
 %90
 \repeat unfold 6 { b8 r r4 | }
 %96
-b8. \noBeam fis'16 \times 2/3 { b8 a gis |
+b8. \noBeam fis'16 \tuplet 3/2 { b8 a gis |
 a gis fis eis fis gis |}
-cis,4 ~ \times 2/3 { cis8 d b |
+cis,4 ~ \tuplet 3/2 { cis8 d b |
 a gis fis } r4 |
 %100
 \repeat unfold 6 { fis8 r r4 | }
 %106
-fis8.\noBeam cis'16 \times 2/3 { fis8 a gis } |
+fis8.\noBeam cis'16 \tuplet 3/2 { fis8 a gis } |
 a8 r r4 |
 %108
-\times 2/3 { r8 cis, d e gis fis } |
+\tuplet 3/2 { r8 cis, d e gis fis } |
 gis r r4 |
-\times 2/3 { r8 b, cis d fis eis | 
+\tuplet 3/2 { r8 b, cis d fis eis | 
 fis a, b cis eis dis |
 eis gis fis eis gis fis |}
 eis2-\trill ~ |
-\times 2/3 { eis!8 \noBeam cis dis eis! dis eis |
+\tuplet 3/2 { eis!8 \noBeam cis dis eis! dis eis |
 %115
 fis d! e! fis e fis |
 gis e fis  gis fis gis |
@@ -505,8 +505,8 @@ b gis a b a b |
 eis, gis fis eis dis eis|
 fis fis, gis a gis a |
 b gis a b a b |}
-cis4 ~ \times 2/3 { cis8 d e } |
-fis4 ~ \times 2/3 { fis8 gis ais |
+cis4 ~ \tuplet 3/2 { cis8 d e } |
+fis4 ~ \tuplet 3/2 { fis8 gis ais |
 	b  cis d cis dis eis |
 	fis, gis a gis a b |
 a b cis } d, r |
@@ -535,7 +535,7 @@ d r cis r |
 
 % --Bar 143 -- %
 d r e r |
-\times 2/3 { fis e d cis dis e }
+\tuplet 3/2 { fis e d cis dis e }
 dis4 r8 b |
 e8. d!16 cis8. fis,16 |
 e8. d16 e8. e,16 |
@@ -543,13 +543,13 @@ a8 r a' r |
 \repeat unfold 6 { a, r a ' r |}
 
 % --Bar 155 -- %
-\times 2/3 { a, \noBeam cis e a cis b |
+\tuplet 3/2 { a, \noBeam cis e a cis b |
 cis a b cis e dis | }
 e2-\trill ~ |
 e2 ~ |
 
 % --Bar 159 -- %
-\times 2/3 { e8 \noBeam e, fis g b a |
+\tuplet 3/2 { e8 \noBeam e, fis g b a |
 b g a  b d cis |}
 d2-\trill ~ |
 d2 ~ |
@@ -557,45 +557,45 @@ d8 r r4 |
 \change Staff = harpsichordUp
 \stemDown
 r8 r16 fis b8. fis16 |
-\times 2/3 { g8 fis e  d e fis |}
+\tuplet 3/2 { g8 fis e  d e fis |}
 \stemNeutral \change Staff = harpsichordDown
-b,8. fis16 \times 2/3 { b8 d cis } |
-\times 2/3 { d b cis d fis e } |
+b,8. fis16 \tuplet 3/2 { b8 d cis } |
+\tuplet 3/2 { d b cis d fis e } |
 
 %168
 fis8. b,16 fis'8. cis16 |
-\times 2/3 { d8 cis b ais b cis } |
+\tuplet 3/2 { d8 cis b ais b cis } |
 fis,4 e' ~ |
-\times 2/3 { e8 d cis b cis ais } |
-\times 2/3 { g' fis e d e cis  } |
+\tuplet 3/2 { e8 d cis b cis ais } |
+\tuplet 3/2 { g' fis e d e cis  } |
 b8. fis16 b8. fis16 |
-\times 2/3 { g8 fis e d e fis } |
-b,8. fis16 \times 2/3 { b8 d cis } |
-\times 2/3 { d b cis d fis eis } |
+\tuplet 3/2 { g8 fis e d e fis } |
+b,8. fis16 \tuplet 3/2 { b8 d cis } |
+\tuplet 3/2 { d b cis d fis eis } |
 
 %177
 fis2-\trill ~ |
-\times 2/3 { fis8 \noBeam a g fis e dis } |
+\tuplet 3/2 { fis8 \noBeam a g fis e dis } |
 e2-\trill ~ |
-\times 2/3 { e8 \noBeam g fis e d cis } |
+\tuplet 3/2 { e8 \noBeam g fis e d cis } |
 d2-\trillB ~ |
 d ~ |
-\times 2/3 { d8 \noBeam fis, a d fis e } |
-\times 2/3 { fis d e fis a gis } |
+\tuplet 3/2 { d8 \noBeam fis, a d fis e } |
+\tuplet 3/2 { fis d e fis a gis } |
 a2^\trillB ~ |
 %186
 a2 ~ |
-\times 2/3 { a8 \noBeam cis, e a cis b |
+\tuplet 3/2 { a8 \noBeam cis, e a cis b |
 cis a b cis e d } |
 e2-\trill ~
-\times 2/3 { e8 \noBeam cis d e cis d  } |
+\tuplet 3/2 { e8 \noBeam cis d e cis d  } |
 e2-\trill ~ |
-\times 2/3 { e8 g fis e d cis | 
+\tuplet 3/2 { e8 g fis e d cis | 
 d fis e d cis b |
 cis e d cis b a | }
 
 %195
-\times 2/3 { b d cis b a gis |
+\tuplet 3/2 { b d cis b a gis |
 a cis b a b a | 
 gis a gis fis eis fis |
 cis eis dis cis dis eis |
@@ -616,7 +616,7 @@ b r g r |
 
 
 % --Bar 211 -- %
-\times 2/3 { e fis g a b c } |
+\tuplet 3/2 { e fis g a b c } |
 d, r g r |
 d' r c r |
 b2~ |
@@ -632,13 +632,13 @@ g8. fis16 g8. e16 |
 % --Bar 222 -- %
 \voiceOne b,16 fis'8. a,16 |
 %should beam down
-\times 2/3 {b8 a g  ais b cis }|
-fis,4 ~ \times 2/3 {fis8 fis' e } |
-\times 2/3 { d b cis d e fis |
+\tuplet 3/2 {b8 a g  ais b cis }|
+fis,4 ~ \tuplet 3/2 {fis8 fis' e } |
+\tuplet 3/2 { d b cis d e fis |
 e cis d e fis g | }
 
 %227
-\times 2/3 { fis d e fis g a |
+\tuplet 3/2 { fis d e fis g a |
 g e fis gis a b |
 a fis gis ais b cis | }
 b8. g!16 d8. e16 |
@@ -655,7 +655,7 @@ R2*7 |
 
 % --Bar 9-- %
  r8 r16 a d8. a16_\fbRootVII |
- \times 2/3 { b8_\fbRootV a g  fis_\fbIinv g a } |
+ \tuplet 3/2 { b8_\fbRootV a g  fis_\fbIinv g a } |
  d, r cis r |
  d r e r |
  fis r cis r |
@@ -665,26 +665,26 @@ fis r gis r |
 
 
  % --Bar 17-- %
-\times 2/3 { a cis b a b cis } |
+\tuplet 3/2 { a cis b a b cis } |
 d r \change Staff = harpsichordUp \stemDown e r | \tieUp %\voiceTwo
 fis2_\trill ~ | 
-\times 2/3 { fis8 \noBeam a gis  fis e d } |
+\tuplet 3/2 { fis8 \noBeam a gis  fis e d } |
 cis2_\trill ~|
-\times 2/3 { cis8 \noBeam a b   cis b cis } | \tieNeutral
-\times 2/3 { dis fis e  dis fis e } |
-\times 2/3 { dis b cis  dis cis dis } |
-\times 2/3 { e16 d! e  fis e d   cis d cis \change Staff = harpsichordDown \stemUp  b a gis | }
+\tuplet 3/2 { cis8 \noBeam a b   cis b cis } | \tieNeutral
+\tuplet 3/2 { dis fis e  dis fis e } |
+\tuplet 3/2 { dis b cis  dis cis dis } |
+\tuplet 3/2 { e16 d! e  fis e d   cis d cis \change Staff = harpsichordDown \stemUp  b a gis | }
 
 \stemNeutral 
 % --Bar 26-- %
-\times 2/3 { fis e fis  gis a fis   b cis b  a gis fis |
+\tuplet 3/2 { fis e fis  gis a fis   b cis b  a gis fis |
 e d e  fis gis e   fis a gis fis e d |
 cis8 b a } e'8. e,16 |
 a8 r fis_\fbIinv r |
 g_\fbIinvVII r 
 <<	
 { 
-\times 2/3 { s_\fbIinvVII s_\fbIV s_\fbVnIII } 
+\tuplet 3/2 { s_\fbIinvVII s_\fbIV s_\fbVnIII } 
 }
 	\\ { \stemUp a d\rest } 
 >>
@@ -703,7 +703,7 @@ b_\fbIinvVII r cis_\fbIinvVII r |
 d r r4 |
 R2 |
 r8 r16 a d8. a16 |
- \times 2/3 { b8 a g  fis g a } |
+ \tuplet 3/2 { b8 a g  fis g a } |
 
 % --Bar 41-- %
 d, r e r |
@@ -716,41 +716,41 @@ fis r g r |
 % --Bar 47-- %
 a8 r b r |
 cis8. \noBeam a16 d8. a16 |
-\times 2/3 { b8 a g fis g  a } |
-\times 2/3 { d, fis e d e fis } |
+\tuplet 3/2 { b8 a g fis g  a } |
+\tuplet 3/2 { d, fis e d e fis } |
 g r a r |
 b2-\trill ~ |
-\times 2/3 { b8 \noBeam d cis b a g} |
+\tuplet 3/2 { b8 \noBeam d cis b a g} |
 fis2-\trill ~ |
-\times 2/3 { fis8 \noBeam d e fis e fis} |
-\times 2/3 { gis b a gis b a } |
-\times 2/3 { gis e fis gis fis gis } |
-\stemDown \times 2/3 { a16 cis \change Staff = harpsichordUp d e fis g! } a8 r |
-\change Staff = harpsichordDown \times 2/3 { r16 b, cis d \change Staff = harpsichordUp e fis } g8 r |
-\change Staff = harpsichordDown \times 2/3 { r16 a, b cis d \change Staff = harpsichordUp e  }fis8 r |
+\tuplet 3/2 { fis8 \noBeam d e fis e fis} |
+\tuplet 3/2 { gis b a gis b a } |
+\tuplet 3/2 { gis e fis gis fis gis } |
+\stemDown \tuplet 3/2 { a16 cis \change Staff = harpsichordUp d e fis g! } a8 r |
+\change Staff = harpsichordDown \tuplet 3/2 { r16 b, cis d \change Staff = harpsichordUp e fis } g8 r |
+\change Staff = harpsichordDown \tuplet 3/2 { r16 a, b cis d \change Staff = harpsichordUp e  }fis8 r |
 
 % --Bar 61-- %
-\change Staff = harpsichordDown g, r \change Staff = harpsichordUp \times 2/3 { e'16 fis e d cis! \change Staff = harpsichordDown \stemNeutral b} |
+\change Staff = harpsichordDown g, r \change Staff = harpsichordUp \tuplet 3/2 { e'16 fis e d cis! \change Staff = harpsichordDown \stemNeutral b} |
 \stemNeutral
-\times 2/3 { a b a g fis e d e d cis b a |
+\tuplet 3/2 { a b a g fis e d e d cis b a |
 b8 a g } a8. a16 |
 d,8 r fis r | % 6 3?
 g r c r | % <2 4 6>
 b8. \noBeam g'16 d'8. a16 |
-\times 2/3 {b8 a g fis gis a |}
+\tuplet 3/2 {b8 a g fis gis a |}
 
 % --Bar 68-- %
 gis2-\trill ~ |
-\times 2/3 {gis8 \noBeam b a gis b a }|
+\tuplet 3/2 {gis8 \noBeam b a gis b a }|
 gis2-\trill ~ | %(tr)
-\times 2/3 {gis8 b a gis fis e |
+\tuplet 3/2 {gis8 b a gis fis e |
 a cis b a g! fis |
 b d cis b a g |
 cis e d cis b a |}
 
 d r fis, r |
 g r a r |
-\times 2/3 {b a g} a8. a,16 |
+\tuplet 3/2 {b a g} a8. a,16 |
 d2-\fermata \bar "||"
 
 } % end for Notes Bass
@@ -768,13 +768,13 @@ harpsichordTa =
 	>>
 
 	\context Staff = harpsichordDown <<   \time 2/4 \clef bass  \key d \major
-		\set Staff.instrument = \markup \smaller { 
-			\column <
+		\set Staff.instrumentName = \markup \smaller { 
+			\column {
 				"Cembalo" 
 				"concertato."
-			 > }
+			 } }
 		%"Harpischord solo"
-		%\set Staff.instr = "Clavier"
+		%\set Staff.shortInstrumentName = "Clavier"
 		\set Staff.midiInstrument = "harpsichord" 	 	
 		\harpsichordBass
 	>>

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord.ly
@@ -1,5 +1,3 @@
-#(ly:set-point-and-click 'line-column )
-
 \include "header.ly"
 
 \version "2.18.0"

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord.ly
@@ -2,28 +2,25 @@
 
 \include "header.ly"
 
-harpsichordTreble = \relative c'' {
-  
-  \commonSettings
-  \triplets \tripletsHide
-  
-  \time 2/4 \clef treble \key d \major
-  % --Bar 1-- %
-  \repeat unfold 10 R2 |
-
+harpsichordTrebleI = \relative c'' {
   % --Bar 11-- %
   r8 r16 d a'8. e16 |
-  \tuplet 3/2 { fis8 e d cis d e } |
-  \tuplet 3/2 { a, cis b a b cis } |
-  \tuplet 3/2 { fis, b a gis cis b } |
-  \tuplet 3/2 { a16 gis a b cis d e fis e d cis b } |
-  \tuplet 3/2 { a cis b a gis fis e fis e d cis b } |
-
+  \tuplet 3/2 { 
+    fis8 e d cis d e |
+    a, cis b a b cis |
+    fis, b a gis cis b |
+    a16 gis a b cis d e fis e d cis b |
+    a cis b a gis fis e fis e d cis b |
+  }
   % --Bar 17-- %
-  \change Staff = harpsichordDown \stemUp a8 \change Staff = harpsichordUp r a' r |
-  a r gis d'\rest | \tieUp
+  \change Staff = harpsichordDown
+  \once \voiceOne 
+  a8 
+  \change Staff = harpsichordUp 
+  r a' r |
+  a r \voiceOne gis r |
   a2 \trill ~ |
-  \tuplet 3/2 { a8 \noBeam cis b a gis! fis } |
+  \tuplet 3/2 { a8 \noBeam cis b a gis! fis | }
   e2 \trill ~ |
   \tuplet 3/2 {
     e8 \noBeam cis d e d e |
@@ -31,21 +28,21 @@ harpsichordTreble = \relative c'' {
     fis dis! e fis e fis |
   }
   gis r <e' cis b> r |
-  \tieNeutral
+  \oneVoice
   % --Bar 26-- %
   <a, cis e > r < fis b d> r |
   <gis b d > r
   <<
     { cis8. d16 | e8. fis16 } \\
     { a,4 ~ | a }
-  >> %\stemDown
-  \stemNeutral b8. a16 |
-  a8 r s ^"accomp." s
-  s2 s s
-  % --Bar 33-- %
-  s s s s s
+  >>
+  b8. a16 |
+  a8 r s^"accomp." s
+  % --Bar 30
+  s2*8 |
+  % --Bar 38-- %
   R2 |
-  R |
+  R2 |
   r8 r16 d a'8. e16 |
 
   % --Bar 41-- %
@@ -76,19 +73,21 @@ harpsichordTreble = \relative c'' {
     b d cis b d cis |
     b gis a b a b |
   }
-  \stemUp cis r \tuplet 3/2 { r16 g' fis e d cis } |
-  d8 r \tuplet 3/2 { r16 fis e d cis b} |
-  cis8 r \tuplet 3/2 { r16 e d c b a } |
+  \voiceOne
+  cis r \tuplet 3/2 { r16 g' fis e d cis | }
+  d8 r \tuplet 3/2 { r16 fis e d cis b| }
+  cis8 r \tuplet 3/2 { r16 e d c b a | }
   \tuplet 3/2 { b c b a g fis } r8 r16 <e g b> | %<c e g> or <g e c>?
+  \oneVoice
   <e g a cis>8 r <fis a d> r |
   <fis b d>8. <e b' d>16 <e a cis>8. <e g cis>16 |
-  <d fis a d>8 r ^"accomp." r4 | \stemNeutral
-  s2 | s2 | % 2 completely emtpy bars
+  <d fis a d>8 r ^"accomp." r4 |
+  s2*2 |
   r8 r16 g d'8. a16 |
 
   % --Bar 68- %
   b2-\trill ~ |
-  \tuplet 3/2 { b8 \noBeam d cis b d cis } |
+  \tuplet 3/2 { b8 \noBeam d cis b d cis | }
   b2^\trillB ~ |
   \tuplet 3/2 {
     b8 \noBeam d cis b a gis |
@@ -96,17 +95,20 @@ harpsichordTreble = \relative c'' {
     d fis e d cis b |
     e g fis e d cis |
   }
-  fis8 r s4 ^"accomp." |
+  fis8 r s4 ^"accomp." | 
+}
+
+harpsichordTrebleII = \relative c'' {
 
   % --Bar 76- %
   s2*3 |
   \tuplet 3/2 {
     fis,8-\pianoB( b d) d( cis d) |
     fis,( b d) d( cis d) |
-    g,!( ais b) cis(ais b) |
-    e,( ais cis) cis(b cis) |
-    fis,(b d) d( cis d) |
-    e,(g cis) cis(ais b)
+    g,!( ais b) cis( ais b) |
+    e,( ais cis) cis( b cis) |
+    fis,( b d) d( cis d) |
+    e,( g cis) cis( ais b)
 
     %85
     cis( ais) b( fis b) ais |
@@ -127,13 +129,13 @@ harpsichordTreble = \relative c'' {
     ais( cis) b ais( b) cis |
   }
   d r r4 |
-  s2 * 2 |
+  s2*2 |
 
   r8 r16 cis_\cantabileB fis8. cis16 |
   d2 ~ |
 
   %101
-  d8. d16 \tuplet 3/2 { e8( cis) d } |
+  d8. d16 \tuplet 3/2 { e8( cis) d | }
   cis2 ~ |
   cis8. cis16 fis8. d16 |
   b2-\trill ~ |
@@ -142,7 +144,7 @@ harpsichordTreble = \relative c'' {
     a \noBeam fis_\forteI gis a cis b |
   }
   cis r r4 |
-  \tuplet 3/2 { r8 e, fis gis b a } |
+  \tuplet 3/2 { r8 e, fis gis b a | }
   b r r4 |
 
   %110
@@ -166,9 +168,9 @@ harpsichordTreble = \relative c'' {
     gis, a b
   } cis4 ~ |
   \tuplet 3/2 { cis8 d e } fis4 ~ |
-  fis8. fis16 \tuplet 3/2 { eis8 fis gis } |
-  cis,8. cis'16 \tuplet 3/2 { b8 cis d } |
-  eis,8.-\trill dis32 eis \tuplet 3/2 { fis8 gis a } |
+  fis8. fis16 \tuplet 3/2 { eis8 fis gis | }
+  cis,8. cis'16 \tuplet 3/2 { b8 cis d | }
+  eis,8.-\trill dis32 eis \tuplet 3/2 { fis8 gis a | }
 
   %127
   \tuplet 3/2 {
@@ -210,14 +212,14 @@ harpsichordTreble = \relative c'' {
   fis8. b,16 fis'8. cis16 |
 
   %168
-  \tuplet 3/2 { d8 cis b ais b cis } |
+  \tuplet 3/2 { d8 cis b ais b cis | }
   fis,4 e' ~ |
   \tuplet 3/2 {
     e8 d cis b cis ais |
     g' fis e d e cis |
   }
   b8. fis16 b8. fis16 |
-  \tuplet 3/2 { g8 fis e d e fis } |
+  \tuplet 3/2 { g8 fis e d e fis | }
   b,8. fis16 \tuplet 3/2 {
     b8 d cis |
     d b cis d fis e |
@@ -226,31 +228,31 @@ harpsichordTreble = \relative c'' {
 
   %177
   a2-\trill ~ |
-  \tuplet 3/2 { a8 \noBeam c b a g fis } |
+  \tuplet 3/2 { a8 \noBeam c b a g fis | }
   g2-\trill ~ |
-  \tuplet 3/2 { g8 \noBeam b a g fis e } |
+  \tuplet 3/2 { g8 \noBeam b a g fis e | }
   fis2^\trillB ~ |
   fis |
   \tuplet 3/2 {
     fis8 \noBeam d e fis a g |
     a fis g a cis b
-  } |
+  | }
   cis2-\trill ~ |
 
   %186
   cis ~ |
   \tuplet 3/2 {
     cis8 \noBeam a b cis e d |
-    e cis d e g fis
-  } |
+    e cis d e g fis |
+  }
   g2-\trill ~ |
-  \tuplet 3/2 { g8 \noBeam e fis g e fis } |
+  \tuplet 3/2 { g8 \noBeam e fis g e fis | }
   g2-\trill ~ |
   \tuplet 3/2 {
     g8 b a g fis e |
     fis a g fis e d |
-    e g fis e d cis
-  } |
+    e g fis e d cis |
+  }
 
   %195
   \tuplet 3/2 {
@@ -258,7 +260,7 @@ harpsichordTreble = \relative c'' {
     cis e d cis d cis |
     b a b cis d16 cis b a |
   }
-  gis8. fis16 \tuplet 3/2 { eis8 gis b } |
+  gis8. fis16 \tuplet 3/2 { eis8 gis b | }
   \tuplet 3/2 {
     a cis b a cis fis |
     b, d cis b fis' eis |
@@ -280,22 +282,22 @@ harpsichordTreble = \relative c'' {
     %211
     g a b
   } e,8. e'16 |
-  \tuplet 3/2 { a8 d, c b a g } |
-  a4 ~ \tuplet 3/2 { a16 g fis e dis e } |
+  \tuplet 3/2 { a8 d, c b a g | }
+  a4 ~ \tuplet 3/2 { a16 g fis e dis e | }
   \tuplet 3/2 {
     fis8 b a g fis e |
     fis b ais b fis' ais, |
   }
   b r r4 |
-  r8 r16 cis \tuplet 3/2 { fis8( ais,) b } |
-  cis8. fis,16 \tuplet 3/2 { b8 gis eis } |
+  r8 r16 cis \tuplet 3/2 { fis8( ais,) b | }
+  cis8. fis,16 \tuplet 3/2 { b8 gis eis | }
 
   %219
-  fis8. cis16 \tuplet 3/2 { d8 \change Staff = harpsichordDown \stemUp ais b } |
-  \change Staff = harpsichordUp \stemNeutral
-  s2 * 2 |
+  fis8. cis16 \tuplet 3/2 { d8 \change Staff = harpsichordDown ais b | }
+  \change Staff = harpsichordUp \oneVoice
+  s2*2 |
   s2^"accomp." |
-  s2 *2 |
+  s2*2 |
   \tuplet 3/2 {
     r8 d e fis gis a |
     gis e fis gis ais b |
@@ -305,131 +307,33 @@ harpsichordTreble = \relative c'' {
     b gis a! b cis d |
     cis ais b cis d e |
     fis( d) b fis'( d) b |
-    fis'( d) b fis( b ais)
-  } |
+    fis'( d) b fis( b ais) |
+  }
   b4 r |
-  << \shiftOn \stemUp { < d, fis a > } \\ { \stemUp d' } >>r | %
-  \stemNeutral \shiftOff
-  %repeat bar 1 to 76
+  << { \voiceOne d } \new Voice { \voiceThree <d, fis a> } >> \oneVoice r |
+}
+
+harpsichordTreble = \relative c'' {
+  \omit TupletNumber
+  
+  \time 2/4
+  \clef treble
+  \key d \major
+  
   % --Bar 1-- %
-  R2 * 9 |
-
-  % --Bar 11-- %
-  r8 r16 d a'8. e16 |
-  \tuplet 3/2 { fis8 e d cis d e } |
-  \tuplet 3/2 { a, cis b a b cis } |
-  \tuplet 3/2 { fis, b a gis cis b } |
-  \tuplet 3/2 { a16 gis a b cis d e fis e d cis b } |
-  \tuplet 3/2 { a cis b a gis fis e fis e d cis b } |
-
-  % --Bar 17-- %
-  \change Staff = harpsichordDown \stemUp a8 \change Staff = harpsichordUp r a' r |
-  a r gis r |
-  \tieUp a2 \trill ~ |
-  \tuplet 3/2 { a8 \noBeam cis b a gis! fis } |
-  e2 \trill ~ |
-  \tuplet 3/2 {
-    e8 \noBeam cis d e d e | \tieNeutral
-    fis a gis fis a gis |
-    fis dis! e fis e fis |
-  }
-  gis r <e' cis b> r |
-
-  % --Bar 26-- %
-  <a, cis e > r < fis b d> r |
-  <gis b d > r
-  <<
-    { cis8. d16 | e8. fis16 }
-    \\
-    { a,4 ~ | a }
-  >> %\stemDown
-  \stemNeutral b8. a16 |
-  a8 r s ^"accomp." s
-  s2 s s
-  % --Bar 33-- %
-  s s s s s
-  R2 |
-  R |
-  r8 r16 d a'8. e16 |
-
-  % --Bar 41-- %
-  \tuplet 3/2 {
-    fis8 e d cis d e |
-    a,16 fis g a b cis d e d cis b a |
-    b d cis b a g fis e fis g a fis |
-    d cis d e fis g a b a g fis e |
-    fis a g fis e d cis b cis d e cis |
-    a d e fis e d b e fis g fis e |
-  }
-
-  % --Bar 47-- %
-  \tuplet 3/2 {
-    cis16 fis g a g fis d g a b a g |
-    e g a b a g fis g a b cis a |
-    d8 cis b a b g |
-  }
-  fis r d' r |
-  d r cis r |
-  d2-\trill ~
-  \tuplet 3/2 { d8 \noBeam fis e d cis b }
-
-  % --Bar 54- %
-  a2-\trill ~ |
-  \tuplet 3/2 {
-    a8 \noBeam fis g a g a |
-    b d cis b d cis |
-    b gis a b a b |
-  }
-  \stemUp cis r \tuplet 3/2 { r16 g' fis e d cis } |
-  d8 r \tuplet 3/2 { r16 fis e d cis b} |
-  cis8 r \tuplet 3/2 { r16 e d c b a } |
-  \tuplet 3/2 { b c b a g fis } r8 r16 <e g b> | %<c e g> or <g e c>?
-  <e g a cis>8 r <fis a d> r |
-  <fis b d>8. <e b' d>16 <e a cis>8. <e g cis>16 |
-  <d fis a d>8 r ^"accomp." r4 | \stemNeutral
-  s2 | s2 | % 2 completely emtpy bars
-  r8 r16 g d'8. a16 |
-
-  % --Bar 68- %
-  b2-\trill ~ |
-  \tuplet 3/2 { b8 \noBeam d cis b d cis } |
-  b2^\trillB ~ | %(tr)?
-  \tuplet 3/2 {
-    b8 \noBeam d cis b a gis |
-    cis e d cis b a |
-    d fis e d cis b |
-    e g fis e d cis |
-  }
-  fis8 r s4 ^"accomp." |
-
-  % --Bar 76- %
+  R2*10 |
+  \harpsichordTrebleI
+  \harpsichordTrebleII
+  R2*9 |
+  \harpsichordTrebleI
   s2*3 |
-
-
 } % ~ ~ end harpsichordTreble ~ ~ %
 
 
-harpsichordBass = \relative c' {
-  \set Score.skipTypesetting = ##t
-  \set Score.skipTypesetting = ##f
-  \commonSettings
-  \triplets \tripletsHide
-  \time 2/4 \clef bass \key d \major
-
-
-  % --Bar 1-- %
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-
-  % --Bar 9-- %
-  r8 r16 a d8. a16_\fbRootVII |
-  \tuplet 3/2 { b8_\fbRootV a g fis_\fbIinv g a } |
+harpsichordBassI = \relative c' {
+    % --Bar 9-- %
+  r8 r16 a d8. a16 |
+  \tuplet 3/2 { b8 a g fis g a | }
   d, r cis r |
   d r e r |
   fis r cis r |
@@ -439,49 +343,36 @@ harpsichordBass = \relative c' {
 
 
   % --Bar 17-- %
-  \tuplet 3/2 { a cis b a b cis } |
-  d r \change Staff = harpsichordUp \stemDown e c\rest | \tieDown %\voiceTwo
+  \tuplet 3/2 { a cis b a b cis | }
+  d r \staffUp e r | 
   fis2_\trill ~ |
-  \tuplet 3/2 { fis8 \noBeam a gis fis e d } |
+  \tuplet 3/2 { fis8 \noBeam a gis fis e d | }
   cis2_\trill ~ |
-  \tuplet 3/2 { cis8 \noBeam a b cis b cis } | \tieNeutral
-  \tuplet 3/2 { dis fis e dis fis e } |
-  \tuplet 3/2 { dis b cis dis cis dis } |
-  \tuplet 3/2 { e16 d! e fis e d cis d cis \change Staff = harpsichordDown \stemUp b a gis | }
+  \tuplet 3/2 { cis8 \noBeam a b cis b cis | }
+  \tuplet 3/2 { dis fis e dis fis e | }
+  \tuplet 3/2 { dis b cis dis cis dis | }
+  \tuplet 3/2 { e16 d! e fis e d cis d cis \staffDown b a gis | }
 
-  \stemNeutral
   % --Bar 26-- %
   \tuplet 3/2 {
     fis e fis gis a fis b cis b a gis fis |
     e d e fis gis e fis a gis fis e d |
     cis8 b a
   } e'8. e,16 |
-  a8 r fis_\fbIinv r |
-  g_\fbIinvVII r
-  <<
-    { \voiceOne a d\rest } \\
-    {
-      \tuplet 3/2 { s_\fbIinvVII s_\fbIVMv s_\fbVnIII }
-    }
-
-
-  >>
-  \oneVoice
-  |
-
-
-  b r cis_\fbIinv r |
-  d r e_\fbIinv r |
+  a8 r fis r |
+  g r a r |
+  b r cis r |
+  d r e r |
 
   % --Bar 33-- %
-  fis_\fbRootV r fis_\fbIinv r |
-  g r a_\fbIinv r |
-  b r a_\fbIinv r |
-  b_\fbIinvVII r cis_\fbIinvVII r |
+  fis r fis r |
+  g r a r |
+  b r a r |
+  b r cis r |
   d r r4 |
   R2 |
   r8 r16 a d8. a16 |
-  \tuplet 3/2 { b8 a g fis g a } |
+  \tuplet 3/2 { b8 a g fis g a | }
 
   % --Bar 41-- %
   d, r e r |
@@ -494,21 +385,23 @@ harpsichordBass = \relative c' {
   % --Bar 47-- %
   a8 r b r |
   cis8. \noBeam a16 d8. a16 |
-  \tuplet 3/2 { b8 a g fis g a } |
-  \tuplet 3/2 { d, fis e d e fis } |
+  \tuplet 3/2 { b8 a g fis g a | }
+  \tuplet 3/2 { d, fis e d e fis | }
   g r a r |
   b2-\trill ~ |
-  \tuplet 3/2 { b8 \noBeam d cis b a g} |
+  \tuplet 3/2 { b8 \noBeam d cis b a g | }
   fis2-\trill ~ |
-  \tuplet 3/2 { fis8 \noBeam d e fis e fis} |
-  \tuplet 3/2 { gis b a gis b a } |
-  \tuplet 3/2 { gis e fis gis fis gis } |
-  \stemDown \tuplet 3/2 { a16 cis \change Staff = harpsichordUp d e fis g! } a8 r |
-  \change Staff = harpsichordDown \tuplet 3/2 { r16 b, cis d \change Staff = harpsichordUp e fis } g8 r |
-  \change Staff = harpsichordDown \tuplet 3/2 { r16 a, b cis d \change Staff = harpsichordUp e }fis8 r |
+  \tuplet 3/2 { fis8 \noBeam d e fis e fis | }
+  \tuplet 3/2 { gis b a gis b a | }
+  \tuplet 3/2 { gis e fis gis fis gis | }
+  \voiceTwo
+  \tuplet 3/2 { a16 cis \staffUp d e fis g! } a8 r \staffDown \stemDown |
+  \tuplet 3/2 { r16 b, cis d \staffUp e fis } g8 r \staffDown \stemDown |
+  \tuplet 3/2 { r16 a, b cis d \staffUp e } fis8 r \staffDown  |
 
   % --Bar 61-- %
-  \change Staff = harpsichordDown g, r \change Staff = harpsichordUp \tuplet 3/2 { e'16 fis e d cis! \change Staff = harpsichordDown \stemNeutral b} |
+  g, r \staffUp \tuplet 3/2 { e'16 fis e d cis! \staffDown \once \stemDown b | }
+  \oneVoice
   \tuplet 3/2 {
     a b a g fis e d e d cis b a |
     b8 a g
@@ -520,7 +413,7 @@ harpsichordBass = \relative c' {
 
   % --Bar 68-- %
   gis2-\trill ~ |
-  \tuplet 3/2 { gis8 \noBeam b a gis b a } |
+  \tuplet 3/2 { gis8 \noBeam b a gis b a | }
   gis2^\trillB ~ |
   \tuplet 3/2 {
     gis8 \noBeam b a gis fis e |
@@ -530,10 +423,14 @@ harpsichordBass = \relative c' {
   }
   d r fis, r |
   g r a r |
-  \tuplet 3/2 { b a g} a8. a,16 |
-  \tuplet 3/2 { d8 fis e d e fis} |
+  \tuplet 3/2 { b a g } a8. a,16 |
+}
+
+harpsichordBassII = \relative c {
+  %78
+  \tuplet 3/2 { d8 fis e d e fis | }
   b,8 r r4 |
-  %79
+  %80
   \repeat unfold 5 { b8 r r4 | }
 
   %85
@@ -560,10 +457,10 @@ harpsichordBass = \relative c' {
   %100
   \repeat unfold 6 { fis8 r r4 | }
   %106
-  fis8.\noBeam cis'16 \tuplet 3/2 { fis8 a gis } |
+  fis8.\noBeam cis'16 \tuplet 3/2 { fis8 a gis | }
   a8 r r4 |
   %108
-  \tuplet 3/2 { r8 cis, d e gis fis } |
+  \tuplet 3/2 { r8 cis, d e gis fis | }
   gis r r4 |
   \tuplet 3/2 {
     r8 b, cis d fis eis |
@@ -583,7 +480,7 @@ harpsichordBass = \relative c' {
     fis fis, gis a gis a |
     b gis a b a b |
   }
-  cis4 ~ \tuplet 3/2 { cis8 d e } |
+  cis4 ~ \tuplet 3/2 { cis8 d e | }
   fis4 ~ \tuplet 3/2 {
     fis8 gis ais |
     b cis d cis dis eis |
@@ -638,52 +535,48 @@ harpsichordBass = \relative c' {
   d2-\trill ~ |
   d2 ~ |
   d8 r r4 |
-  \change Staff = harpsichordUp
-  \stemDown
+  \staffUp
   r8 r16 fis b8. fis16 |
   \tuplet 3/2 { g8 fis e d e fis | }
-  \stemNeutral \change Staff = harpsichordDown
-  b,8. fis16 \tuplet 3/2 { b8 d cis } |
-  \tuplet 3/2 { d b cis d fis e } |
+  \staffDown
+  b,8. fis16 \tuplet 3/2 { b8 d cis | }
+  \tuplet 3/2 { d b cis d fis e | }
 
   %168
   fis8. b,16 fis'8. cis16 |
-  \tuplet 3/2 { d8 cis b ais b cis } |
+  \tuplet 3/2 { d8 cis b ais b cis | }
   fis,4 e' ~ |
-  \tuplet 3/2 { e8 d cis b cis ais } |
-  \tuplet 3/2 { g' fis e d e cis } |
+  \tuplet 3/2 { e8 d cis b cis ais | }
+  \tuplet 3/2 { g' fis e d e cis | }
   b8. fis16 b8. fis16 |
-  \tuplet 3/2 { g8 fis e d e fis } |
-  b,8. fis16 \tuplet 3/2 { b8 d cis } |
-  \tuplet 3/2 { d b cis d fis eis } |
+  \tuplet 3/2 { g8 fis e d e fis | }
+  b,8. fis16 \tuplet 3/2 { b8 d cis | }
+  \tuplet 3/2 { d b cis d fis eis | }
 
   %177
   fis2-\trill ~ |
-  \tuplet 3/2 { fis8 \noBeam a g fis e dis } |
+  \tuplet 3/2 { fis8 \noBeam a g fis e dis | }
   e2-\trill ~ |
-  \tuplet 3/2 { e8 \noBeam g fis e d cis } |
+  \tuplet 3/2 { e8 \noBeam g fis e d cis | }
   d2-\trillB ~ |
   d ~ |
-  \tuplet 3/2 { d8 \noBeam fis, a d fis e } |
-  \tuplet 3/2 { fis d e fis a gis } |
+  \tuplet 3/2 { d8 \noBeam fis, a d fis e | }
+  \tuplet 3/2 { fis d e fis a gis | }
   a2^\trillB ~ |
   %186
   a2 ~ |
   \tuplet 3/2 {
     a8 \noBeam cis, e a cis b |
     cis a b cis e d
-  } |
+  | }
   e2-\trill ~
-  \tuplet 3/2 { e8 \noBeam cis d e cis d } |
+  \tuplet 3/2 { e8 \noBeam cis d e cis d | }
   e2-\trill ~ |
   \tuplet 3/2 {
     e8 g fis e d cis |
     d fis e d cis b |
     cis e d cis b a |
-  }
-
   %195
-  \tuplet 3/2 {
     b d cis b a gis |
     a cis b a b a |
     gis a gis fis eis fis |
@@ -706,35 +599,26 @@ harpsichordBass = \relative c' {
 
 
   % --Bar 211 -- %
-  \tuplet 3/2 { e fis g a b c } |
+  \tuplet 3/2 { e fis g a b c | }
   d, r g r |
   d' r c r |
   b2 ~ |
   b8. \noBeam fis'16 b8. fis16 |
   g8. fis16 g8. e16 |
-  <<
-    { \tieDown fis,2 ~ | fis ~ | fis } \\
-    { \tieUp \stemUp fis' ~ | fis ~ | fis }
-  >> |
+  <fis, fis'>2 ~ |
+  q ~ |
+  q |
 
   % --Bar 220 -- %
-  <<
-    { \tieDown fis,^\markup { \bold "tasto solo"} ~ | fis ~ | fis8. } \\
-    { \tieUp \stemUp fis'2 ~ | fis ~ | fis8. }
-  >>
-  \stemNeutral \tieNeutral
-  % --Bar 222 -- %
-  \voiceOne b,16 fis'8. a,16 |
+  <fis fis'>2^\markup { \bold "tasto solo"} ~ |
+  q ~ q8.\noBeam b16 fis'8. a,16 |
   %should beam down
-  \tuplet 3/2 { b8 a g ais b cis } |
-  fis,4 ~ \tuplet 3/2 { fis8 fis' e } |
+  \tuplet 3/2 { b8 a g ais b cis | }
+  fis,4 ~ \tuplet 3/2 { fis8 fis' e | }
   \tuplet 3/2 {
     d b cis d e fis |
     e cis d e fis g |
-  }
-
   %227
-  \tuplet 3/2 {
     fis d e fis g a |
     g e fis gis a b |
     a fis gis ais b cis |
@@ -742,130 +626,120 @@ harpsichordBass = \relative c' {
   b8. g!16 d8. e16 |
   fis8. e16 fis8. fis,16 |
   b4 r |
-  \oneVoice
   %233
-  << { \stemDown d } \\ { \stemUp a'} \\ { \stemUp fis } >> \oneVoice r |
-  \stemNeutral
+  << 
+    { \voiceOne a' }
+    \new Voice { \voiceThree fis }
+    \new Voice { \voiceTwo d }
+  >> \oneVoice r |
+}
 
+harpsichordBass = \relative c' {
+  \omit TupletNumber
+  \time 2/4
+  \clef bass
+  \key d \major
+
+  % --Bar 1-- %
+  R2*8 |
+  \harpsichordBassI
+  \harpsichordBassII
   %234
   R2*7 |
   %241
+  \harpsichordBassI
+  d,2\fermata \bar "|."
 
-  % --Bar 9-- %
-  r8 r16 a d8. a16_\fbRootVII |
-  \tuplet 3/2 { b8_\fbRootV a g fis_\fbIinv g a } |
-  d, r cis r |
-  d r e r |
-  fis r cis r |
-  d r e r |
-  fis r e r |
-  fis r gis r |
+} % end for notes
 
-
-  % --Bar 17-- %
-  \tuplet 3/2 { a cis b a b cis } |
-  d r \change Staff = harpsichordUp \stemDown e r | \tieUp %\voiceTwo
-  fis2_\trill ~ |
-  \tuplet 3/2 { fis8 \noBeam a gis fis e d } |
-  cis2_\trill ~ |
-  \tuplet 3/2 { cis8 \noBeam a b cis b cis } | \tieNeutral
-  \tuplet 3/2 { dis fis e dis fis e } |
-  \tuplet 3/2 { dis b cis dis cis dis } |
-  \tuplet 3/2 { e16 d! e fis e d cis d cis \change Staff = harpsichordDown \stemUp b a gis | }
-
-  \stemNeutral
-  % --Bar 26-- %
-  \tuplet 3/2 {
-    fis e fis gis a fis b cis b a gis fis |
-    e d e fis gis e fis a gis fis e d |
-    cis8 b a
-  } e'8. e,16 |
-  a8 r fis_\fbIinv r |
-  g_\fbIinvVII r
-  <<
-    {
-      \tuplet 3/2 { s_\fbIinvVII s_\fbIV s_\fbVnIII }
-    }
-    \\ { \stemUp a d\rest }
-  >>
-  \oneVoice
-  |
-
-
-  b r cis_\fbIinv r |
-  d r e_\fbIinv r |
-
-  % --Bar 33-- %
-  fis_\fbRootV r fis_\fbIinv r |
-  g r a_\fbIinv r |
-  b r a_\fbIinv r |
-  b_\fbIinvVII r cis_\fbIinvVII r |
-  d r r4 |
+harpsichordFiguresI = \figuremode {
+  R2*8 |
+  s4 s8. <7 5>16 |
+  <5>4 <6> |
+  R2*18 |
+  s4 <6>8 s |
+  \bassFigureExtendersOn
+  \tuplet 3/2 { <6 5>8 s s <6 5> <6 4> <5 3> | }
+  \bassFigureExtendersOff
+  s4 <6>8 s |
+  s4 <6>8 s |
+  <5>8 s <6> s |
+  s4 <6>8 s |
+  s4 <6>8 s |
+  <6 5>8 s <6 5> s |
+  R2*27 |
+  s4 <6 5!>8 s |
+  s4 <6 4 2>8 s |
+  <6>4 s8. <7 5>16 |
+  <5>4 s |
+  R2*7 |
+  s4 <6>8 s |
+  s4 <6>8 s |
+  \tuplet 3/2 { <5>8 s <6 5> } s4 |
   R2 |
-  r8 r16 a d8. a16 |
-  \tuplet 3/2 { b8 a g fis g a } |
+}
 
-  % --Bar 41-- %
-  d, r e r |
-  fis r fis, r |
-  g r a r |
-  b r cis r |
-  d r e r |
-  fis r g r |
-
-  % --Bar 47-- %
-  a8 r b r |
-  cis8. \noBeam a16 d8. a16 |
-  \tuplet 3/2 { b8 a g fis g a } |
-  \tuplet 3/2 { d, fis e d e fis } |
-  g r a r |
-  b2-\trill ~ |
-  \tuplet 3/2 { b8 \noBeam d cis b a g} |
-  fis2-\trill ~ |
-  \tuplet 3/2 { fis8 \noBeam d e fis e fis} |
-  \tuplet 3/2 { gis b a gis b a } |
-  \tuplet 3/2 { gis e fis gis fis gis } |
-  \stemDown \tuplet 3/2 { a16 cis \change Staff = harpsichordUp d e fis g! } a8 r |
-  \change Staff = harpsichordDown \tuplet 3/2 { r16 b, cis d \change Staff = harpsichordUp e fis } g8 r |
-  \change Staff = harpsichordDown \tuplet 3/2 { r16 a, b cis d \change Staff = harpsichordUp e }fis8 r |
-
-  % --Bar 61-- %
-  \change Staff = harpsichordDown g, r \change Staff = harpsichordUp \tuplet 3/2 { e'16 fis e d cis! \change Staff = harpsichordDown \stemNeutral b} |
-  \stemNeutral
-  \tuplet 3/2 {
-    a b a g fis e d e d cis b a |
-    b8 a g
-  } a8. a16 |
-  d,8 r fis r | % 6 3?
-  g r c r | % <2 4 6>
-  b8. \noBeam g'16 d'8. a16 |
-  \tuplet 3/2 { b8 a g fis gis a | }
-
-  % --Bar 68-- %
-  gis2-\trill ~ |
-  \tuplet 3/2 { gis8 \noBeam b a gis b a } |
-  gis2-\trill ~ | %(tr)
-  \tuplet 3/2 {
-    gis8 b a gis fis e |
-    a cis b a g! fis |
-    b d cis b a g |
-    cis e d cis b a |
+harpsichordFiguresII = \figuremode {
+    R2*7 |
+  s4 \tuplet 3/2 { s8 s <6\\> | 
+    <6>8 s s <6> s <7> |
+    \bassFigureExtendersOn
+    <6 _+>4 <6 4>8 <5 _+> s s |
+    \bassFigureExtendersOff
   }
+  R2*7 |
+  s4 \tuplet 3/2 { s8 s <6\\> | 
+    <6>8 s s <6> s <7> |
+    \bassFigureExtendersOn
+    <6 _+>4 <6 4>8 <5 _+> s s |
+    \bassFigureExtendersOff
+  }
+  <6>4 s |
+  R2*28 |
+  s4 <6> |
+  <5>8 s <6\\> s |
+  \bassFigureExtendersOn
+  \tuplet 3/2 { <6 9>8 <6 8> s <6> s s }
+  <_!>4 <6\\> |
+  \tuplet 3/2 { <6 9>8 <6 8> s <6> s s }
+  s4 <6\\> |
+  \tuplet 3/2 { <6 9>8 <6 8> s <6> s s }
+  s4 <6\\> |
+  \tuplet 3/2 { <5 9\\>8 <5 8> s } <6>4 |
+  <5!>4 <6> |
+  \bassFigureExtendersOff
+  <5> <6> |
+  <5> <6\\> |
+  <5> <6> |
+  <5> <6> |
+  <4 2>8 s <6>8 s |
+  <6 5>8 s <6 4 _+> s |
+  <5>8 s <6> s |
+  <6 5>4 s8 <7 _+> |
+  <_+>8. <6 4>16 <6>8. <6>16 |
+  <6 4>4 <5 _+> |
+  R2*74 | 
+  s4 <_+>8. <6\\>16 |
+  \bassFigureExtendersOn
+  \tuplet 3/2 {<6>4 s8 <6>4 <7>8 |
+    <6 _+>4 <6 4>8 <5 _+> s s |
+  }
+  \bassFigureExtendersOff
+  R2*8 |
+}
 
-  d r fis, r |
-  g r a r |
-  \tuplet 3/2 { b a g} a8. a,16 |
-  d2-\fermata \bar "|."
 
-} % end for Notes Bass
-
-
-% end for notes
+harpsichordFigures = \figuremode {
+  \harpsichordFiguresI
+  \harpsichordFiguresII
+  \harpsichordFiguresI
+}
 
 harpsichordStaff = \new PianoStaff \with {
   instrumentName = \markup \smaller \center-column { "Cembalo" "concertato." }
   midiInstrument = "harpsichord"
 } <<
-  \new Staff = harpsichordUp \harpsichordTreble
-  \new Staff = harpsichordDown \harpsichordBass
+  \new Staff = "harpsichordUp" \harpsichordTreble
+  \new Staff = "harpsichordDown" \harpsichordBass
+  \new FiguredBass \harpsichordFigures
 >>

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord.ly
@@ -334,6 +334,7 @@ harpsichordTreble = \relative c'' {
 
 harpsichordBass = \relative c' {
   \omit TupletNumber
+  \tempo "Allegro."
   \time 2/4
   \clef bass
   \key d \major

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord.ly
@@ -362,7 +362,9 @@ harpsichordBass = \relative c' {
     \tuplet 3/2 { cis8 \noBeam a b cis b cis | }
     \tuplet 3/2 { dis8 fis e dis fis e | }
     \tuplet 3/2 { dis8 b cis dis cis dis | }
-    \tuplet 3/2 { e16 d! e fis e d cis d cis \staffDown b a gis | }
+    \tuplet 3/2 { e16 d! e fis e d }
+    \once \override Beam.positions = #'(-6 . -5.5)
+    \tuplet 3/2 { cis d cis \staffDown b a gis | }
 
     % --Bar 26-- %
     \tuplet 3/2 {

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord.ly
@@ -5,777 +5,885 @@
 \version "2.18.0"
 harpsichordTreble =  \relative c'' {
 
-\commonSettings
-   \triplets \tripletsHide
+  \commonSettings
+  \triplets \tripletsHide
 
-% --Bar 1-- %
-    \repeat unfold 10 R2| 
+  % --Bar 1-- %
+  \repeat unfold 10 R2|
 
-% --Bar 11-- %
-    r8 r16 d a'8. e16 |
-    \tuplet 3/2 { fis8 e d  cis d e } |
-    \tuplet 3/2 { a, cis b  a b cis } |
-    \tuplet 3/2 { fis, b a  gis cis b } |
-    \tuplet 3/2 { a16 gis a b cis d   e fis e d cis b } |
-    \tuplet 3/2 { a cis b a gis fis   e fis e d cis b } |
+  % --Bar 11-- %
+  r8 r16 d a'8. e16 |
+  \tuplet 3/2 { fis8 e d  cis d e } |
+  \tuplet 3/2 { a, cis b  a b cis } |
+  \tuplet 3/2 { fis, b a  gis cis b } |
+  \tuplet 3/2 { a16 gis a b cis d   e fis e d cis b } |
+  \tuplet 3/2 { a cis b a gis fis   e fis e d cis b } |
 
-% --Bar 17-- %
-\change Staff = harpsichordDown \stemUp  a8  \change Staff = harpsichordUp  r a' r |
-   a r gis d'\rest | \tieUp
-   a2 \trill ~ |
-   \tuplet 3/2 { a8 \noBeam cis b  a gis! fis } |
-   e2 \trill ~| 
-   \tuplet 3/2 { e8 \noBeam cis d   e d e  |
-        fis a gis  fis a gis |
-        fis dis! e   fis e fis  | }
-   gis r <e' cis b> r|
-   \tieNeutral
-% --Bar 26-- %
-   <a, cis e > r < fis b d> r |
-   <gis b d > r 
-  << { cis8. d16 | e8. fis16 } 
-	\\
-	{  a,4~ |a } >> %\stemDown
-\stemNeutral b8. a16 | 
-a8 r  s ^"accomp." s
-s2 s s
-% --Bar 33-- %
-s s s s s
-R2| 
-R |
-r8 r16 d a'8. e16 |
+  % --Bar 17-- %
+  \change Staff = harpsichordDown \stemUp  a8  \change Staff = harpsichordUp  r a' r |
+  a r gis d'\rest | \tieUp
+  a2 \trill ~ |
+  \tuplet 3/2 { a8 \noBeam cis b  a gis! fis } |
+  e2 \trill ~|
+  \tuplet 3/2 {
+    e8 \noBeam cis d   e d e  |
+    fis a gis  fis a gis |
+    fis dis! e   fis e fis  |
+  }
+  gis r <e' cis b> r|
+  \tieNeutral
+  % --Bar 26-- %
+  <a, cis e > r < fis b d> r |
+  <gis b d > r
+  <<
+    { cis8. d16 | e8. fis16 }
+    \\
+    {  a,4~ |a }
+  >> %\stemDown
+  \stemNeutral b8. a16 |
+  a8 r  s ^"accomp." s
+  s2 s s
+  % --Bar 33-- %
+  s s s s s
+  R2|
+  R |
+  r8 r16 d a'8. e16 |
 
-% --Bar 41-- %
-\tuplet 3/2 {fis8 e d cis d e  |
-  a,16 fis g a b cis d e d cis b a |
-  b d cis b a g fis e fis g a fis |
-  d cis d e fis g a b a g fis e|
-  fis a g fis e d cis b cis d e cis |
-  a d e fis e d b e fis g fis e | }
+  % --Bar 41-- %
+  \tuplet 3/2 {
+    fis8 e d cis d e  |
+    a,16 fis g a b cis d e d cis b a |
+    b d cis b a g fis e fis g a fis |
+    d cis d e fis g a b a g fis e|
+    fis a g fis e d cis b cis d e cis |
+    a d e fis e d b e fis g fis e |
+  }
 
-% --Bar 47-- %
-\tuplet 3/2 { cis16 fis g a g fis d g a b a g |
-e g a b a g  fis g a b cis a |
-d8 cis b a b g |
-}
-fis r d' r |
-d r cis r |
-d2-\trill ~ 
-\tuplet 3/2 { d8 \noBeam fis e d cis b  }
+  % --Bar 47-- %
+  \tuplet 3/2 {
+    cis16 fis g a g fis d g a b a g |
+    e g a b a g  fis g a b cis a |
+    d8 cis b a b g |
+  }
+  fis r d' r |
+  d r cis r |
+  d2-\trill ~
+  \tuplet 3/2 { d8 \noBeam fis e d cis b  }
 
-% --Bar 54- %
-a2-\trill ~ |
-\tuplet 3/2 { a8 \noBeam fis g a g a |
-b d cis b d cis |
-b gis a b a b | }
-\stemUp cis r \tuplet 3/2 { r16 g' fis e d cis } |
-d8 r \tuplet 3/2 { r16 fis e d cis b} |
-cis8 r \tuplet 3/2 { r16 e d c b a } |
-\tuplet 3/2 { b c b a g fis } r8 r16 <e g b> | %<c e g>  or <g e c>?
-<e g a cis>8 r <fis a d> r |
-<fis b d>8. <e b' d>16 <e a cis>8. <e g cis>16 |
-<d fis a d>8 r ^"accomp." r4 | \stemNeutral
-s2 | s2| % 2 completely emtpy bars
-r8 r16 g d'8. a16 |
+  % --Bar 54- %
+  a2-\trill ~ |
+  \tuplet 3/2 {
+    a8 \noBeam fis g a g a |
+    b d cis b d cis |
+    b gis a b a b |
+  }
+  \stemUp cis r \tuplet 3/2 { r16 g' fis e d cis } |
+  d8 r \tuplet 3/2 { r16 fis e d cis b} |
+  cis8 r \tuplet 3/2 { r16 e d c b a } |
+  \tuplet 3/2 { b c b a g fis } r8 r16 <e g b> | %<c e g>  or <g e c>?
+  <e g a cis>8 r <fis a d> r |
+  <fis b d>8. <e b' d>16 <e a cis>8. <e g cis>16 |
+  <d fis a d>8 r ^"accomp." r4 | \stemNeutral
+  s2 | s2| % 2 completely emtpy bars
+  r8 r16 g d'8. a16 |
 
-% --Bar 68- %
-b2-\trill ~ |
-\tuplet 3/2 {b8 \noBeam d cis b d cis } |
-b2^\trillB ~ | 
-\tuplet 3/2 {b8 \noBeam d cis b a gis | 
-cis e d cis b a |
-d fis e d cis b |
-e g fis e d cis |}
-fis8 r s4 ^"accomp." |
+  % --Bar 68- %
+  b2-\trill ~ |
+  \tuplet 3/2 {b8 \noBeam d cis b d cis } |
+  b2^\trillB ~ |
+  \tuplet 3/2 {
+    b8 \noBeam d cis b a gis |
+    cis e d cis b a |
+    d fis e d cis b |
+    e g fis e d cis |
+  }
+  fis8 r s4 ^"accomp." |
 
-% --Bar 76- %
-s2*3|
-\tuplet 3/2{
-fis,8-\pianoB( b d) d( cis d)|
-fis,( b d) d( cis d)|
-g,! (ais b) cis(ais b)|
-e,( ais cis)  cis(b cis)|
-fis,(b d) d (cis d)|
-e,(g cis) cis(ais b)
+  % --Bar 76- %
+  s2*3|
+  \tuplet 3/2{
+    fis,8-\pianoB( b d) d( cis d)|
+    fis,( b d) d( cis d)|
+    g,! (ais b) cis(ais b)|
+    e,( ais cis)  cis(b cis)|
+    fis,(b d) d (cis d)|
+    e,(g cis) cis(ais b)
 
-%85
-cis( ais) b (fis b) ais |}
-b8 r r4 |
-s2*2|
-\tuplet 3/2 { b8(-\pianoB fis' b) b( ais b) |
-d,( fis b) b(ais b) |
-e, (fis g)  e(fis d) |
-cis ( e ais) ais(gis ais) |}
+    %85
+    cis( ais) b (fis b) ais |
+  }
+  b8 r r4 |
+  s2*2|
+  \tuplet 3/2 {
+    b8(-\pianoB fis' b) b( ais b) |
+    d,( fis b) b(ais b) |
+    e, (fis g)  e(fis d) |
+    cis ( e ais) ais(gis ais) |
+  }
 
-%93
-\tuplet 3/2 { d,8( fis b) b( ais b) |
-g!( e cis)  ais( cis b) |
-ais( cis) b ais(b) cis | }
-d r r4 |
-s2 * 2 |
+  %93
+  \tuplet 3/2 {
+    d,8( fis b) b( ais b) |
+    g!( e cis)  ais( cis b) |
+    ais( cis) b ais(b) cis |
+  }
+  d r r4 |
+  s2 * 2 |
 
-r8 r16 cis_\cantabileB fis8. cis16 |
-d2 ~ |
+  r8 r16 cis_\cantabileB fis8. cis16 |
+  d2 ~ |
 
-%101
-d8. d16 \tuplet 3/2 { e8( cis) d } |
-cis2 ~ |
-cis8. cis16 fis8. d16 |
-b2-\trill ~ |
-\tuplet 3/2 { b8 cis d cis d b |
-a \noBeam fis_\forteI gis a cis b | } 
-cis r r4 |
-\tuplet 3/2 { r8 e, fis gis b a  } |
-b r r4 |
+  %101
+  d8. d16 \tuplet 3/2 { e8( cis) d } |
+  cis2 ~ |
+  cis8. cis16 fis8. d16 |
+  b2-\trill ~ |
+  \tuplet 3/2 {
+    b8 cis d cis d b |
+    a \noBeam fis_\forteI gis a cis b |
+  }
+  cis r r4 |
+  \tuplet 3/2 { r8 e, fis gis b a  } |
+  b r r4 |
 
-%110
-\tuplet 3/2 { r8 d, e fis a gis |
-a cis, dis eis gis fis |
-gis b a gis b a | }
-gis2-\trill ~ |
-\tuplet 3/2 { gis!8 \noBeam eis fis gis fis gis |
-a fis gis a gis a |
-b gis a b ais b |
-cis a b cis b cis |
-d b cis d cis d |
+  %110
+  \tuplet 3/2 {
+    r8 d, e fis a gis |
+    a cis, dis eis gis fis |
+    gis b a gis b a |
+  }
+  gis2-\trill ~ |
+  \tuplet 3/2 {
+    gis!8 \noBeam eis fis gis fis gis |
+    a fis gis a gis a |
+    b gis a b ais b |
+    cis a b cis b cis |
+    d b cis d cis d |
 
-%119
-gis, b a gis fis gis |
-a a, b cis b cis |
-d b cis d cis d |
-gis, a b } cis4 ~ |
-\tuplet 3/2 { cis8 d e } fis4 ~ |
-fis8. fis16 \tuplet 3/2 { eis8 fis gis } |
-cis,8. cis'16 \tuplet 3/2 { b8 cis d } |
-eis,8.-\trill dis32 eis \tuplet 3/2 { fis8 gis a } |
+    %119
+    gis, b a gis fis gis |
+    a a, b cis b cis |
+    d b cis d cis d |
+    gis, a b
+  } cis4 ~ |
+  \tuplet 3/2 { cis8 d e } fis4 ~ |
+  fis8. fis16 \tuplet 3/2 { eis8 fis gis } |
+  cis,8. cis'16 \tuplet 3/2 { b8 cis d } |
+  eis,8.-\trill dis32 eis \tuplet 3/2 { fis8 gis a } |
 
-%127
-\tuplet 3/2 { b cis d cis d b |
-a gis fis } r4^"accomp" |
-s2 * 19 |
+  %127
+  \tuplet 3/2 {
+    b cis d cis d b |
+    a gis fis
+  } r4^"accomp" |
+  s2 * 19 |
 
-%148
-\tuplet 3/2 { cis'8_\pianoB( e a) a( gis a) |
-cis,( e a) a( gis a)  |
-d,( e fis)  d( e cis) |
+  %148
+  \tuplet 3/2 {
+    cis'8_\pianoB( e a) a( gis a) |
+    cis,( e a) a( gis a)  |
+    d,( e fis)  d( e cis) |
 
-%151
-b( d gis) gis( fis gis) |
-cis,( e a) a( gis a) |
-fis( d b) gis( b a) |
-gis( b) a gis( a) b |
-cis \noBeam a_\forteI b  cis e d |
-e cis d e g fis | }
-g2-\trill ~ |
-g |
+    %151
+    b( d gis) gis( fis gis) |
+    cis,( e a) a( gis a) |
+    fis( d b) gis( b a) |
+    gis( b) a gis( a) b |
+    cis \noBeam a_\forteI b  cis e d |
+    e cis d e g fis |
+  }
+  g2-\trill ~ |
+  g |
 
-%159
-\tuplet 3/2 { g8 \noBeam g, a b d cis |
-d b cis d fis e | }
-fis2-\trill ~ |
-fis ~|
-fis8. \noBeam fis16 b8. fis16 |
-\stemUp \tuplet 3/2 { g8 fis e d e fis | }
-b,8. fis16 \tuplet 3/2 { b8 d cis |
-\stemNeutral d b cis d fis e |}
-fis8. b,16 fis'8. cis16 |
+  %159
+  \tuplet 3/2 {
+    g8 \noBeam g, a b d cis |
+    d b cis d fis e |
+  }
+  fis2-\trill ~ |
+  fis ~|
+  fis8. \noBeam fis16 b8. fis16 |
+  \stemUp \tuplet 3/2 { g8 fis e d e fis | }
+  b,8. fis16 \tuplet 3/2 {
+    b8 d cis |
+    \stemNeutral d b cis d fis e |
+  }
+  fis8. b,16 fis'8. cis16 |
 
-%168
-\tuplet 3/2 { d8 cis b ais b cis } |
-fis,4 e' ~ |
-\tuplet 3/2 { e8 d cis b cis ais |
-g' fis e d e cis | }
-b8. fis16 b8. fis16 |
-\tuplet 3/2 { g8 fis e d e fis } |
-b,8. fis16 \tuplet 3/2 { b8 d cis |
-d b cis d fis e |
-fis d e fis a gis | }
+  %168
+  \tuplet 3/2 { d8 cis b ais b cis } |
+  fis,4 e' ~ |
+  \tuplet 3/2 {
+    e8 d cis b cis ais |
+    g' fis e d e cis |
+  }
+  b8. fis16 b8. fis16 |
+  \tuplet 3/2 { g8 fis e d e fis } |
+  b,8. fis16 \tuplet 3/2 {
+    b8 d cis |
+    d b cis d fis e |
+    fis d e fis a gis |
+  }
 
-%177
-a2-\trill ~ |
-\tuplet 3/2 { a8 \noBeam c b a g fis } |
-g2-\trill ~ |
-\tuplet 3/2 { g8 \noBeam b a g fis e } |
-fis2^\trillB ~ |
-fis |
-\tuplet 3/2 { fis8 \noBeam d e fis a g |
-a fis g a cis b } |
-cis2-\trill ~ |
+  %177
+  a2-\trill ~ |
+  \tuplet 3/2 { a8 \noBeam c b a g fis } |
+  g2-\trill ~ |
+  \tuplet 3/2 { g8 \noBeam b a g fis e } |
+  fis2^\trillB ~ |
+  fis |
+  \tuplet 3/2 {
+    fis8 \noBeam d e fis a g |
+    a fis g a cis b
+  } |
+  cis2-\trill ~ |
 
-%186
-cis ~ |
-\tuplet 3/2 { cis8 \noBeam a b cis e d |
-e cis d e g fis } |
-g2-\trill ~ |
-\tuplet 3/2 { g8 \noBeam  e fis g e fis } |
-g2-\trill ~ |
-\tuplet 3/2 { g8 b a g fis e |
-fis a g fis e d |
-e g fis e d cis } |
+  %186
+  cis ~ |
+  \tuplet 3/2 {
+    cis8 \noBeam a b cis e d |
+    e cis d e g fis
+  } |
+  g2-\trill ~ |
+  \tuplet 3/2 { g8 \noBeam  e fis g e fis } |
+  g2-\trill ~ |
+  \tuplet 3/2 {
+    g8 b a g fis e |
+    fis a g fis e d |
+    e g fis e d cis
+  } |
 
-%195
-\tuplet 3/2 { d fis e d cis b |
-cis e d cis d cis |
-b a b cis d16 cis b a | }
-gis8. fis16 \tuplet 3/2 { eis8 gis b } |
-\tuplet 3/2 { a cis b a cis fis |
-b, d cis b fis' eis |
-fis a, b cis d e |
-d fis e d fis b |
+  %195
+  \tuplet 3/2 {
+    d fis e d cis b |
+    cis e d cis d cis |
+    b a b cis d16 cis b a |
+  }
+  gis8. fis16 \tuplet 3/2 { eis8 gis b } |
+  \tuplet 3/2 {
+    a cis b a cis fis |
+    b, d cis b fis' eis |
+    fis a, b cis d e |
+    d fis e d fis b |
 
-%203
-gis eis fis } g4 ~ |
-\tuplet 3/2 { g8 fis e! d cis b |
-cis fis e dis e fis |
-b, e fis g a b |
-c! dis, e b e dis |
-e b a g fis g |
-e a g fis g a |
-d, g a b c a |
+    %203
+    gis eis fis
+  } g4 ~ |
+  \tuplet 3/2 {
+    g8 fis e! d cis b |
+    cis fis e dis e fis |
+    b, e fis g a b |
+    c! dis, e b e dis |
+    e b a g fis g |
+    e a g fis g a |
+    d, g a b c a |
 
-%211
-g a b } e,8. e'16 |
-\tuplet 3/2 { a8 d, c b a g } |
-a4 ~ \tuplet 3/2 { a16 g fis e dis e } |
-\tuplet 3/2 { fis8 b a g fis e |
-fis b ais b fis' ais, | }
-b r r4 |
-r8 r16 cis \tuplet 3/2 { fis8( ais,) b } |
-cis8. fis,16 \tuplet 3/2 { b8 gis eis } |
+    %211
+    g a b
+  } e,8. e'16 |
+  \tuplet 3/2 { a8 d, c b a g } |
+  a4 ~ \tuplet 3/2 { a16 g fis e dis e } |
+  \tuplet 3/2 {
+    fis8 b a g fis e |
+    fis b ais b fis' ais, |
+  }
+  b r r4 |
+  r8 r16 cis \tuplet 3/2 { fis8( ais,) b } |
+  cis8. fis,16 \tuplet 3/2 { b8 gis eis } |
 
-%219
-fis8. cis16 \tuplet 3/2 { d8 \change Staff = harpsichordDown \stemUp ais b } | 
-\change Staff = harpsichordUp \stemNeutral 
-s2 * 2 |
-s2^"accomp." | 
-s2 *2 |
-\tuplet 3/2 { r8 d e fis gis a |
-gis e fis gis ais b |
+  %219
+  fis8. cis16 \tuplet 3/2 { d8 \change Staff = harpsichordDown \stemUp ais b } |
+  \change Staff = harpsichordUp \stemNeutral
+  s2 * 2 |
+  s2^"accomp." |
+  s2 *2 |
+  \tuplet 3/2 {
+    r8 d e fis gis a |
+    gis e fis gis ais b |
 
-%227
-ais fis gis ais b cis |
-b gis a! b cis d |
-cis ais b cis d e |
-fis( d) b fis'( d) b |
-fis'( d) b fis( b ais) } |
-b4 r | 
-<< \shiftOn \stemUp { < d, fis a > } \\ { \stemUp d' }   >>r | %
-\stemNeutral \shiftOff
-%repeat bar 1 to 76
-% --Bar 1-- %
-    R2 * 9 | 
-    
-% --Bar 11-- %
-    r8 r16 d a'8. e16 |
-    \tuplet 3/2 { fis8 e d  cis d e } |
-    \tuplet 3/2 { a, cis b  a b cis } |
-    \tuplet 3/2 { fis, b a  gis cis b } |
-    \tuplet 3/2 { a16 gis a b cis d   e fis e d cis b } |
-    \tuplet 3/2 { a cis b a gis fis   e fis e d cis b } |
+    %227
+    ais fis gis ais b cis |
+    b gis a! b cis d |
+    cis ais b cis d e |
+    fis( d) b fis'( d) b |
+    fis'( d) b fis( b ais)
+  } |
+  b4 r |
+  << \shiftOn \stemUp { < d, fis a > } \\ { \stemUp d' }   >>r | %
+  \stemNeutral \shiftOff
+  %repeat bar 1 to 76
+  % --Bar 1-- %
+  R2 * 9 |
 
-% --Bar 17-- %
-\change Staff = harpsichordDown \stemUp  a8  \change Staff = harpsichordUp  r a' r |
-   a r gis r |
-   \tieUp a2 \trill ~ |
-   \tuplet 3/2 { a8 \noBeam cis b  a gis! fis } |
-   e2 \trill ~| 
-   \tuplet 3/2 { e8 \noBeam cis d   e d e  | \tieNeutral
-        fis a gis  fis a gis |
-        fis dis! e   fis e fis  | }
-   gis r <e' cis b> r|
+  % --Bar 11-- %
+  r8 r16 d a'8. e16 |
+  \tuplet 3/2 { fis8 e d  cis d e } |
+  \tuplet 3/2 { a, cis b  a b cis } |
+  \tuplet 3/2 { fis, b a  gis cis b } |
+  \tuplet 3/2 { a16 gis a b cis d   e fis e d cis b } |
+  \tuplet 3/2 { a cis b a gis fis   e fis e d cis b } |
 
-% --Bar 26-- %
-   <a, cis e > r < fis b d> r |
-   <gis b d > r 
-  << { cis8. d16 | e8. fis16 } 
-	\\
-	{  a,4~ |a } >> %\stemDown
-\stemNeutral b8. a16 | 
-a8 r  s ^"accomp." s
-s2 s s
-% --Bar 33-- %
-s s s s s
-R2| 
-R |
-r8 r16 d a'8. e16 |
+  % --Bar 17-- %
+  \change Staff = harpsichordDown \stemUp  a8  \change Staff = harpsichordUp  r a' r |
+  a r gis r |
+  \tieUp a2 \trill ~ |
+  \tuplet 3/2 { a8 \noBeam cis b  a gis! fis } |
+  e2 \trill ~|
+  \tuplet 3/2 {
+    e8 \noBeam cis d   e d e  | \tieNeutral
+    fis a gis  fis a gis |
+    fis dis! e   fis e fis  |
+  }
+  gis r <e' cis b> r|
 
-% --Bar 41-- %
-\tuplet 3/2 {fis8 e d cis d e  |
-  a,16 fis g a b cis d e d cis b a |
-  b d cis b a g fis e fis g a fis |
-  d cis d e fis g a b a g fis e|
-  fis a g fis e d cis b cis d e cis |
-  a d e fis e d b e fis g fis e | }
+  % --Bar 26-- %
+  <a, cis e > r < fis b d> r |
+  <gis b d > r
+  <<
+    { cis8. d16 | e8. fis16 }
+    \\
+    {  a,4~ |a }
+  >> %\stemDown
+  \stemNeutral b8. a16 |
+  a8 r  s ^"accomp." s
+  s2 s s
+  % --Bar 33-- %
+  s s s s s
+  R2|
+  R |
+  r8 r16 d a'8. e16 |
 
-% --Bar 47-- %
-\tuplet 3/2 { cis16 fis g a g fis d g a b a g |
-e g a b a g  fis g a b cis a |
-d8 cis b a b g |
-}
-fis r d' r |
-d r cis r |
-d2-\trill ~ 
-\tuplet 3/2 { d8 \noBeam fis e d cis b  }
+  % --Bar 41-- %
+  \tuplet 3/2 {
+    fis8 e d cis d e  |
+    a,16 fis g a b cis d e d cis b a |
+    b d cis b a g fis e fis g a fis |
+    d cis d e fis g a b a g fis e|
+    fis a g fis e d cis b cis d e cis |
+    a d e fis e d b e fis g fis e |
+  }
 
-% --Bar 54- %
-a2-\trill ~ |
-\tuplet 3/2 { a8 \noBeam fis g a g a |
-b d cis b d cis |
-b gis a b a b | }
-\stemUp cis r \tuplet 3/2 { r16 g' fis e d cis } |
-d8 r \tuplet 3/2 { r16 fis e d cis b} |
-cis8 r \tuplet 3/2 { r16 e d c b a } |
-\tuplet 3/2 { b c b a g fis } r8 r16 <e g b> | %<c e g>  or <g e c>?
-<e g a cis>8 r <fis a d> r |
-<fis b d>8. <e b' d>16 <e a cis>8. <e g cis>16 |
-<d fis a d>8 r ^"accomp." r4 | \stemNeutral
-s2 | s2| % 2 completely emtpy bars
-r8 r16 g d'8. a16 |
+  % --Bar 47-- %
+  \tuplet 3/2 {
+    cis16 fis g a g fis d g a b a g |
+    e g a b a g  fis g a b cis a |
+    d8 cis b a b g |
+  }
+  fis r d' r |
+  d r cis r |
+  d2-\trill ~
+  \tuplet 3/2 { d8 \noBeam fis e d cis b  }
 
-% --Bar 68- %
-b2-\trill ~ |
-\tuplet 3/2 {b8 \noBeam d cis b d cis } |
-b2^\trillB ~ | %(tr)?
-\tuplet 3/2 {b8 \noBeam d cis b a gis | 
-cis e d cis b a |
-d fis e d cis b |
-e g fis e d cis |}
-fis8 r s4 ^"accomp." |
+  % --Bar 54- %
+  a2-\trill ~ |
+  \tuplet 3/2 {
+    a8 \noBeam fis g a g a |
+    b d cis b d cis |
+    b gis a b a b |
+  }
+  \stemUp cis r \tuplet 3/2 { r16 g' fis e d cis } |
+  d8 r \tuplet 3/2 { r16 fis e d cis b} |
+  cis8 r \tuplet 3/2 { r16 e d c b a } |
+  \tuplet 3/2 { b c b a g fis } r8 r16 <e g b> | %<c e g>  or <g e c>?
+  <e g a cis>8 r <fis a d> r |
+  <fis b d>8. <e b' d>16 <e a cis>8. <e g cis>16 |
+  <d fis a d>8 r ^"accomp." r4 | \stemNeutral
+  s2 | s2| % 2 completely emtpy bars
+  r8 r16 g d'8. a16 |
 
-% --Bar 76- %
-s2*3|
-	
+  % --Bar 68- %
+  b2-\trill ~ |
+  \tuplet 3/2 {b8 \noBeam d cis b d cis } |
+  b2^\trillB ~ | %(tr)?
+  \tuplet 3/2 {
+    b8 \noBeam d cis b a gis |
+    cis e d cis b a |
+    d fis e d cis b |
+    e g fis e d cis |
+  }
+  fis8 r s4 ^"accomp." |
+
+  % --Bar 76- %
+  s2*3|
+
 
 }   %~~end harpsichordTreble~~%
 
 
 harpsichordBass =  \relative c' {
- \set Score.skipTypesetting = ##t
- \set Score.skipTypesetting = ##f
- \commonSettings
- \triplets \tripletsHide
- 
- 
-
- % --Bar 1-- %
- R2|
- R2|
- R2|
- R2|
- R2|
- R2|
- R2|
- R2|
-
- % --Bar 9-- %
- r8 r16 a d8. a16_\fbRootVII |
- \tuplet 3/2 { b8_\fbRootV a g  fis_\fbIinv g a } |
- d, r cis r |
- d r e r |
- fis r cis r |
- d r e r |
- fis r e r |
-fis r gis r |
+  \set Score.skipTypesetting = ##t
+  \set Score.skipTypesetting = ##f
+  \commonSettings
+  \triplets \tripletsHide
 
 
- % --Bar 17-- %
-\tuplet 3/2 { a cis b a b cis } |
-d r \change Staff = harpsichordUp \stemDown e c\rest | \tieDown %\voiceTwo
-fis2_\trill ~ | 
-\tuplet 3/2 { fis8 \noBeam a gis  fis e d } |
-cis2_\trill ~|
-\tuplet 3/2 { cis8 \noBeam a b   cis b cis } | \tieNeutral
-\tuplet 3/2 { dis fis e  dis fis e } |
-\tuplet 3/2 { dis b cis  dis cis dis } |
-\tuplet 3/2 { e16 d! e  fis e d   cis d cis \change Staff = harpsichordDown \stemUp  b a gis | }
 
-\stemNeutral 
-% --Bar 26-- %
-\tuplet 3/2 { fis e fis  gis a fis   b cis b  a gis fis |
-e d e  fis gis e   fis a gis fis e d |
-cis8 b a } e'8. e,16 |
-a8 r fis_\fbIinv r |
-g_\fbIinvVII r 
-<<	
-	 { \voiceOne a d\rest } \\ 
-{ 
-\tuplet 3/2 { s_\fbIinvVII s_\fbIVMv s_\fbVnIII } 
-}
+  % --Bar 1-- %
+  R2|
+  R2|
+  R2|
+  R2|
+  R2|
+  R2|
+  R2|
+  R2|
+
+  % --Bar 9-- %
+  r8 r16 a d8. a16_\fbRootVII |
+  \tuplet 3/2 { b8_\fbRootV a g  fis_\fbIinv g a } |
+  d, r cis r |
+  d r e r |
+  fis r cis r |
+  d r e r |
+  fis r e r |
+  fis r gis r |
 
 
->>
-\oneVoice
- | 
+  % --Bar 17-- %
+  \tuplet 3/2 { a cis b a b cis } |
+  d r \change Staff = harpsichordUp \stemDown e c\rest | \tieDown %\voiceTwo
+  fis2_\trill ~ |
+  \tuplet 3/2 { fis8 \noBeam a gis  fis e d } |
+  cis2_\trill ~|
+  \tuplet 3/2 { cis8 \noBeam a b   cis b cis } | \tieNeutral
+  \tuplet 3/2 { dis fis e  dis fis e } |
+  \tuplet 3/2 { dis b cis  dis cis dis } |
+  \tuplet 3/2 { e16 d! e  fis e d   cis d cis \change Staff = harpsichordDown \stemUp  b a gis | }
+
+  \stemNeutral
+  % --Bar 26-- %
+  \tuplet 3/2 {
+    fis e fis  gis a fis   b cis b  a gis fis |
+    e d e  fis gis e   fis a gis fis e d |
+    cis8 b a
+  } e'8. e,16 |
+  a8 r fis_\fbIinv r |
+  g_\fbIinvVII r
+  <<
+    { \voiceOne a d\rest } \\
+    {
+      \tuplet 3/2 { s_\fbIinvVII s_\fbIVMv s_\fbVnIII }
+    }
 
 
-b r cis_\fbIinv r |
-d r e_\fbIinv r |
-
-% --Bar 33-- %
-fis_\fbRootV r fis_\fbIinv r |
-g r a_\fbIinv r |
-b r a_\fbIinv r |
-b_\fbIinvVII r cis_\fbIinvVII r |
-d r r4 |
-R2 |
-r8 r16 a d8. a16 |
- \tuplet 3/2 { b8 a g  fis g a } |
-
-% --Bar 41-- %
-d, r e r |
-fis r fis, r |
-g r a r |
-b r cis r |
-d r e r |
-fis r g r |
-
-% --Bar 47-- %
-a8 r b r |
-cis8. \noBeam a16 d8. a16 |
-\tuplet 3/2 { b8 a g fis g  a } |
-\tuplet 3/2 { d, fis e d e fis } |
-g r a r |
-b2-\trill ~ |
-\tuplet 3/2 { b8 \noBeam d cis b a g} |
-fis2-\trill ~ |
-\tuplet 3/2 { fis8 \noBeam d e fis e fis} |
-\tuplet 3/2 { gis b a gis b a } |
-\tuplet 3/2 { gis e fis gis fis gis } |
-\stemDown \tuplet 3/2 { a16 cis \change Staff = harpsichordUp d e fis g! } a8 r |
-\change Staff = harpsichordDown \tuplet 3/2 { r16 b, cis d \change Staff = harpsichordUp e fis } g8 r |
-\change Staff = harpsichordDown \tuplet 3/2 { r16 a, b cis d \change Staff = harpsichordUp e  }fis8 r |
-
-% --Bar 61-- %
-\change Staff = harpsichordDown g, r \change Staff = harpsichordUp \tuplet 3/2 { e'16 fis e d cis! \change Staff = harpsichordDown \stemNeutral b} |
-\tuplet 3/2 { a b a g fis e d e d cis b a |
-b8 a g } a8. a16 |
-d,8 r fis r | % 6 3?
-g r c r | % <2 4 6>
-b8. \noBeam g'16 d'8. a16 |
-\tuplet 3/2 {b8 a g fis gis a |}
-
-% --Bar 68-- %
-gis2-\trill ~ |
-\tuplet 3/2 {gis8 \noBeam b a gis b a }|
-gis2^\trillB ~ | 
-\tuplet 3/2 {gis8 \noBeam b a gis fis e |
-a cis b a g! fis |
-b d cis b a g |
-cis e d cis b a |}
-d r fis, r |
-g r a r |
-\tuplet 3/2 {b a g} a8. a,16 |
-\tuplet 3/2 {d8 fis e d e fis}|
-b,8 r r4 |
-%79
-\repeat unfold 5{ b8 r r4 |}
-
-%85
-b8 r r4 |
-b8. \noBeam fis'16 \tuplet 3/2 { b8 d cis |
-d cis b ais b cis |}
-fis,4 ~ \tuplet 3/2 { fis8 g e |
-d cis b } r4 |
-%90
-\repeat unfold 6 { b8 r r4 | }
-%96
-b8. \noBeam fis'16 \tuplet 3/2 { b8 a gis |
-a gis fis eis fis gis |}
-cis,4 ~ \tuplet 3/2 { cis8 d b |
-a gis fis } r4 |
-%100
-\repeat unfold 6 { fis8 r r4 | }
-%106
-fis8.\noBeam cis'16 \tuplet 3/2 { fis8 a gis } |
-a8 r r4 |
-%108
-\tuplet 3/2 { r8 cis, d e gis fis } |
-gis r r4 |
-\tuplet 3/2 { r8 b, cis d fis eis | 
-fis a, b cis eis dis |
-eis gis fis eis gis fis |}
-eis2-\trill ~ |
-\tuplet 3/2 { eis!8 \noBeam cis dis eis! dis eis |
-%115
-fis d! e! fis e fis |
-gis e fis  gis fis gis |
-a fis gis a gis a |
-b gis a b a b |
-%119
-eis, gis fis eis dis eis|
-fis fis, gis a gis a |
-b gis a b a b |}
-cis4 ~ \tuplet 3/2 { cis8 d e } |
-fis4 ~ \tuplet 3/2 { fis8 gis ais |
-	b  cis d cis dis eis |
-	fis, gis a gis a b |
-a b cis } d, r |
-
-%127
-b r cis r |
-
-% --Bar 128 -- %
-fis, r a r |
-b r cis r |
-d r dis r |
-e r fis r |
-g r gis r |
-a r b r |
-cis r cis, r  |
-
-% --Bar 135 -- %
-d r e r |
-fis r fis, r |
-gis r gis' r |
-a r a, r |
-b r b' r |
-cis r cis, r |
-d r d' r |
-d r cis r |
-
-% --Bar 143 -- %
-d r e r |
-\tuplet 3/2 { fis e d cis dis e }
-dis4 r8 b |
-e8. d!16 cis8. fis,16 |
-e8. d16 e8. e,16 |
-a8 r a' r |
-\repeat unfold 6 { a, r a ' r |}
-
-% --Bar 155 -- %
-\tuplet 3/2 { a, \noBeam cis e a cis b |
-cis a b cis e dis | }
-e2-\trill ~ |
-e2 ~ |
-
-% --Bar 159 -- %
-\tuplet 3/2 { e8 \noBeam e, fis g b a |
-b g a  b d cis |}
-d2-\trill ~ |
-d2 ~ |
-d8 r r4 |
-\change Staff = harpsichordUp
-\stemDown
-r8 r16 fis b8. fis16 |
-\tuplet 3/2 { g8 fis e  d e fis |}
-\stemNeutral \change Staff = harpsichordDown
-b,8. fis16 \tuplet 3/2 { b8 d cis } |
-\tuplet 3/2 { d b cis d fis e } |
-
-%168
-fis8. b,16 fis'8. cis16 |
-\tuplet 3/2 { d8 cis b ais b cis } |
-fis,4 e' ~ |
-\tuplet 3/2 { e8 d cis b cis ais } |
-\tuplet 3/2 { g' fis e d e cis  } |
-b8. fis16 b8. fis16 |
-\tuplet 3/2 { g8 fis e d e fis } |
-b,8. fis16 \tuplet 3/2 { b8 d cis } |
-\tuplet 3/2 { d b cis d fis eis } |
-
-%177
-fis2-\trill ~ |
-\tuplet 3/2 { fis8 \noBeam a g fis e dis } |
-e2-\trill ~ |
-\tuplet 3/2 { e8 \noBeam g fis e d cis } |
-d2-\trillB ~ |
-d ~ |
-\tuplet 3/2 { d8 \noBeam fis, a d fis e } |
-\tuplet 3/2 { fis d e fis a gis } |
-a2^\trillB ~ |
-%186
-a2 ~ |
-\tuplet 3/2 { a8 \noBeam cis, e a cis b |
-cis a b cis e d } |
-e2-\trill ~
-\tuplet 3/2 { e8 \noBeam cis d e cis d  } |
-e2-\trill ~ |
-\tuplet 3/2 { e8 g fis e d cis | 
-d fis e d cis b |
-cis e d cis b a | }
-
-%195
-\tuplet 3/2 { b d cis b a gis |
-a cis b a b a | 
-gis a gis fis eis fis |
-cis eis dis cis dis eis |
-fis a gis  fis eis fis |
-gis b a  gis fis gis |
-a cis b  a gis fis |
-b d cis  b a gis |}
-
-% --Bar 203 -- %
-cis8 r cis, r |
-fis8 r r4 |
-fis8 r fis, r |
-g8 r r4 |
-a8 r b r |
-e,8 r r4 |
-a8 r d r |
-b r g r |
+  >>
+  \oneVoice
+  |
 
 
-% --Bar 211 -- %
-\tuplet 3/2 { e fis g a b c } |
-d, r g r |
-d' r c r |
-b2~ |
-b8. \noBeam fis'16 b8. fis16 |
-g8. fis16 g8. e16 |
-<< { \tieDown fis,2 ~ | fis ~ | fis  } \\
-	{ \tieUp \stemUp fis' ~ |  fis~ |  fis } >>  |
+  b r cis_\fbIinv r |
+  d r e_\fbIinv r |
 
-% --Bar 220 -- %
-<< { \tieDown fis,^\markup {\bold "tasto solo"} ~ | fis ~ | fis8.  } \\
-	{ \tieUp \stemUp fis'2 ~|  fis ~|  fis8. } >>  
-\stemNeutral \tieNeutral
-% --Bar 222 -- %
-\voiceOne b,16 fis'8. a,16 |
-%should beam down
-\tuplet 3/2 {b8 a g  ais b cis }|
-fis,4 ~ \tuplet 3/2 {fis8 fis' e } |
-\tuplet 3/2 { d b cis d e fis |
-e cis d e fis g | }
+  % --Bar 33-- %
+  fis_\fbRootV r fis_\fbIinv r |
+  g r a_\fbIinv r |
+  b r a_\fbIinv r |
+  b_\fbIinvVII r cis_\fbIinvVII r |
+  d r r4 |
+  R2 |
+  r8 r16 a d8. a16 |
+  \tuplet 3/2 { b8 a g  fis g a } |
 
-%227
-\tuplet 3/2 { fis d e fis g a |
-g e fis gis a b |
-a fis gis ais b cis | }
-b8. g!16 d8. e16 |
-fis8. e16 fis8. fis,16 |
-b4 r |
-\oneVoice
-%233
-<< { \stemDown d } \\ { \stemUp a'} \\ { \stemUp fis } >> \oneVoice r |
-\stemNeutral
+  % --Bar 41-- %
+  d, r e r |
+  fis r fis, r |
+  g r a r |
+  b r cis r |
+  d r e r |
+  fis r g r |
 
-%234
-R2*7 |
-%241
+  % --Bar 47-- %
+  a8 r b r |
+  cis8. \noBeam a16 d8. a16 |
+  \tuplet 3/2 { b8 a g fis g  a } |
+  \tuplet 3/2 { d, fis e d e fis } |
+  g r a r |
+  b2-\trill ~ |
+  \tuplet 3/2 { b8 \noBeam d cis b a g} |
+  fis2-\trill ~ |
+  \tuplet 3/2 { fis8 \noBeam d e fis e fis} |
+  \tuplet 3/2 { gis b a gis b a } |
+  \tuplet 3/2 { gis e fis gis fis gis } |
+  \stemDown \tuplet 3/2 { a16 cis \change Staff = harpsichordUp d e fis g! } a8 r |
+  \change Staff = harpsichordDown \tuplet 3/2 { r16 b, cis d \change Staff = harpsichordUp e fis } g8 r |
+  \change Staff = harpsichordDown \tuplet 3/2 { r16 a, b cis d \change Staff = harpsichordUp e  }fis8 r |
 
-% --Bar 9-- %
- r8 r16 a d8. a16_\fbRootVII |
- \tuplet 3/2 { b8_\fbRootV a g  fis_\fbIinv g a } |
- d, r cis r |
- d r e r |
- fis r cis r |
- d r e r |
- fis r e r |
-fis r gis r |
+  % --Bar 61-- %
+  \change Staff = harpsichordDown g, r \change Staff = harpsichordUp \tuplet 3/2 { e'16 fis e d cis! \change Staff = harpsichordDown \stemNeutral b} |
+  \tuplet 3/2 {
+    a b a g fis e d e d cis b a |
+    b8 a g
+  } a8. a16 |
+  d,8 r fis r | % 6 3?
+  g r c r | % <2 4 6>
+  b8. \noBeam g'16 d'8. a16 |
+  \tuplet 3/2 {b8 a g fis gis a |}
+
+  % --Bar 68-- %
+  gis2-\trill ~ |
+  \tuplet 3/2 {gis8 \noBeam b a gis b a }|
+  gis2^\trillB ~ |
+  \tuplet 3/2 {
+    gis8 \noBeam b a gis fis e |
+    a cis b a g! fis |
+    b d cis b a g |
+    cis e d cis b a |
+  }
+  d r fis, r |
+  g r a r |
+  \tuplet 3/2 {b a g} a8. a,16 |
+  \tuplet 3/2 {d8 fis e d e fis}|
+  b,8 r r4 |
+  %79
+  \repeat unfold 5{ b8 r r4 |}
+
+  %85
+  b8 r r4 |
+  b8. \noBeam fis'16 \tuplet 3/2 {
+    b8 d cis |
+    d cis b ais b cis |
+  }
+  fis,4 ~ \tuplet 3/2 {
+    fis8 g e |
+    d cis b
+  } r4 |
+  %90
+  \repeat unfold 6 { b8 r r4 | }
+  %96
+  b8. \noBeam fis'16 \tuplet 3/2 {
+    b8 a gis |
+    a gis fis eis fis gis |
+  }
+  cis,4 ~ \tuplet 3/2 {
+    cis8 d b |
+    a gis fis
+  } r4 |
+  %100
+  \repeat unfold 6 { fis8 r r4 | }
+  %106
+  fis8.\noBeam cis'16 \tuplet 3/2 { fis8 a gis } |
+  a8 r r4 |
+  %108
+  \tuplet 3/2 { r8 cis, d e gis fis } |
+  gis r r4 |
+  \tuplet 3/2 {
+    r8 b, cis d fis eis |
+    fis a, b cis eis dis |
+    eis gis fis eis gis fis |
+  }
+  eis2-\trill ~ |
+  \tuplet 3/2 {
+    eis!8 \noBeam cis dis eis! dis eis |
+    %115
+    fis d! e! fis e fis |
+    gis e fis  gis fis gis |
+    a fis gis a gis a |
+    b gis a b a b |
+    %119
+    eis, gis fis eis dis eis|
+    fis fis, gis a gis a |
+    b gis a b a b |
+  }
+  cis4 ~ \tuplet 3/2 { cis8 d e } |
+  fis4 ~ \tuplet 3/2 {
+    fis8 gis ais |
+    b  cis d cis dis eis |
+    fis, gis a gis a b |
+    a b cis
+  } d, r |
+
+  %127
+  b r cis r |
+
+  % --Bar 128 -- %
+  fis, r a r |
+  b r cis r |
+  d r dis r |
+  e r fis r |
+  g r gis r |
+  a r b r |
+  cis r cis, r  |
+
+  % --Bar 135 -- %
+  d r e r |
+  fis r fis, r |
+  gis r gis' r |
+  a r a, r |
+  b r b' r |
+  cis r cis, r |
+  d r d' r |
+  d r cis r |
+
+  % --Bar 143 -- %
+  d r e r |
+  \tuplet 3/2 { fis e d cis dis e }
+  dis4 r8 b |
+  e8. d!16 cis8. fis,16 |
+  e8. d16 e8. e,16 |
+  a8 r a' r |
+  \repeat unfold 6 { a, r a ' r |}
+
+  % --Bar 155 -- %
+  \tuplet 3/2 {
+    a, \noBeam cis e a cis b |
+    cis a b cis e dis |
+  }
+  e2-\trill ~ |
+  e2 ~ |
+
+  % --Bar 159 -- %
+  \tuplet 3/2 {
+    e8 \noBeam e, fis g b a |
+    b g a  b d cis |
+  }
+  d2-\trill ~ |
+  d2 ~ |
+  d8 r r4 |
+  \change Staff = harpsichordUp
+  \stemDown
+  r8 r16 fis b8. fis16 |
+  \tuplet 3/2 { g8 fis e  d e fis |}
+  \stemNeutral \change Staff = harpsichordDown
+  b,8. fis16 \tuplet 3/2 { b8 d cis } |
+  \tuplet 3/2 { d b cis d fis e } |
+
+  %168
+  fis8. b,16 fis'8. cis16 |
+  \tuplet 3/2 { d8 cis b ais b cis } |
+  fis,4 e' ~ |
+  \tuplet 3/2 { e8 d cis b cis ais } |
+  \tuplet 3/2 { g' fis e d e cis  } |
+  b8. fis16 b8. fis16 |
+  \tuplet 3/2 { g8 fis e d e fis } |
+  b,8. fis16 \tuplet 3/2 { b8 d cis } |
+  \tuplet 3/2 { d b cis d fis eis } |
+
+  %177
+  fis2-\trill ~ |
+  \tuplet 3/2 { fis8 \noBeam a g fis e dis } |
+  e2-\trill ~ |
+  \tuplet 3/2 { e8 \noBeam g fis e d cis } |
+  d2-\trillB ~ |
+  d ~ |
+  \tuplet 3/2 { d8 \noBeam fis, a d fis e } |
+  \tuplet 3/2 { fis d e fis a gis } |
+  a2^\trillB ~ |
+  %186
+  a2 ~ |
+  \tuplet 3/2 {
+    a8 \noBeam cis, e a cis b |
+    cis a b cis e d
+  } |
+  e2-\trill ~
+  \tuplet 3/2 { e8 \noBeam cis d e cis d  } |
+  e2-\trill ~ |
+  \tuplet 3/2 {
+    e8 g fis e d cis |
+    d fis e d cis b |
+    cis e d cis b a |
+  }
+
+  %195
+  \tuplet 3/2 {
+    b d cis b a gis |
+    a cis b a b a |
+    gis a gis fis eis fis |
+    cis eis dis cis dis eis |
+    fis a gis  fis eis fis |
+    gis b a  gis fis gis |
+    a cis b  a gis fis |
+    b d cis  b a gis |
+  }
+
+  % --Bar 203 -- %
+  cis8 r cis, r |
+  fis8 r r4 |
+  fis8 r fis, r |
+  g8 r r4 |
+  a8 r b r |
+  e,8 r r4 |
+  a8 r d r |
+  b r g r |
 
 
- % --Bar 17-- %
-\tuplet 3/2 { a cis b a b cis } |
-d r \change Staff = harpsichordUp \stemDown e r | \tieUp %\voiceTwo
-fis2_\trill ~ | 
-\tuplet 3/2 { fis8 \noBeam a gis  fis e d } |
-cis2_\trill ~|
-\tuplet 3/2 { cis8 \noBeam a b   cis b cis } | \tieNeutral
-\tuplet 3/2 { dis fis e  dis fis e } |
-\tuplet 3/2 { dis b cis  dis cis dis } |
-\tuplet 3/2 { e16 d! e  fis e d   cis d cis \change Staff = harpsichordDown \stemUp  b a gis | }
+  % --Bar 211 -- %
+  \tuplet 3/2 { e fis g a b c } |
+  d, r g r |
+  d' r c r |
+  b2~ |
+  b8. \noBeam fis'16 b8. fis16 |
+  g8. fis16 g8. e16 |
+  <<
+    { \tieDown fis,2 ~ | fis ~ | fis  } \\
+    { \tieUp \stemUp fis' ~ |  fis~ |  fis }
+  >>  |
 
-\stemNeutral 
-% --Bar 26-- %
-\tuplet 3/2 { fis e fis  gis a fis   b cis b  a gis fis |
-e d e  fis gis e   fis a gis fis e d |
-cis8 b a } e'8. e,16 |
-a8 r fis_\fbIinv r |
-g_\fbIinvVII r 
-<<	
-{ 
-\tuplet 3/2 { s_\fbIinvVII s_\fbIV s_\fbVnIII } 
-}
-	\\ { \stemUp a d\rest } 
->>
-\oneVoice
- | 
+  % --Bar 220 -- %
+  <<
+    { \tieDown fis,^\markup {\bold "tasto solo"} ~ | fis ~ | fis8.  } \\
+    { \tieUp \stemUp fis'2 ~|  fis ~|  fis8. }
+  >>
+  \stemNeutral \tieNeutral
+  % --Bar 222 -- %
+  \voiceOne b,16 fis'8. a,16 |
+  %should beam down
+  \tuplet 3/2 {b8 a g  ais b cis }|
+  fis,4 ~ \tuplet 3/2 {fis8 fis' e } |
+  \tuplet 3/2 {
+    d b cis d e fis |
+    e cis d e fis g |
+  }
+
+  %227
+  \tuplet 3/2 {
+    fis d e fis g a |
+    g e fis gis a b |
+    a fis gis ais b cis |
+  }
+  b8. g!16 d8. e16 |
+  fis8. e16 fis8. fis,16 |
+  b4 r |
+  \oneVoice
+  %233
+  << { \stemDown d } \\ { \stemUp a'} \\ { \stemUp fis } >> \oneVoice r |
+  \stemNeutral
+
+  %234
+  R2*7 |
+  %241
+
+  % --Bar 9-- %
+  r8 r16 a d8. a16_\fbRootVII |
+  \tuplet 3/2 { b8_\fbRootV a g  fis_\fbIinv g a } |
+  d, r cis r |
+  d r e r |
+  fis r cis r |
+  d r e r |
+  fis r e r |
+  fis r gis r |
 
 
-b r cis_\fbIinv r |
-d r e_\fbIinv r |
+  % --Bar 17-- %
+  \tuplet 3/2 { a cis b a b cis } |
+  d r \change Staff = harpsichordUp \stemDown e r | \tieUp %\voiceTwo
+  fis2_\trill ~ |
+  \tuplet 3/2 { fis8 \noBeam a gis  fis e d } |
+  cis2_\trill ~|
+  \tuplet 3/2 { cis8 \noBeam a b   cis b cis } | \tieNeutral
+  \tuplet 3/2 { dis fis e  dis fis e } |
+  \tuplet 3/2 { dis b cis  dis cis dis } |
+  \tuplet 3/2 { e16 d! e  fis e d   cis d cis \change Staff = harpsichordDown \stemUp  b a gis | }
 
-% --Bar 33-- %
-fis_\fbRootV r fis_\fbIinv r |
-g r a_\fbIinv r |
-b r a_\fbIinv r |
-b_\fbIinvVII r cis_\fbIinvVII r |
-d r r4 |
-R2 |
-r8 r16 a d8. a16 |
- \tuplet 3/2 { b8 a g  fis g a } |
+  \stemNeutral
+  % --Bar 26-- %
+  \tuplet 3/2 {
+    fis e fis  gis a fis   b cis b  a gis fis |
+    e d e  fis gis e   fis a gis fis e d |
+    cis8 b a
+  } e'8. e,16 |
+  a8 r fis_\fbIinv r |
+  g_\fbIinvVII r
+  <<
+    {
+      \tuplet 3/2 { s_\fbIinvVII s_\fbIV s_\fbVnIII }
+    }
+    \\ { \stemUp a d\rest }
+  >>
+  \oneVoice
+  |
 
-% --Bar 41-- %
-d, r e r |
-fis r fis, r |
-g r a r |
-b r cis r |
-d r e r |
-fis r g r |
 
-% --Bar 47-- %
-a8 r b r |
-cis8. \noBeam a16 d8. a16 |
-\tuplet 3/2 { b8 a g fis g  a } |
-\tuplet 3/2 { d, fis e d e fis } |
-g r a r |
-b2-\trill ~ |
-\tuplet 3/2 { b8 \noBeam d cis b a g} |
-fis2-\trill ~ |
-\tuplet 3/2 { fis8 \noBeam d e fis e fis} |
-\tuplet 3/2 { gis b a gis b a } |
-\tuplet 3/2 { gis e fis gis fis gis } |
-\stemDown \tuplet 3/2 { a16 cis \change Staff = harpsichordUp d e fis g! } a8 r |
-\change Staff = harpsichordDown \tuplet 3/2 { r16 b, cis d \change Staff = harpsichordUp e fis } g8 r |
-\change Staff = harpsichordDown \tuplet 3/2 { r16 a, b cis d \change Staff = harpsichordUp e  }fis8 r |
+  b r cis_\fbIinv r |
+  d r e_\fbIinv r |
 
-% --Bar 61-- %
-\change Staff = harpsichordDown g, r \change Staff = harpsichordUp \tuplet 3/2 { e'16 fis e d cis! \change Staff = harpsichordDown \stemNeutral b} |
-\stemNeutral
-\tuplet 3/2 { a b a g fis e d e d cis b a |
-b8 a g } a8. a16 |
-d,8 r fis r | % 6 3?
-g r c r | % <2 4 6>
-b8. \noBeam g'16 d'8. a16 |
-\tuplet 3/2 {b8 a g fis gis a |}
+  % --Bar 33-- %
+  fis_\fbRootV r fis_\fbIinv r |
+  g r a_\fbIinv r |
+  b r a_\fbIinv r |
+  b_\fbIinvVII r cis_\fbIinvVII r |
+  d r r4 |
+  R2 |
+  r8 r16 a d8. a16 |
+  \tuplet 3/2 { b8 a g  fis g a } |
 
-% --Bar 68-- %
-gis2-\trill ~ |
-\tuplet 3/2 {gis8 \noBeam b a gis b a }|
-gis2-\trill ~ | %(tr)
-\tuplet 3/2 {gis8 b a gis fis e |
-a cis b a g! fis |
-b d cis b a g |
-cis e d cis b a |}
+  % --Bar 41-- %
+  d, r e r |
+  fis r fis, r |
+  g r a r |
+  b r cis r |
+  d r e r |
+  fis r g r |
 
-d r fis, r |
-g r a r |
-\tuplet 3/2 {b a g} a8. a,16 |
-d2-\fermata \bar "||"
+  % --Bar 47-- %
+  a8 r b r |
+  cis8. \noBeam a16 d8. a16 |
+  \tuplet 3/2 { b8 a g fis g  a } |
+  \tuplet 3/2 { d, fis e d e fis } |
+  g r a r |
+  b2-\trill ~ |
+  \tuplet 3/2 { b8 \noBeam d cis b a g} |
+  fis2-\trill ~ |
+  \tuplet 3/2 { fis8 \noBeam d e fis e fis} |
+  \tuplet 3/2 { gis b a gis b a } |
+  \tuplet 3/2 { gis e fis gis fis gis } |
+  \stemDown \tuplet 3/2 { a16 cis \change Staff = harpsichordUp d e fis g! } a8 r |
+  \change Staff = harpsichordDown \tuplet 3/2 { r16 b, cis d \change Staff = harpsichordUp e fis } g8 r |
+  \change Staff = harpsichordDown \tuplet 3/2 { r16 a, b cis d \change Staff = harpsichordUp e  }fis8 r |
+
+  % --Bar 61-- %
+  \change Staff = harpsichordDown g, r \change Staff = harpsichordUp \tuplet 3/2 { e'16 fis e d cis! \change Staff = harpsichordDown \stemNeutral b} |
+  \stemNeutral
+  \tuplet 3/2 {
+    a b a g fis e d e d cis b a |
+    b8 a g
+  } a8. a16 |
+  d,8 r fis r | % 6 3?
+  g r c r | % <2 4 6>
+  b8. \noBeam g'16 d'8. a16 |
+  \tuplet 3/2 {b8 a g fis gis a |}
+
+  % --Bar 68-- %
+  gis2-\trill ~ |
+  \tuplet 3/2 {gis8 \noBeam b a gis b a }|
+  gis2-\trill ~ | %(tr)
+  \tuplet 3/2 {
+    gis8 b a gis fis e |
+    a cis b a g! fis |
+    b d cis b a g |
+    cis e d cis b a |
+  }
+
+  d r fis, r |
+  g r a r |
+  \tuplet 3/2 {b a g} a8. a,16 |
+  d2-\fermata \bar "||"
 
 } % end for Notes Bass
 
 
 % end for notes
 
-harpsichordTa = 
+harpsichordTa =
 
 \context PianoStaff  <<
-	
-	\context Staff = harpsichordUp <<  \time 2/4 \clef treble \key d \major
-		\set Staff.midiInstrument = "harpsichord" 
-		\harpsichordTreble
-	>>
 
-	\context Staff = harpsichordDown <<   \time 2/4 \clef bass  \key d \major
-		\set Staff.instrumentName = \markup \smaller { 
-			\column {
-				"Cembalo" 
-				"concertato."
-			 } }
-		%"Harpischord solo"
-		%\set Staff.shortInstrumentName = "Clavier"
-		\set Staff.midiInstrument = "harpsichord" 	 	
-		\harpsichordBass
-	>>
+  \context Staff = harpsichordUp <<
+    \time 2/4 \clef treble \key d \major
+    \set Staff.midiInstrument = "harpsichord"
+    \harpsichordTreble
+  >>
+
+  \context Staff = harpsichordDown <<
+    \time 2/4 \clef bass  \key d \major
+    \set Staff.instrumentName = \markup \smaller {
+      \column {
+        "Cembalo"
+        "concertato."
+      }
+    }
+    %"Harpischord solo"
+    %\set Staff.shortInstrumentName = "Clavier"
+    \set Staff.midiInstrument = "harpsichord"
+    \harpsichordBass
+  >>
 >>

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/harpsichord.ly
@@ -3,9 +3,11 @@
 \include "header.ly"
 
 harpsichordTreble = \relative c'' {
+  
   \commonSettings
   \triplets \tripletsHide
-
+  
+  \time 2/4 \clef treble \key d \major
   % --Bar 1-- %
   \repeat unfold 10 R2 |
 
@@ -412,7 +414,7 @@ harpsichordBass = \relative c' {
   \set Score.skipTypesetting = ##f
   \commonSettings
   \triplets \tripletsHide
-
+  \time 2/4 \clef bass \key d \major
 
 
   % --Bar 1-- %
@@ -853,33 +855,17 @@ harpsichordBass = \relative c' {
   d r fis, r |
   g r a r |
   \tuplet 3/2 { b a g} a8. a,16 |
-  d2-\fermata \bar "||"
+  d2-\fermata \bar "|."
 
 } % end for Notes Bass
 
 
 % end for notes
 
-harpsichordTa =
-\context PianoStaff <<
-
-  \context Staff = harpsichordUp <<
-    \time 2/4 \clef treble \key d \major
-    \set Staff.midiInstrument = "harpsichord"
-    \harpsichordTreble
-  >>
-
-  \context Staff = harpsichordDown <<
-    \time 2/4 \clef bass \key d \major
-    \set Staff.instrumentName = \markup \smaller {
-      \column {
-        "Cembalo"
-        "concertato."
-      }
-    }
-    %"Harpischord solo"
-    %\set Staff.shortInstrumentName = "Clavier"
-    \set Staff.midiInstrument = "harpsichord"
-    \harpsichordBass
-  >>
+harpsichordStaff = \new PianoStaff \with {
+  instrumentName = \markup \smaller \center-column { "Cembalo" "concertato." }
+  midiInstrument = "harpsichord"
+} <<
+  \new Staff = harpsichordUp \harpsichordTreble
+  \new Staff = harpsichordDown \harpsichordBass
 >>

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/header.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/header.ly
@@ -48,9 +48,9 @@
 #(set-global-staff-size 18)
 
 \header {
-  title = "Brandenberg Concerto No.5 (Keyboard Concencerto)"
+  title = "Brandenburg Concerto No. 5 in D Major"
   subtitle = "3rd Movement"
-  composer = "J.S. Bach"
+  composer = "Johann Sebastian Bach"
   meter = "Allegro"
 
   %instrument = "Baroque Chamber"

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/header.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/header.ly
@@ -73,7 +73,7 @@
   lastupdated = "2005/March/31"
 
   footer = "Mutopia-2005/04/11-548"
-  tagline = "\\raisebox{10mm}{\\parbox{188mm}{\\quad\\small\\noindent " + \footer + " \\hspace{\\stretch{1}} This music is part of the Mutopia project: \\hspace{\\stretch{1}} \\texttt{http://www.MutopiaProject.org/}\\\\ \\makebox[188mm][c]{It has been typeset and placed in the public domain by " + \maintainer + ".} \\makebox[188mm][c]{Unrestricted modification and redistribution is permitted and encouraged---copy this music and share it!}}}"
+  %tagline = "\\raisebox{10mm}{\\parbox{188mm}{\\quad\\small\\noindent " + \footer + " \\hspace{\\stretch{1}} This music is part of the Mutopia project: \\hspace{\\stretch{1}} \\texttt{http://www.MutopiaProject.org/}\\\\ \\makebox[188mm][c]{It has been typeset and placed in the public domain by " + \maintainer + ".} \\makebox[188mm][c]{Unrestricted modification and redistribution is permitted and encouraged---copy this music and share it!}}}"
 }
 
 %some fuctions
@@ -91,16 +91,13 @@ forteI = \markup \italic {\dynamic "f" "orte" }
 % set Triplets to 3 notes each
 triplets = \tupletSpan 4
 % hides the 3
-tripletsHide = \override TupletBracket.number-visibility % number-visibility is deprecated. Tune the TupletNumber instead
-= ##f
+tripletsHide = \hide TupletNumber % number-visibility is deprecated. Tune the TupletNumber instead
 % shows the 3
-tripletsShow = \override TupletBracket.number-visibility % number-visibility is deprecated. Tune the TupletNumber instead
-= ##t
+tripletsShow = \undo \hide TupletNumber % number-visibility is deprecated. Tune the TupletNumber instead
 % shows the 3 once
-tripletsShowOnce = \once \override TupletBracket.number-visibility % number-visibility is deprecated. Tune the TupletNumber instead
-= ##t
+tripletsShowOnce = \once \undo \hide TupletNumber % number-visibility is deprecated. Tune the TupletNumber instead
 % displays n condenses multi measure rests
-multirests = \set Score.skipBars = ##t
+multirests = \compressFullBarRests
 
 %hide triplets bracket
 bracketsHide = \override TupletBracket.bracket-visibility = ##f

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/header.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/header.ly
@@ -81,79 +81,23 @@ forteB = \markup { \italic "(forte)" }
 pianoB = \markup { \italic "(piano)" }
 forte = \markup { \italic "forte" }
 piano = \markup { \italic "piano" }
-pianoissimo = \markup { \italic "pianoissimo" }
-pianoissimoB = \markup { \italic "(pianoissimo)" }
+pianissimo = \markup { \italic "pianissimo" }
+pianissimoB = \markup { \italic "(pianissimo)" }
 trillB = \markup { "(" \musicglyph #"scripts.trill" ")"}
 cantabile = \markup { \italic "cantabile" }
 cantabileB = \markup { \italic "(cantabile)" }
 forteI = \markup \italic { \dynamic "f" "orte" }
 
-% set Triplets to 3 notes each
-triplets = \tupletSpan 4
-% hides the 3
-tripletsHide = \hide TupletNumber % number-visibility is deprecated. Tune the TupletNumber instead
-% shows the 3
-tripletsShow = \undo \hide TupletNumber % number-visibility is deprecated. Tune the TupletNumber instead
-% shows the 3 once
-tripletsShowOnce = \once \undo \hide TupletNumber % number-visibility is deprecated. Tune the TupletNumber instead
-% displays n condenses multi measure rests
-multirests = \compressFullBarRests
+onceShowTupletNumber = \once \override TupletNumber.stencil = #ly:tuplet-number::print
+staffUp = { \change Staff = harpsichordUp \voiceTwo }
+staffDown = { \change Staff = harpsichordDown \oneVoice }
 
-%hide triplets bracket
-bracketsHide = \hide TupletBracket
-
-commonSettings = {
-  \triplets
-  \multirests
-  \bracketsHide
-  \tupletUp
+\layout {
+  \compressFullBarRests
+  \override MultiMeasureRest.expand-limit = 8
+  \tupletSpan 4
+  \omit TupletBracket
+  \set FiguredBass.figuredBassAlterationDirection = #RIGHT
+  \override FiguredBass.BassFigure.font-size = -2
+  \hide FiguredBass.BassFigureContinuation
 }
-
-%figured sharp
-fbis = \markup { \small \sharp }
-fbes = \markup { \small \flat }
-fbna = \markup { \small \natural }
-
-%root 7th
-fbRootVII = \markup { }
-%root 5
-fbRootV = \markup { }
-
-%root 5 (853)
-fbVnIII = \markup { }
-
-% 1st inversion
-fbIinv = \markup { }
-
-fbIinvVII = \markup { }
-
-% 8 5 4
-fbIV = \markup { }
-fbIVMv = \markup { }
-
-%{
-	 More figure bass work needed
-	 They are disabled now
-	 slashed \ 6
-	 6 5nat
-	 6 #
-	 5 #
-
- %root 7th
- fbRootVII = \markup { \small \column { "7" "5"} }
- %root 5
- fbRootV = \markup { \small "5" }
-
- %root 5 (853)
- fbVnIII = \markup { \small \column { "5" "3"} }
-
- % 1st inversion
- fbIinv = \markup { \small "6" }
-
- fbIinvVII = \markup { \small \column { "6" "5"} }
-
- % 8 5 4
- fbIV = \markup { \small "4" }
- fbIVMv = \markup { \small \column { " " "4"} }
-
-%}

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/header.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/header.ly
@@ -91,10 +91,13 @@ staffUp = { \change Staff = harpsichordUp \voiceTwo }
 staffDown = { \change Staff = harpsichordDown \oneVoice }
 
 \layout {
+  % compressed rests
   \compressFullBarRests
   \override MultiMeasureRest.expand-limit = 8
+  % invisble (implicit) tuplets - with some exceptions inline
   \tupletSpan 4
   \omit TupletBracket
+  % figured bass - hidden continuation line used for number ordering
   \set FiguredBass.figuredBassAlterationDirection = #RIGHT
   \override FiguredBass.BassFigure.font-size = -2
   \hide FiguredBass.BassFigureContinuation

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/header.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/header.ly
@@ -37,7 +37,7 @@
 		 My friends (music friends, school friends)
 		 My church (brethren in Christ)
 		 Friendly net pals (who helped me along)
-	 and in one or  many other aspects in my life
+	 and in one or many other aspects in my life
 
 	 I'd love to hear any comments. Email me at joshuakoo@myrealbox.com or zz85@users.sourceforge.net
 
@@ -48,45 +48,45 @@
 #(set-global-staff-size 18)
 
 \header {
-  title = "Brandenberg Concerto No.5 (Keyboard Concencerto)"
-  subtitle = "3rd Movement"
-  composer = "J.S. Bach"
-  meter = "Allegro"
+ title = "Brandenberg Concerto No.5 (Keyboard Concencerto)"
+ subtitle = "3rd Movement"
+ composer = "J.S. Bach"
+ meter = "Allegro"
 
-  %instrument = "Baroque Chamber"
-  %dedication = "Typesetted for my Friends"
-  %piece = ""
-  %head = ""
-  %footer = ""
-  %tagline = "joshuakoo@myrealbox.com. WIP for mutopia-project"
+ %instrument = "Baroque Chamber"
+ %dedication = "Typesetted for my Friends"
+ %piece = ""
+ %head = ""
+ %footer = ""
+ %tagline = "joshuakoo@myrealbox.com. WIP for mutopia-project"
 
-  mutopiatitle = "Brandenburg Concerto No. 5 in D Major"
-  mutopiacomposer = "BachJS"
-  mutopiaopus = "BWV 1050"
-  mutopiainstrument = "Ensemble: Flute, Two Violins, Violas, 'Cello, Bass and Harpsichord"
-  date = "1719?"
-  source = "Dover From the Bach-Gesellschaft Edition"
-  style = "Baroque"
-  copyright = "Public Domain"
-  maintainer = "Joshua Koo"
-  maintainerEmail = "zz85@users.sourceforge.net"
-  lastupdated = "2005/March/31"
+ mutopiatitle = "Brandenburg Concerto No. 5 in D Major"
+ mutopiacomposer = "BachJS"
+ mutopiaopus = "BWV 1050"
+ mutopiainstrument = "Ensemble: Flute, Two Violins, Violas, 'Cello, Bass and Harpsichord"
+ date = "1719?"
+ source = "Dover From the Bach-Gesellschaft Edition"
+ style = "Baroque"
+ copyright = "Public Domain"
+ maintainer = "Joshua Koo"
+ maintainerEmail = "zz85@users.sourceforge.net"
+ lastupdated = "2005/March/31"
 
-  footer = "Mutopia-2005/04/11-548"
-  %tagline = "\\raisebox{10mm}{\\parbox{188mm}{\\quad\\small\\noindent " + \footer + " \\hspace{\\stretch{1}} This music is part of the Mutopia project: \\hspace{\\stretch{1}} \\texttt{http://www.MutopiaProject.org/}\\\\ \\makebox[188mm][c]{It has been typeset and placed in the public domain by " + \maintainer + ".} \\makebox[188mm][c]{Unrestricted modification and redistribution is permitted and encouraged---copy this music and share it!}}}"
+ footer = "Mutopia-2005/04/11-548"
+ %tagline = "\\raisebox { 10mm} { \\parbox { 188mm} { \\quad\\small\\noindent " + \footer + " \\hspace { \\stretch { 1}} This music is part of the Mutopia project: \\hspace { \\stretch { 1}} \\texttt { http://www.MutopiaProject.org/}\\\\ \\makebox[188mm][c] { It has been typeset and placed in the public domain by " + \maintainer + ".} \\makebox[188mm][c] { Unrestricted modification and redistribution is permitted and encouraged---copy this music and share it!}}}"
 }
 
 %some fuctions
-forteB = \markup {  \italic "(forte)" }
-pianoB = \markup {  \italic "(piano)" }
-forte = \markup {  \italic "forte" }
-piano = \markup {  \italic "piano" }
-pianoissimo = \markup {  \italic "pianoissimo" }
-pianoissimoB = \markup {  \italic "(pianoissimo)" }
-trillB = \markup {   "(" \musicglyph #"scripts.trill"  ")"}
-cantabile = \markup {  \italic "cantabile" }
-cantabileB = \markup {  \italic "(cantabile)" }
-forteI = \markup \italic {\dynamic "f" "orte" }
+forteB = \markup { \italic "(forte)" }
+pianoB = \markup { \italic "(piano)" }
+forte = \markup { \italic "forte" }
+piano = \markup { \italic "piano" }
+pianoissimo = \markup { \italic "pianoissimo" }
+pianoissimoB = \markup { \italic "(pianoissimo)" }
+trillB = \markup { "(" \musicglyph #"scripts.trill" ")"}
+cantabile = \markup { \italic "cantabile" }
+cantabileB = \markup { \italic "(cantabile)" }
+forteI = \markup \italic { \dynamic "f" "orte" }
 
 % set Triplets to 3 notes each
 triplets = \tupletSpan 4
@@ -110,9 +110,9 @@ commonSettings = {
 }
 
 %figured sharp
-fbis =  \markup{ \small \sharp }
-fbes =  \markup{ \small \flat }
-fbna =  \markup{ \small \natural }
+fbis = \markup { \small \sharp }
+fbes = \markup { \small \flat }
+fbna = \markup { \small \natural }
 
 %root 7th
 fbRootVII = \markup { }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/header.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/header.ly
@@ -43,6 +43,15 @@
 
 	 Joshua Koo
 
+         --------------
+         I updated this piece to LilyPond 2.18. After contacting Joshua Koo, we
+         agreed that I can contribute to this piece in addition to updating it.
+         The musical content is still what Joshua entered and I left the above
+         dedication and comments. Main change to the content was to make use of
+         the A-B-A structure of the piece and fix some typos where the two A
+         parts showed differences.
+
+         Joram Berger
 %}
 
 #(set-global-staff-size 18)
@@ -60,7 +69,7 @@
   source = "Dover From the Bach-Gesellschaft Edition"
   style = "Baroque"
   copyright = ##f
-  maintainer = "Joshua Koo"
+  maintainer = "Joshua Koo, Joram Berger"
   maintainerEmail = "zz85@users.sourceforge.net"
   lastupdated = "2015-09-27"
 

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/header.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/header.ly
@@ -1,6 +1,6 @@
 \version "2.18.0"
 
- %{
+%{
 	 Let all glory be for God
 
 	 This typeset is for anyone, but especially for my friends,
@@ -43,98 +43,98 @@
 
 	 Joshua Koo
 
- %}
+%}
 
 #(set-global-staff-size 18)
 
- \header {
-	 title = "Brandenberg Concerto No.5 (Keyboard Concencerto)"
-	 subtitle = "3rd Movement"
-	 composer = "J.S. Bach"
-	 meter = "Allegro"
+\header {
+  title = "Brandenberg Concerto No.5 (Keyboard Concencerto)"
+  subtitle = "3rd Movement"
+  composer = "J.S. Bach"
+  meter = "Allegro"
 
-	%instrument = "Baroque Chamber"
-	%dedication = "Typesetted for my Friends"
-	%piece = ""
-	%head = ""
-	%footer = ""
-	%tagline = "joshuakoo@myrealbox.com. WIP for mutopia-project"
+  %instrument = "Baroque Chamber"
+  %dedication = "Typesetted for my Friends"
+  %piece = ""
+  %head = ""
+  %footer = ""
+  %tagline = "joshuakoo@myrealbox.com. WIP for mutopia-project"
 
-	 mutopiatitle = "Brandenburg Concerto No. 5 in D Major"
-	 mutopiacomposer = "BachJS"
-	 mutopiaopus = "BWV 1050"
-	 mutopiainstrument = "Ensemble: Flute, Two Violins, Violas, 'Cello, Bass and Harpsichord"
-	 date = "1719?"
-	 source = "Dover From the Bach-Gesellschaft Edition"
-	 style = "Baroque"
-	 copyright = "Public Domain"
-	 maintainer = "Joshua Koo"
-	 maintainerEmail = "zz85@users.sourceforge.net"
-	 lastupdated = "2005/March/31"
+  mutopiatitle = "Brandenburg Concerto No. 5 in D Major"
+  mutopiacomposer = "BachJS"
+  mutopiaopus = "BWV 1050"
+  mutopiainstrument = "Ensemble: Flute, Two Violins, Violas, 'Cello, Bass and Harpsichord"
+  date = "1719?"
+  source = "Dover From the Bach-Gesellschaft Edition"
+  style = "Baroque"
+  copyright = "Public Domain"
+  maintainer = "Joshua Koo"
+  maintainerEmail = "zz85@users.sourceforge.net"
+  lastupdated = "2005/March/31"
 
-         footer = "Mutopia-2005/04/11-548"
-         tagline = "\\raisebox{10mm}{\\parbox{188mm}{\\quad\\small\\noindent " + \footer + " \\hspace{\\stretch{1}} This music is part of the Mutopia project: \\hspace{\\stretch{1}} \\texttt{http://www.MutopiaProject.org/}\\\\ \\makebox[188mm][c]{It has been typeset and placed in the public domain by " + \maintainer + ".} \\makebox[188mm][c]{Unrestricted modification and redistribution is permitted and encouraged---copy this music and share it!}}}"
+  footer = "Mutopia-2005/04/11-548"
+  tagline = "\\raisebox{10mm}{\\parbox{188mm}{\\quad\\small\\noindent " + \footer + " \\hspace{\\stretch{1}} This music is part of the Mutopia project: \\hspace{\\stretch{1}} \\texttt{http://www.MutopiaProject.org/}\\\\ \\makebox[188mm][c]{It has been typeset and placed in the public domain by " + \maintainer + ".} \\makebox[188mm][c]{Unrestricted modification and redistribution is permitted and encouraged---copy this music and share it!}}}"
 }
 
- %some fuctions
- forteB = \markup {  \italic "(forte)" }
- pianoB = \markup {  \italic "(piano)" }
- forte = \markup {  \italic "forte" }
- piano = \markup {  \italic "piano" }
- pianoissimo = \markup {  \italic "pianoissimo" }
- pianoissimoB = \markup {  \italic "(pianoissimo)" }
- trillB = \markup {   "(" \musicglyph #"scripts.trill"  ")"}
- cantabile = \markup {  \italic "cantabile" }
- cantabileB = \markup {  \italic "(cantabile)" }
- forteI = \markup \italic {\dynamic "f" "orte" }
+%some fuctions
+forteB = \markup {  \italic "(forte)" }
+pianoB = \markup {  \italic "(piano)" }
+forte = \markup {  \italic "forte" }
+piano = \markup {  \italic "piano" }
+pianoissimo = \markup {  \italic "pianoissimo" }
+pianoissimoB = \markup {  \italic "(pianoissimo)" }
+trillB = \markup {   "(" \musicglyph #"scripts.trill"  ")"}
+cantabile = \markup {  \italic "cantabile" }
+cantabileB = \markup {  \italic "(cantabile)" }
+forteI = \markup \italic {\dynamic "f" "orte" }
 
-  % set Triplets to 3 notes each
- triplets = \tupletSpan 4
-  % hides the 3
- tripletsHide = \override TupletBracket.number-visibility % number-visibility is deprecated. Tune the TupletNumber instead
- = ##f
-  % shows the 3
- tripletsShow = \override TupletBracket.number-visibility % number-visibility is deprecated. Tune the TupletNumber instead
- = ##t
-  % shows the 3 once
- tripletsShowOnce = \once \override TupletBracket.number-visibility % number-visibility is deprecated. Tune the TupletNumber instead
- = ##t
-  % displays n condenses multi measure rests
- multirests = \set Score.skipBars = ##t
+% set Triplets to 3 notes each
+triplets = \tupletSpan 4
+% hides the 3
+tripletsHide = \override TupletBracket.number-visibility % number-visibility is deprecated. Tune the TupletNumber instead
+= ##f
+% shows the 3
+tripletsShow = \override TupletBracket.number-visibility % number-visibility is deprecated. Tune the TupletNumber instead
+= ##t
+% shows the 3 once
+tripletsShowOnce = \once \override TupletBracket.number-visibility % number-visibility is deprecated. Tune the TupletNumber instead
+= ##t
+% displays n condenses multi measure rests
+multirests = \set Score.skipBars = ##t
 
- %hide triplets bracket
- bracketsHide = \override TupletBracket.bracket-visibility = ##f
+%hide triplets bracket
+bracketsHide = \override TupletBracket.bracket-visibility = ##f
 
- commonSettings = {
-	  \triplets
-	 \multirests
-	 \bracketsHide
-	 \tupletUp
- }
+commonSettings = {
+  \triplets
+  \multirests
+  \bracketsHide
+  \tupletUp
+}
 
- %figured sharp
- fbis =  \markup{ \small \sharp }
- fbes =  \markup{ \small \flat }
- fbna =  \markup{ \small \natural }
+%figured sharp
+fbis =  \markup{ \small \sharp }
+fbes =  \markup{ \small \flat }
+fbna =  \markup{ \small \natural }
 
- %root 7th
- fbRootVII = \markup { }
- %root 5
- fbRootV = \markup { }
+%root 7th
+fbRootVII = \markup { }
+%root 5
+fbRootV = \markup { }
 
- %root 5 (853)
- fbVnIII = \markup { }
+%root 5 (853)
+fbVnIII = \markup { }
 
- % 1st inversion
- fbIinv = \markup { }
+% 1st inversion
+fbIinv = \markup { }
 
- fbIinvVII = \markup { }
+fbIinvVII = \markup { }
 
- % 8 5 4
- fbIV = \markup { }
- fbIVMv = \markup { }
+% 8 5 4
+fbIV = \markup { }
+fbIVMv = \markup { }
 
- %{
+%{
 	 More figure bass work needed
 	 They are disabled now
 	 slashed \ 6
@@ -159,4 +159,4 @@
  fbIV = \markup { \small "4" }
  fbIVMv = \markup { \small \column { " " "4"} }
 
- %}
+%}

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/header.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/header.ly
@@ -51,8 +51,6 @@
   title = "Brandenburg Concerto No. 5 in D Major"
   subtitle = "3rd Movement"
   composer = "Johann Sebastian Bach"
-  meter = "Allegro"
-
   %instrument = "Baroque Chamber"
   %dedication = "Typesetted for my Friends"
   %piece = ""

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/header.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/header.ly
@@ -48,32 +48,32 @@
 #(set-global-staff-size 18)
 
 \header {
- title = "Brandenberg Concerto No.5 (Keyboard Concencerto)"
- subtitle = "3rd Movement"
- composer = "J.S. Bach"
- meter = "Allegro"
+  title = "Brandenberg Concerto No.5 (Keyboard Concencerto)"
+  subtitle = "3rd Movement"
+  composer = "J.S. Bach"
+  meter = "Allegro"
 
- %instrument = "Baroque Chamber"
- %dedication = "Typesetted for my Friends"
- %piece = ""
- %head = ""
- %footer = ""
- %tagline = "joshuakoo@myrealbox.com. WIP for mutopia-project"
+  %instrument = "Baroque Chamber"
+  %dedication = "Typesetted for my Friends"
+  %piece = ""
+  %head = ""
+  %footer = ""
+  %tagline = "joshuakoo@myrealbox.com. WIP for mutopia-project"
 
- mutopiatitle = "Brandenburg Concerto No. 5 in D Major"
- mutopiacomposer = "BachJS"
- mutopiaopus = "BWV 1050"
- mutopiainstrument = "Ensemble: Flute, Two Violins, Violas, 'Cello, Bass and Harpsichord"
- date = "1719?"
- source = "Dover From the Bach-Gesellschaft Edition"
- style = "Baroque"
- copyright = "Public Domain"
- maintainer = "Joshua Koo"
- maintainerEmail = "zz85@users.sourceforge.net"
- lastupdated = "2005/March/31"
+  mutopiatitle = "Brandenburg Concerto No. 5 in D Major"
+  mutopiacomposer = "BachJS"
+  mutopiaopus = "BWV 1050"
+  mutopiainstrument = "Ensemble: Flute, Two Violins, Violas, 'Cello, Bass and Harpsichord"
+  date = "1719?"
+  source = "Dover From the Bach-Gesellschaft Edition"
+  style = "Baroque"
+  copyright = "Public Domain"
+  maintainer = "Joshua Koo"
+  maintainerEmail = "zz85@users.sourceforge.net"
+  lastupdated = "2005/March/31"
 
- footer = "Mutopia-2005/04/11-548"
- %tagline = "\\raisebox { 10mm} { \\parbox { 188mm} { \\quad\\small\\noindent " + \footer + " \\hspace { \\stretch { 1}} This music is part of the Mutopia project: \\hspace { \\stretch { 1}} \\texttt { http://www.MutopiaProject.org/}\\\\ \\makebox[188mm][c] { It has been typeset and placed in the public domain by " + \maintainer + ".} \\makebox[188mm][c] { Unrestricted modification and redistribution is permitted and encouraged---copy this music and share it!}}}"
+  footer = "Mutopia-2005/04/11-548"
+  %tagline = "\\raisebox { 10mm} { \\parbox { 188mm} { \\quad\\small\\noindent " + \footer + " \\hspace { \\stretch { 1}} This music is part of the Mutopia project: \\hspace { \\stretch { 1}} \\texttt { http://www.MutopiaProject.org/}\\\\ \\makebox[188mm][c] { It has been typeset and placed in the public domain by " + \maintainer + ".} \\makebox[188mm][c] { Unrestricted modification and redistribution is permitted and encouraged---copy this music and share it!}}}"
 }
 
 %some fuctions
@@ -100,7 +100,7 @@ tripletsShowOnce = \once \undo \hide TupletNumber % number-visibility is depreca
 multirests = \compressFullBarRests
 
 %hide triplets bracket
-bracketsHide = \override TupletBracket.bracket-visibility = ##f
+bracketsHide = \hide TupletBracket
 
 commonSettings = {
   \triplets

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/header.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/header.ly
@@ -101,3 +101,10 @@ staffDown = { \change Staff = harpsichordDown \oneVoice }
   \override FiguredBass.BassFigure.font-size = -2
   \hide FiguredBass.BassFigureContinuation
 }
+
+\paper {
+  left-margin = 1.5\cm
+  right-margin = 1.5\cm
+  top-margin = 0.8\cm
+  bottom-margin = 0.7\cm
+}

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/header.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/header.ly
@@ -51,12 +51,6 @@
   title = "Brandenburg Concerto No. 5 in D Major"
   subtitle = "3rd Movement"
   composer = "Johann Sebastian Bach"
-  %instrument = "Baroque Chamber"
-  %dedication = "Typesetted for my Friends"
-  %piece = ""
-  %head = ""
-  %footer = ""
-  %tagline = "joshuakoo@myrealbox.com. WIP for mutopia-project"
 
   mutopiatitle = "Brandenburg Concerto No. 5 in D Major"
   mutopiacomposer = "BachJS"
@@ -65,13 +59,35 @@
   date = "1719?"
   source = "Dover From the Bach-Gesellschaft Edition"
   style = "Baroque"
-  copyright = "Public Domain"
+  copyright = ##f
   maintainer = "Joshua Koo"
   maintainerEmail = "zz85@users.sourceforge.net"
-  lastupdated = "2005/March/31"
+  lastupdated = "2015-09-27"
 
   footer = "Mutopia-2005/04/11-548"
-  %tagline = "\\raisebox { 10mm} { \\parbox { 188mm} { \\quad\\small\\noindent " + \footer + " \\hspace { \\stretch { 1}} This music is part of the Mutopia project: \\hspace { \\stretch { 1}} \\texttt { http://www.MutopiaProject.org/}\\\\ \\makebox[188mm][c] { It has been typeset and placed in the public domain by " + \maintainer + ".} \\makebox[188mm][c] { Unrestricted modification and redistribution is permitted and encouraged---copy this music and share it!}}}"
+  thecopyright = "Creative Commons Attribution-ShareAlike 4.0"
+  tagline = \markup {
+    \override #'(baseline-skip . 2.2)
+    \center-column {
+      \abs-fontsize #8 \sans \bold
+      \with-url #"http://www.MutopiaProject.org" {
+        "Mutopia"
+        "Project"
+      }
+    }
+    \override #'(baseline-skip . 0)
+    \column {
+      \with-color #grey
+      \filled-box #'( 0 . 1) #'(-2.5 . 1.4) #0
+    }
+    \override #'(baseline-skip . 2.2)
+    \column {
+      \abs-fontsize #8 \sans
+      \concat{"Typeset using " \with-url #"http://www.lilypond.org" "LilyPond" " © 2014 by " \maintainer "." }
+      \abs-fontsize #8 \sans
+      \concat {"This work is licensed under a " \with-url #"http://creativecommons.org/licenses/by-sa/4.0" \thecopyright " license."}
+    }
+  }
 }
 
 %some fuctions

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/header.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/header.ly
@@ -1,3 +1,5 @@
+\version "2.18.0"
+
  %{
 	 Let all glory be for God
 
@@ -42,7 +44,7 @@
 	 Joshua Koo
 
  %}
-#(ly:set-point-and-click 'line-column)
+
 #(set-global-staff-size 18)
 
  \header {
@@ -81,24 +83,27 @@
  piano = \markup {  \italic "piano" }
  pianoissimo = \markup {  \italic "pianoissimo" }
  pianoissimoB = \markup {  \italic "(pianoissimo)" }
- trillB = \markup {   "(" \musicglyph #"scripts-trill"  ")"}
+ trillB = \markup {   "(" \musicglyph #"scripts.trill"  ")"}
  cantabile = \markup {  \italic "cantabile" }
  cantabileB = \markup {  \italic "(cantabile)" }
  forteI = \markup \italic {\dynamic "f" "orte" }
 
   % set Triplets to 3 notes each
- triplets = \set tupletSpannerDuration = #(ly:make-moment 1 4)
+ triplets = \tupletSpan 4
   % hides the 3
- tripletsHide = \override TupletBracket   #'number-visibility = ##f
+ tripletsHide = \override TupletBracket.number-visibility % number-visibility is deprecated. Tune the TupletNumber instead
+ = ##f
   % shows the 3
- tripletsShow = \override TupletBracket   #'number-visibility = ##t
+ tripletsShow = \override TupletBracket.number-visibility % number-visibility is deprecated. Tune the TupletNumber instead
+ = ##t
   % shows the 3 once
- tripletsShowOnce = \once \override TupletBracket   #'number-visibility = ##t
+ tripletsShowOnce = \once \override TupletBracket.number-visibility % number-visibility is deprecated. Tune the TupletNumber instead
+ = ##t
   % displays n condenses multi measure rests
  multirests = \set Score.skipBars = ##t
 
  %hide triplets bracket
- bracketsHide = \override TupletBracket  #'bracket-visibility = ##f
+ bracketsHide = \override TupletBracket.bracket-visibility = ##f
 
  commonSettings = {
 	  \triplets
@@ -138,20 +143,20 @@
 	 5 #
 
  %root 7th
- fbRootVII = \markup { \small \column < "7" "5"> }
+ fbRootVII = \markup { \small \column { "7" "5"} }
  %root 5
  fbRootV = \markup { \small "5" }
 
  %root 5 (853)
- fbVnIII = \markup { \small \column < "5" "3"> }
+ fbVnIII = \markup { \small \column { "5" "3"} }
 
  % 1st inversion
  fbIinv = \markup { \small "6" }
 
- fbIinvVII = \markup { \small \column < "6" "5"> }
+ fbIinvVII = \markup { \small \column { "6" "5"} }
 
  % 8 5 4
  fbIV = \markup { \small "4" }
- fbIVMv = \markup { \small \column < " " "4"> }
+ fbIVMv = \markup { \small \column { " " "4"} }
 
  %}

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/score.ly
@@ -12,49 +12,39 @@
 #(set-global-staff-size 13)
 
 \score {
-  \header {
-    instrument = "Ensemble"
-  }
-
   <<
     \new GrandStaff <<
       \new Staff \with {
-        instrumentName = \markup \smaller \column { "Flauto" "traverso." }
-        % shortInstrumentName = "Fl"
+        instrumentName = \markup \smaller \center-column { "Flauto" "traverso." }
         midiInstrument = "flute"
       } \flute
       \new Staff \with {
-        instrumentName = \markup \smaller \column { "Violino" "principate." }
-        % shortInstrumentName = "Vl.I"
+        instrumentName = \markup \smaller \center-column { "Violino" "principate." }
         midiInstrument = "violin"
       } \violinP
     >>
 
-    \new StaffGroup <<
+    \new GrandStaff <<
       \new Staff \with {
-        instrumentName = \markup \smaller \column { "Violino" "di ripieno." }
-        % shortInstrumentName = "Vl"
+        instrumentName = \markup \smaller \center-column { "Violino" "di ripieno." }
         midiInstrument = "violin"
       } \violin
       \new Staff \with {
-        instrumentName = \markup \smaller \column { "Viola" "di ripieno." }
-        % shortInstrumentName = "Va"
+        instrumentName = \markup \smaller \center-column { "Viola" "di ripieno." }
         midiInstrument = "viola"
       } \viola
       \new Staff \with {
-        instrumentName = \markup \smaller "Violoncello." 	%Cello
-        % shortInstrumentName = "Vn"
+        instrumentName = \markup \smaller "Violoncello." %Cello
         midiInstrument = "cello"
       } \cello
       \new Staff \with {
         instrumentName = \markup \smaller "Violone." %"Double Bass"
-        % shortInstrumentName = "B"
         midiInstrument = "contrabass"
       } \violone
     >>
-    \harpsichordTa
+    \harpsichordStaff
   >>
 
   \layout {}
-  \midi { \tempo 2 = 90 }
+  \midi { \tempo 4 = 120 }
 }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/score.ly
@@ -34,11 +34,11 @@
         midiInstrument = "viola"
       } \viola
       \new Staff \with {
-        instrumentName = \markup \smaller "Violoncello." %Cello
+        instrumentName = \markup \smaller "Violoncello."
         midiInstrument = "cello"
       } \cello
       \new Staff \with {
-        instrumentName = \markup \smaller "Violone." %"Double Bass"
+        instrumentName = \markup \smaller "Violone."
         midiInstrument = "contrabass"
       } \violone
     >>

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/score.ly
@@ -1,4 +1,4 @@
- \version "2.4.0"
+ \version "2.18.0"
 
 \include "header.ly"
 \include "flute.ly"
@@ -20,16 +20,16 @@
 <<
  \context GrandStaff = Solos <<
 	 \context Staff = Flute	<<
-		\set Staff.instrument = \markup \smaller "Flauto traverso." %flute solo
-		%\set Staff.instr = "Fl"
+		\set Staff.instrumentName = \markup \smaller "Flauto traverso." %flute solo
+		%\set Staff.shortInstrumentName = "Fl"
  		\flute
 		\set Staff.midiInstrument = "flute"
 		
 	>>
 
 	 \context Staff = ViolinPrinciple <<
-		\set Staff.instrument = \markup \smaller "Violino principate." %violin solo
-		%\set Staff.instr = "Vl.I"
+		\set Staff.instrumentName = \markup \smaller "Violino principate." %violin solo
+		%\set Staff.shortInstrumentName = "Vl.I"
                 \set Staff.midiInstrument = #"violin"
 		\violinP 
 	 >>
@@ -39,36 +39,36 @@
  \context GrandStaff = Strings <<
 	
  	\context Staff = ViolinMain <<
-		\set Staff.instrument = \markup \smaller { 
-			\column <
+		\set Staff.instrumentName = \markup \smaller { 
+			\column {
 				"Violino"
 				"di ripieno."
-			 > }
+			 } }
 		
-		%\set Staff.instr = "Vl"
+		%\set Staff.shortInstrumentName = "Vl"
 	 	\set Staff.midiInstrument = "violin"
 		\violin
 	>>
  	
 	\context Staff = ViolaRip <<
-		\set Staff.instrument = \markup \smaller { 
-			\column <
+		\set Staff.instrumentName = \markup \smaller { 
+			\column {
 				"Viola"
 				"di ripieno."
-			 > }
-		%\set Staff.instr = "Va"
+			 } }
+		%\set Staff.shortInstrumentName = "Va"
 	 	\set Staff.midiInstrument = "viola"
  		\viola 
 	>>
 	 \context Staff = Cellos <<
-	 	\set Staff.instrument = \markup \smaller "Violoncello." 	%Cello
-		%\set Staff.instr = "Vn"
+	 	\set Staff.instrumentName = \markup \smaller "Violoncello." 	%Cello
+		%\set Staff.shortInstrumentName = "Vn"
 		\set Staff.midiInstrument = "cello"
 		\cello  		
 	>>
 	 \context Staff = DoubleBass <<
-		\set Staff.instrument = \markup \smaller "Violone." %"Double Bass"
-		%\set Staff.instr = "B"
+		\set Staff.instrumentName = \markup \smaller "Violone." %"Double Bass"
+		%\set Staff.shortInstrumentName = "B"
 	 	\set Staff.midiInstrument = "contrabass"
 		\violone
 	>>
@@ -83,9 +83,12 @@
 	{
 	}
 
-	\midi { 
-	\tempo 2=90
-	}
+	
+  \midi {
+    \tempo 2 = 90
+    }
+
+
 
 
 }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/score.ly
@@ -11,6 +11,10 @@
 
 #(set-global-staff-size 13)
 
+\paper {
+  ragged-last-bottom = ##f
+}
+
 \score {
   <<
     \new GrandStaff <<

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/score.ly
@@ -15,60 +15,42 @@
   \header {
     instrument = "Ensemble"
   }
-  <<
-    \context GrandStaff = Solos <<
-      \context Staff = Flute <<
-        \set Staff.instrumentName = \markup \smaller "Flauto traverso." %flute solo
-        %\set Staff.shortInstrumentName = "Fl"
-        \flute
-        \set Staff.midiInstrument = "flute"
-      >>
 
-      \context Staff = ViolinPrinciple <<
-        \set Staff.instrumentName = \markup \smaller "Violino principate." %violin solo
-        %\set Staff.shortInstrumentName = "Vl.I"
-        \set Staff.midiInstrument = #"violin"
-        \violinP
-      >>
+  <<
+    \new GrandStaff <<
+      \new Staff \with {
+        instrumentName = \markup \smaller \column { "Flauto" "traverso." }
+        % shortInstrumentName = "Fl"
+        midiInstrument = "flute"
+      } \flute
+      \new Staff \with {
+        instrumentName = \markup \smaller \column { "Violino" "principate." }
+        % shortInstrumentName = "Vl.I"
+        midiInstrument = "violin"
+      } \violinP
     >>
 
-    \context GrandStaff = Strings <<
-
-      \context Staff = ViolinMain <<
-        \set Staff.instrumentName = \markup \smaller {
-          \column {
-            "Violino"
-            "di ripieno."
-          }
-        }
-        %\set Staff.shortInstrumentName = "Vl"
-        \set Staff.midiInstrument = "violin"
-        \violin
-      >>
-
-      \context Staff = ViolaRip <<
-        \set Staff.instrumentName = \markup \smaller {
-          \column {
-            "Viola"
-            "di ripieno."
-          }
-        }
-        %\set Staff.shortInstrumentName = "Va"
-        \set Staff.midiInstrument = "viola"
-        \viola
-      >>
-      \context Staff = Cellos <<
-        \set Staff.instrumentName = \markup \smaller "Violoncello." 	%Cello
-        %\set Staff.shortInstrumentName = "Vn"
-        \set Staff.midiInstrument = "cello"
-        \cello
-      >>
-      \context Staff = DoubleBass <<
-        \set Staff.instrumentName = \markup \smaller "Violone." %"Double Bass"
-        %\set Staff.shortInstrumentName = "B"
-        \set Staff.midiInstrument = "contrabass"
-        \violone
-      >>
+    \new StaffGroup <<
+      \new Staff \with {
+        instrumentName = \markup \smaller \column { "Violino" "di ripieno." }
+        % shortInstrumentName = "Vl"
+        midiInstrument = "violin"
+      } \violin
+      \new Staff \with {
+        instrumentName = \markup \smaller \column { "Viola" "di ripieno." }
+        % shortInstrumentName = "Va"
+        midiInstrument = "viola"
+      } \viola
+      \new Staff \with {
+        instrumentName = \markup \smaller "Violoncello." 	%Cello
+        % shortInstrumentName = "Vn"
+        midiInstrument = "cello"
+      } \cello
+      \new Staff \with {
+        instrumentName = \markup \smaller "Violone." %"Double Bass"
+        % shortInstrumentName = "B"
+        midiInstrument = "contrabass"
+      } \violone
     >>
     \harpsichordTa
   >>

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/score.ly
@@ -11,20 +11,17 @@
 
 #(set-global-staff-size 13)
 
-\score
-{
-  \header
-  {
+\score {
+  \header {
     instrument = "Ensemble"
   }
   <<
     \context GrandStaff = Solos <<
-      \context Staff = Flute	<<
+      \context Staff = Flute <<
         \set Staff.instrumentName = \markup \smaller "Flauto traverso." %flute solo
         %\set Staff.shortInstrumentName = "Fl"
         \flute
         \set Staff.midiInstrument = "flute"
-
       >>
 
       \context Staff = ViolinPrinciple <<
@@ -35,7 +32,6 @@
       >>
     >>
 
-
     \context GrandStaff = Strings <<
 
       \context Staff = ViolinMain <<
@@ -45,7 +41,6 @@
             "di ripieno."
           }
         }
-
         %\set Staff.shortInstrumentName = "Vl"
         \set Staff.midiInstrument = "violin"
         \violin
@@ -76,21 +71,8 @@
       >>
     >>
     \harpsichordTa
-
   >>
 
-
-
-  \layout
-  {
-  }
-
-
-  \midi {
-    \tempo 2 = 90
-  }
-
-
-
-
+  \layout {}
+  \midi { \tempo 2 = 90 }
 }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/score.ly
@@ -1,4 +1,4 @@
- \version "2.18.0"
+\version "2.18.0"
 
 \include "header.ly"
 \include "flute.ly"
@@ -11,82 +11,84 @@
 
 #(set-global-staff-size 13)
 
-\score 
+\score
 {
-	\header
-	{
-		instrument = "Ensemble"
-	}
-<<
- \context GrandStaff = Solos <<
-	 \context Staff = Flute	<<
-		\set Staff.instrumentName = \markup \smaller "Flauto traverso." %flute solo
-		%\set Staff.shortInstrumentName = "Fl"
- 		\flute
-		\set Staff.midiInstrument = "flute"
-		
-	>>
+  \header
+  {
+    instrument = "Ensemble"
+  }
+  <<
+    \context GrandStaff = Solos <<
+      \context Staff = Flute	<<
+        \set Staff.instrumentName = \markup \smaller "Flauto traverso." %flute solo
+        %\set Staff.shortInstrumentName = "Fl"
+        \flute
+        \set Staff.midiInstrument = "flute"
 
-	 \context Staff = ViolinPrinciple <<
-		\set Staff.instrumentName = \markup \smaller "Violino principate." %violin solo
-		%\set Staff.shortInstrumentName = "Vl.I"
-                \set Staff.midiInstrument = #"violin"
-		\violinP 
-	 >>
+      >>
+
+      \context Staff = ViolinPrinciple <<
+        \set Staff.instrumentName = \markup \smaller "Violino principate." %violin solo
+        %\set Staff.shortInstrumentName = "Vl.I"
+        \set Staff.midiInstrument = #"violin"
+        \violinP
+      >>
+    >>
+
+
+    \context GrandStaff = Strings <<
+
+      \context Staff = ViolinMain <<
+        \set Staff.instrumentName = \markup \smaller {
+          \column {
+            "Violino"
+            "di ripieno."
+          }
+        }
+
+        %\set Staff.shortInstrumentName = "Vl"
+        \set Staff.midiInstrument = "violin"
+        \violin
+      >>
+
+      \context Staff = ViolaRip <<
+        \set Staff.instrumentName = \markup \smaller {
+          \column {
+            "Viola"
+            "di ripieno."
+          }
+        }
+        %\set Staff.shortInstrumentName = "Va"
+        \set Staff.midiInstrument = "viola"
+        \viola
+      >>
+      \context Staff = Cellos <<
+        \set Staff.instrumentName = \markup \smaller "Violoncello." 	%Cello
+        %\set Staff.shortInstrumentName = "Vn"
+        \set Staff.midiInstrument = "cello"
+        \cello
+      >>
+      \context Staff = DoubleBass <<
+        \set Staff.instrumentName = \markup \smaller "Violone." %"Double Bass"
+        %\set Staff.shortInstrumentName = "B"
+        \set Staff.midiInstrument = "contrabass"
+        \violone
+      >>
+    >>
+    \harpsichordTa
+
   >>
 
-  
- \context GrandStaff = Strings <<
-	
- 	\context Staff = ViolinMain <<
-		\set Staff.instrumentName = \markup \smaller { 
-			\column {
-				"Violino"
-				"di ripieno."
-			 } }
-		
-		%\set Staff.shortInstrumentName = "Vl"
-	 	\set Staff.midiInstrument = "violin"
-		\violin
-	>>
- 	
-	\context Staff = ViolaRip <<
-		\set Staff.instrumentName = \markup \smaller { 
-			\column {
-				"Viola"
-				"di ripieno."
-			 } }
-		%\set Staff.shortInstrumentName = "Va"
-	 	\set Staff.midiInstrument = "viola"
- 		\viola 
-	>>
-	 \context Staff = Cellos <<
-	 	\set Staff.instrumentName = \markup \smaller "Violoncello." 	%Cello
-		%\set Staff.shortInstrumentName = "Vn"
-		\set Staff.midiInstrument = "cello"
-		\cello  		
-	>>
-	 \context Staff = DoubleBass <<
-		\set Staff.instrumentName = \markup \smaller "Violone." %"Double Bass"
-		%\set Staff.shortInstrumentName = "B"
-	 	\set Staff.midiInstrument = "contrabass"
-		\violone
-	>>
->>
-	\harpsichordTa
-
->>
 
 
+  \layout
+  {
+  }
 
-	\layout 
-	{
-	}
 
-	
   \midi {
     \tempo 2 = 90
-    }
+  }
 
 
 

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola-score.ly
@@ -4,16 +4,16 @@
 \include "viola.ly"
 
 
-\score 
+\score
 {
-	% 
-	\viola
-	\midi {}
- 	\layout 
-	{
-	}
-	\header
-	{
-	}
+  %
+  \viola
+  \midi {}
+  \layout
+  {
+  }
+  \header
+  {
+  }
 
-}	
+}

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola-score.ly
@@ -1,6 +1,9 @@
 \version "2.18.0"
-
 \include "viola.ly"
+
+\header {
+  instrument = "Viola di ripieno"
+}
 
 \score {
   \viola

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola-score.ly
@@ -1,4 +1,4 @@
-\version "2.4.0"
+\version "2.18.0"
 
 \include "header.ly"
 \include "viola.ly"

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola-score.ly
@@ -1,19 +1,9 @@
 \version "2.18.0"
 
-\include "header.ly"
 \include "viola.ly"
 
-
-\score
-{
-  %
+\score {
   \viola
   \midi {}
-  \layout
-  {
-  }
-  \header
-  {
-  }
-
+  \layout {}
 }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola.ly
@@ -2,233 +2,183 @@
 \include "header.ly"
 
 viola = \relative c'' {
-  \clef alto  
+  \clef alto
   \key d \major
   \time 2/4
 
-  % --Bar 1-- %
-  R2*28 |
+  \repeat unfold 2 {
+    % --Bar 1-- %
+    R2*28 |
 
-  % --Bar 29-- %
-  r8 r16 a16 d8. a16 |
-  \tuplet 3/2 { b8(a) g fis( g) a } |
-  d, r e r |
-  a, r e' r |
+    % --Bar 29-- %
+    r8 r16 a d8. a16 |
+    \tuplet 3/2 { b8( a) g fis( g) a } |
+    d,8 r e r |
+    a,8 r e' r |
 
-  % --Bar 33-- %
-  \tuplet 3/2 { cis(  d) e fis( g) a | }
-  \omit TupletNumber
-  d, r a' r |
-  fis r \tuplet 3/2 { a( g) a | }
-  \tuplet 3/2 { fis( e) d } a' r |
-  a r cis, r |
-  d r e r |
-  fis8. cis'16 a8. g16 |
-  fis8. g16 a8. a16 |
+    % --Bar 33-- %
+    \tuplet 3/2 { cis8( d) e fis( g) a | }
+    \omit TupletNumber
+    d,8 r a' r |
+    fis8 r \tuplet 3/2 { a( g) a | }
+    \tuplet 3/2 { fis8( e) d } a' r |
+    a8 r cis, r |
+    d8 r e r |
+    fis8. cis'16 a8. g16 |
+    fis8. g16 a8. a16 |
 
-  % --Bar 41-- %
-  a8 r g r |
-  fis r d r |
-  d r a' r |
-  fis r \tuplet 3/2 { e( cis a) | }
-  \tuplet 3/2 { fis'( d a) g'(e cis) }
-  fis r d r |
+    % --Bar 41-- %
+    a8 r g r |
+    fis8 r d r |
+    d8 r a' r |
+    fis8 r \tuplet 3/2 { e( cis a) | }
+    \tuplet 3/2 { fis'8( d a) g'( e cis) } |
+    fis8 r d r |
 
+    % --Bar 47-- %
+    fis8 r fis r |
+    e8 r fis8. e16 |
+    d8. g16 e8. a,16 |
+    a8 r d r |
+    d8 r fis r |
+    b,2 ~ |
+    b |
 
-  % --Bar 47-- %
-  fis r fis r |
-  e r fis8. e16 |
-  d8. g16 e8. a,16 |
-  a8 r d r |
-  d r fis r |
-  b,2 ~ |
-  b |
+    % --Bar 54-- %
+    a ~ |
+    a |
+    e' ~ |
+    e |
+    e8 r fis r |
+    fis8 r e r |
+    e8 r d r |
 
-  % --Bar 54-- %
-  a ~ |
-  a |
-  e' ~ |
-  e |
-  e8 r fis r |
-  fis r e r |
-  e r d r |
+    %61
+    d4 r |
+    r8 r16 a' fis8. e16 |
+    \tuplet 3/2 { d8( cis) b e( fis) g | }
+    fis8. \noBeam a16 d8. a16 |
+    \tuplet 3/2 { b8( a) g fis( g) a | }
+    d,8 r d r |
+    \tuplet 3/2 { d8( c) b a( b) cis } |
 
-  %61
-  d4 r |
-  r8 r16 a' fis8. d16 |
-  \tuplet 3/2 { d8( cis) b e( fis) g | }
-  fis8. \noBeam a16 d8. a16 |
-  \tuplet 3/2 { b8( a) g fis( g) a | }
-  d, r d r |
-  \tuplet 3/2 { d(c) b a(b) cis| }
+    % --Bar 68-- %
+    \tuplet 3/2 { b8( d) cis b( d) cis } |
+    b2 ~ |
+    \tuplet 3/2 { b8 \noBeam gis a b gis a | }
+    b4 ~ b8. gis'16 |
+    a8. e16 a8 r |
+    r8 r16 fis b8 r |
+    r8 r16 a cis8 r |
+    r4 d,8 r |
 
-  % --Bar 68-- %
-  \tuplet 3/2 { b(d)cis b(d)cis | }
-  b2 ~ |
-  \tuplet 3/2 { b8 \noBeam gis a b gis a| }
-  b4 ~ b8. gis'16 |
-  a8. e16 a8 r |
-  r8 r16 fis b8 r |
-  r r16 a cis8 r |
-  r4 d,8 r |
+    %76
+    d8 r a' r |
+    fis8. g16 e8. fis16 |
+  }
+  \alternative {
+    {
+      fis2 |
 
-  %76
-  d r a' r |
-  fis8. g16 e8. fis16 |
-  fis2 |
-  R2*6 |
+      R2*8 |
+      %87
+      r8 r16 b fis8. cis'16 |
+      \tuplet 3/2 { d8( cis) b ais( b) cis| }
+      a r r4 |
 
-  %85
-  R2 |
-  R2 |
-  r8 r16 b fis8. cis'16 |
-  \tuplet 3/2 { d8( cis) b ais( b) cis| }
-  a r r4 |
-  R2*3 |
+      %90
+      R2*7 |
 
-  %93
-  R2*4 |
-
-
-  % Bar 97
-
-  r8 r16 fis cis'8. gis16 |
-  \tuplet 3/2 { a8( gis) fis eis( fis) gis | }
-  cis,8 r fis,_\pianissimoB r |
-  \repeat unfold 6 { r4 fis8 r | }
-  R2 |
-  r4 fis'8_\forteB r |
-  cis8 r r4 |
-  r e8 r |
-  b8 r r4 |
-  R2*17 |
-  r4 r8 r16 fis' |
-  \tuplet 3/2 { fis8 e d } e4 ~ |
-  \tuplet 3/2 { e8 d cis } b r |
-  b r fis'4 ~ |
-  \tuplet 3/2 { fis8 b, e } e r |
-  e8 r b'4 ~ |
-  \tuplet 3/2 { b8 e, a } a r |
-  a8 r e4 ~ |
-  \tuplet 3/2 { e8 a, d } a' r |
-  e8 r b' r |
-  a8 r cis r |
-  fis,8 r d' r |
-  cis8 r e r |
-  a,8 r fis r |
-  b8 r a r |
-  d8 r gis, r |
-  \tuplet 3/2 { a8( gis) fis e( fis) gis | }
-  fis4 r8 b |
-  b8. gis16 a8. a,16 |
-  e'8 r e r |
-  e8. \noBeam e16_\cantabile a8. e16 |
-  \appoggiatura e( fis2) ~ |
-  fis8. fis16
-  \tuplet 3/2 { g!8( e) fis | } 
-  \appoggiatura fis16( e2) ~ |
-  e8. e16 a8. fis16 |
-  \appoggiatura e( d2) ~ |
-  \tuplet 3/2 { d8 e fis e( fis) d | }
-  cis8 r r4 |
-  R2 |
-  r8 r16 b'_\piano e8. b16 |
-  \tuplet 3/2 { c8( b) a g( a) b | }
-  e,8 r r4 |
-  R2 |
-  r8 r16 fis b8. fis16 |
-  \tuplet 3/2 { g8( fis) e d( e) fis | }
-  b,8 r r4 |
-  R2*13 |
-  r4 fis |
-  b4 r |
-  r4 e, |
-  a4 r |
-  r8 r16 a' d8. a16 |
-  \tuplet 3/2 { b8( a) g fis( g) a | }
-  d,4 r |
-  R2 |
-  r8 r16 e a8. e16 |
-  \tuplet 3/2 { fis8( e) d cis( d) e | }
-  a,4 r |
-  R2 |
-  r8 r16 e' a8. e16 |
-  cis2 ~ |
-  \tuplet 3/2 { cis8 \noBeam cis d e( cis) d | }
-  a8 r r4 |
-  R2*5 |
-  eis'8 r r4 |
-  cis8 r r4 |
-  b'8 r r4 |
-  a8 r r4 |
-  fis8 r r4 |
-  cis8 r r4 |
-  R2*17 |
-  r8 r16 b fis'8. cis16 |
-  \tuplet 3/2 { d8( cis) b ais( b) cis | }
-  a8. fis'16
-  \tuplet 3/2 { fis8( d) e | }
-  \tuplet 3/2 { fis8( e) d e( d) cis | }
-  b8 r r4 |
-  R2*4 |
-  r8 r16 g' fis8. e16 |
-  d8 r fis r |
-  d4 r |
-  R2*28 |
-  r8 r16 a' d8. a16 | 
-  \undo \omit TupletNumber
-  \tuplet 3/2 { b8( a) g fis( g) a | }
-  d,8 r e r |
-  a,8 r e' r |
-  \tuplet 3/2 { cis8( d) e fis( g) a | } 
-  \omit TupletNumber
-  d,8 r a' r |
-  fis8 r
-  \tuplet 3/2 { a( g) a | }
-  \tuplet 3/2 { fis8( e) d } a'8 r |
-  a8 r cis, r |
-  d8 r e r |
-
-  %Bar 271
-  fis8. cis'16 a8. g16 |
-  fis8. g16 a8. a16 |
-  a8 r g r |
-  fis8 r d r |
-  d8 r a' r |
-  fis8 r
-  \tuplet 3/2 { e( cis a) | }
-  \tuplet 3/2 { fis'8( d a) g'( e cis) | }
-  fis8 r d r |
-  fis8 r fis r |
-  e8 r fis8. e16 |
-  d8. g16 e8. a,16 |
-  a8 r d r |
-  d8 r fis r |
-  b,2 ~ |
-  b |
-  a ~ |
-  a |
-  e' ~ |
-  e |
-  e8 r fis r |
-  fis8 r e r |
-  e8 r d r |
-  d4 r |
-  r8 r16 a' fis8. e16 |
-  \tuplet 3/2 { d8( cis) b e( fis) g | }
-  fis8. \noBeam a16 d8. a16 |
-  \tuplet 3/2 { b8( a) g fis( g) a | }
-  d,8 r d r |
-  \tuplet 3/2 { d8( c) b a( b) cis | }
-  \tuplet 3/2 { b8( d) cis b( d) cis | }
-  b2 ~ |
-  \tuplet 3/2 { b8 \noBeam gis a b gis a | }
-  b4 ~ b8. gis'16 |
-  a8. e16 a8 r |
-  r8 r16 fis b8 r |
-  r8 r16 a cis8 r |
-  r4 d,8 r |
-  d8 r a' r |
-  fis8. g16 e8. fis16 |
-  fis2\fermata\bar "|."
+      % Bar 97
+      r8 r16 fis cis'8. gis16 |
+      \tuplet 3/2 { a8( gis) fis eis( fis) gis | }
+      cis,8 r fis,_\pianissimoB r |
+      \repeat unfold 6 { r4 fis8 r | }
+      R2 |
+      r4 fis'8_\forteB r |
+      cis8 r r4 |
+      r e8 r |
+      b8 r r4 |
+      
+      R2*17 |
+      r4 r8 r16 fis' |
+      \tuplet 3/2 { fis8 e d } e4 ~ |
+      \tuplet 3/2 { e8 d cis } b r |
+      b r fis'4 ~ |
+      \tuplet 3/2 { fis8 b, e } e r |
+      e8 r b'4 ~ |
+      \tuplet 3/2 { b8 e, a } a r |
+      a8 r e4 ~ |
+      \tuplet 3/2 { e8 a, d } a' r |
+      e8 r b' r |
+      a8 r cis r |
+      fis,8 r d' r |
+      cis8 r e r |
+      a,8 r fis r |
+      b8 r a r |
+      d8 r gis, r |
+      \tuplet 3/2 { a8( gis) fis e( fis) gis | }
+      fis4 r8 b |
+      b8. gis16 a8. a,16 |
+      e'8 r e r |
+      e8. \noBeam e16_\cantabile a8. e16 |
+      \appoggiatura e( fis2) ~ |
+      fis8. fis16
+      \tuplet 3/2 { g!8( e) fis | }
+      \appoggiatura fis16( e2) ~ |
+      e8. e16 a8. fis16 |
+      \appoggiatura e( d2) ~ |
+      \tuplet 3/2 { d8 e fis e( fis) d | }
+      cis8 r r4 |
+      R2 |
+      r8 r16 b'_\piano e8. b16 |
+      \tuplet 3/2 { c8( b) a g( a) b | }
+      e,8 r r4 |
+      R2 |
+      r8 r16 fis b8. fis16 |
+      \tuplet 3/2 { g8( fis) e d( e) fis | }
+      b,8 r r4 |
+      R2*13 |
+      r4 fis |
+      b4 r |
+      r4 e, |
+      a4 r |
+      r8 r16 a' d8. a16 |
+      \tuplet 3/2 { b8( a) g fis( g) a | }
+      d,4 r |
+      R2 |
+      r8 r16 e a8. e16 |
+      \tuplet 3/2 { fis8( e) d cis( d) e | }
+      a,4 r |
+      R2 |
+      r8 r16 e' a8. e16 |
+      cis2 ~ |
+      \tuplet 3/2 { cis8 \noBeam cis d e( cis) d | }
+      a8 r r4 |
+      
+      R2*5 |
+      eis'8 r r4 |
+      cis8 r r4 |
+      b'8 r r4 |
+      a8 r r4 |
+      fis8 r r4 |
+      cis8 r r4 |
+      
+      R2*17 |
+      r8 r16 b fis'8. cis16 |
+      \tuplet 3/2 { d8( cis) b ais( b) cis | }
+      a8. fis'16
+      \tuplet 3/2 { fis8( d) e | }
+      \tuplet 3/2 { fis8( e) d e( d) cis | }
+      b8 r r4 |
+      
+      R2*4 |
+      r8 r16 g' fis8. e16 |
+      d8 r fis r |
+      d4 r |
+    }
+    {
+      fis2\fermata \bar "|."
+    }
+  }
 }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola.ly
@@ -1,5 +1,5 @@
-\version "2.4.0"
-#(ly:set-point-and-click 'line-column)
+\version "2.18.0"
+
 
 viola =  \relative c'' {
  \clef alto \key d \major
@@ -13,15 +13,15 @@ viola =  \relative c'' {
 
 % --Bar 29-- %
   r8 r16 a16 d8. a16 |
-\times 2/3 { b8( a) g  fis( g) a } |
+\tuplet 3/2 { b8( a) g  fis( g) a } |
 d, r e r |
 a, r e' r |
 
 % --Bar 33-- %
-\times 2/3 { cis ( d) e fis( g) a } | \tripletsHide
+\tuplet 3/2 { cis ( d) e fis( g) a } | \tripletsHide
 d, r a' r |
-fis r \times 2/3 { a( g) a } |
-\times 2/3 { fis ( e) d } a' r |
+fis r \tuplet 3/2 { a( g) a } |
+\tuplet 3/2 { fis ( e) d } a' r |
 a r cis, r |
 d r e r |
 fis8. cis'16 a8. g16 |
@@ -31,8 +31,8 @@ fis8. g16 a8. a16 |
 a8 r g r |
 fis r d r |
 d r a' r |
-fis r \times 2/3 {e ( cis  a) } |
-\times 2/3{fis' ( d  a) g'(e cis) }
+fis r \tuplet 3/2 {e ( cis  a) } |
+\tuplet 3/2{fis' ( d  a) g'(e cis) }
 fis r d r |
 
 
@@ -57,16 +57,16 @@ e r d r |
 %61
 d4 r |
 r8 r16 a'  fis8. d16 |
-\times 2/3 { d8 (cis) b e( fis) g } |
+\tuplet 3/2 { d8 (cis) b e( fis) g } |
 fis8. \noBeam a16 d8. a16 |
-\times 2/3 { b8( a) g  fis( g) a } |
+\tuplet 3/2 { b8( a) g  fis( g) a } |
 d, r d r |
-\times 2/3 { d(c) b  a(b) cis} |
+\tuplet 3/2 { d(c) b  a(b) cis} |
 
 % --Bar 68-- %
-\times 2/3 { b(d)cis  b(d)cis } |
+\tuplet 3/2 { b(d)cis  b(d)cis } |
 b2 ~|
-\times 2/3 { b8 \noBeam gis a  b gis a} |
+\tuplet 3/2 { b8 \noBeam gis a  b gis a} |
 b4 ~ b8. gis'16 |
 a8. e16 a8 r |
 r8 r16 fis b8 r |
@@ -82,7 +82,7 @@ R2*6 |
 %85
 R2*2 |
 r8 r16 b fis8. cis'16 |
-\times 2/3 { d8(cis) b ais(b) cis} |
+\tuplet 3/2 { d8(cis) b ais(b) cis} |
 a r r4 |
 R2*3 |
 
@@ -93,7 +93,7 @@ R2*4 |
 % Bar 97
 
  r8 r16 fis cis'8. gis16 |
-  \times 2/3 { a8(  gis) fis eis(  fis) gis }  |
+  \tuplet 3/2 { a8(  gis) fis eis(  fis) gis }  |
  cis,8 r fis,_\pianoissimoB r |
  r4 fis8 r |
  r4 fis8 r |
@@ -124,14 +124,14 @@ R2*4 |
  R2 |
  R2 |
  r4 r8 r16 fis' |
-  \times 2/3 { fis8 e d }  e4~ |
-  \times 2/3 { e8 d cis }  b r |
+  \tuplet 3/2 { fis8 e d }  e4~ |
+  \tuplet 3/2 { e8 d cis }  b r |
  b r fis'4~ |
-  \times 2/3 { fis8 b, e }  e r |
+  \tuplet 3/2 { fis8 b, e }  e r |
  e8 r b'4~ |
-  \times 2/3 { b8 e, a }  a r |
+  \tuplet 3/2 { b8 e, a }  a r |
  a8 r e4~ |
-  \times 2/3 { e8 a, d }  a' r |
+  \tuplet 3/2 { e8 a, d }  a' r |
  e8 r b' r |
  a8 r cis r |
  fis,8 r d' r |
@@ -139,27 +139,27 @@ R2*4 |
  a,8 r fis r |
  b8 r a r |
  d8 r gis, r |
-  \times 2/3 { a8(  gis) fis e(  fis) gis }  |
+  \tuplet 3/2 { a8(  gis) fis e(  fis) gis }  |
  fis4 r8 b |
  b8. gis16 a8. a,16 |
  e'8 r e r |
  e8. \noBeam e16_\cantabile a8. e16 | 
  \appoggiatura e( fis2)~ |
  fis8. fis16 
-  \times 2/3 { g!8(  e) fis }  | \appoggiatura
+  \tuplet 3/2 { g!8(  e) fis }  | \appoggiatura
    fis16( 
   e2)~ |
  e8. e16 a8. fis16 |
  \appoggiatura e( d2)~ |
-  \times 2/3 { d8 e fis e(  fis) d }  |
+  \tuplet 3/2 { d8 e fis e(  fis) d }  |
  cis8 r r4 |
  R2 |
  r8 r16 b'_\piano e8. b16 |
-  \times 2/3 { c8( b) a g( a) b }  |
+  \tuplet 3/2 { c8( b) a g( a) b }  |
  e,8 r r4 |
  R2 |
  r8 r16 fis b8. fis16 |
-  \times 2/3 { g8(  fis) e d(  e) fis }  |
+  \tuplet 3/2 { g8(  fis) e d(  e) fis }  |
  b,8 r r4 |
  R2 |
  R2 |
@@ -179,16 +179,16 @@ R2*4 |
  r4 e, |
  a4 r |
  r8 r16 a' d8. a16 |
-  \times 2/3 { b8(  a) g fis(  g) a }  |
+  \tuplet 3/2 { b8(  a) g fis(  g) a }  |
  d,4 r |
  R2 |
  r8 r16 e a8. e16 |
-  \times 2/3 { fis8(  e) d cis(  d) e }  |
+  \tuplet 3/2 { fis8(  e) d cis(  d) e }  |
  a,4 r |
  R2 |
  r8 r16 e' a8. e16 |
  cis2~ |
-\times 2/3 { cis8 \noBeam cis d e(  cis) d }  |
+\tuplet 3/2 { cis8 \noBeam cis d e(  cis) d }  |
  a8 r r4 |
  R2 |
  R2 |
@@ -219,10 +219,10 @@ R2*4 |
  R2 |
  R2 |
  r8 r16 b fis'8. cis16 |
-  \times 2/3 { d8( cis) b ais( b) cis }  |
+  \tuplet 3/2 { d8( cis) b ais( b) cis }  |
  a8. fis'16 
-  \times 2/3 { fis8(  d) e }  |
-  \times 2/3 { fis8(  e) d e(  d) cis }  |
+  \tuplet 3/2 { fis8(  d) e }  |
+  \tuplet 3/2 { fis8(  e) d e(  d) cis }  |
  b8 r r4 |
  R2 |
  R2 |
@@ -260,14 +260,14 @@ R2*4 |
  R2 |
  R2 |
  r8 r16 a' d8. a16 | \tripletsShow
-  \times 2/3 { b8(  a) g fis(  g) a }  | 
+  \tuplet 3/2 { b8(  a) g fis(  g) a }  | 
  d,8 r e r |
  a,8 r e' r |
-  \times 2/3 { cis8(  d) e fis(  g) a }  | \tripletsHide
+  \tuplet 3/2 { cis8(  d) e fis(  g) a }  | \tripletsHide
  d,8 r a' r |
  fis8 r 
-  \times 2/3 { a(  g) a }  |
-  \times 2/3 { fis8(  e) d }  a'8 r|
+  \tuplet 3/2 { a(  g) a }  |
+  \tuplet 3/2 { fis8(  e) d }  a'8 r|
  a8 r cis, r |
  d8 r e r |
  
@@ -278,8 +278,8 @@ R2*4 |
  fis8 r d r |
  d8 r a' r |
  fis8 r 
-  \times 2/3 { e( cis  a) }  |
-  \times 2/3 { fis'8( d  a) g'( e  cis) }  |
+  \tuplet 3/2 { e( cis  a) }  |
+  \tuplet 3/2 { fis'8( d  a) g'( e  cis) }  |
  fis8 r d r |
  fis8 r fis r |
  e8 r fis8. e16 |
@@ -297,14 +297,14 @@ R2*4 |
  e8 r d r |
  d4 r |
  r8 r16 a' fis8. e16 |
-  \times 2/3 { d8(  cis) b e(  fis) g }  |
+  \tuplet 3/2 { d8(  cis) b e(  fis) g }  |
  fis8. \noBeam a16 d8. a16 |
-  \times 2/3 { b8(  a) g fis(  g) a }  |
+  \tuplet 3/2 { b8(  a) g fis(  g) a }  |
  d,8 r d r |
-  \times 2/3 { d8(  c) b a(  b) cis }  |
-  \times 2/3 { b8(  d) cis b(  d) cis }  |
+  \tuplet 3/2 { d8(  c) b a(  b) cis }  |
+  \tuplet 3/2 { b8(  d) cis b(  d) cis }  |
  b2~ |
-  \times 2/3 { b8 \noBeam gis a b gis a }  |
+  \tuplet 3/2 { b8 \noBeam gis a b gis a }  |
  b4 ~ b8. gis'16 |
  a8. e16 a8 r |
  r8 r16 fis b8 r |

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola.ly
@@ -2,315 +2,315 @@
 
 
 viola =  \relative c'' {
- \clef alto \key d \major
- \time 2/4
+  \clef alto \key d \major
+  \time 2/4
 
   \commonSettings
 
 
- % --Bar 1-- %
-    \repeat unfold 28 R2|
+  % --Bar 1-- %
+  \repeat unfold 28 R2|
 
-% --Bar 29-- %
+  % --Bar 29-- %
   r8 r16 a16 d8. a16 |
-\tuplet 3/2 { b8( a) g  fis( g) a } |
-d, r e r |
-a, r e' r |
+  \tuplet 3/2 { b8( a) g  fis( g) a } |
+  d, r e r |
+  a, r e' r |
 
-% --Bar 33-- %
-\tuplet 3/2 { cis ( d) e fis( g) a } | \tripletsHide
-d, r a' r |
-fis r \tuplet 3/2 { a( g) a } |
-\tuplet 3/2 { fis ( e) d } a' r |
-a r cis, r |
-d r e r |
-fis8. cis'16 a8. g16 |
-fis8. g16 a8. a16 |
+  % --Bar 33-- %
+  \tuplet 3/2 { cis ( d) e fis( g) a } | \tripletsHide
+  d, r a' r |
+  fis r \tuplet 3/2 { a( g) a } |
+  \tuplet 3/2 { fis ( e) d } a' r |
+  a r cis, r |
+  d r e r |
+  fis8. cis'16 a8. g16 |
+  fis8. g16 a8. a16 |
 
-% --Bar 41-- %
-a8 r g r |
-fis r d r |
-d r a' r |
-fis r \tuplet 3/2 {e ( cis  a) } |
-\tuplet 3/2{fis' ( d  a) g'(e cis) }
-fis r d r |
-
-
-% --Bar 47-- %
-fis r fis r |
-e r fis8. e16 |
-d8. g16 e8. a,16 |
-a8 r d r|
-d r fis r |
-b,2 ~ |
-b |
-
-% --Bar 54-- %
-a~ |
-a |
-e' ~ |
-e |
-e8 r fis r |
-fis r e r |
-e r d r |
-
-%61
-d4 r |
-r8 r16 a'  fis8. d16 |
-\tuplet 3/2 { d8 (cis) b e( fis) g } |
-fis8. \noBeam a16 d8. a16 |
-\tuplet 3/2 { b8( a) g  fis( g) a } |
-d, r d r |
-\tuplet 3/2 { d(c) b  a(b) cis} |
-
-% --Bar 68-- %
-\tuplet 3/2 { b(d)cis  b(d)cis } |
-b2 ~|
-\tuplet 3/2 { b8 \noBeam gis a  b gis a} |
-b4 ~ b8. gis'16 |
-a8. e16 a8 r |
-r8 r16 fis b8 r |
-r r16 a cis8 r |
-r4 d,8 r |
-
-%76
-d r a' r |
-fis8. g16 e8. fis16 |
-fis2|
-R2*6 |
-
-%85
-R2*2 |
-r8 r16 b fis8. cis'16 |
-\tuplet 3/2 { d8(cis) b ais(b) cis} |
-a r r4 |
-R2*3 |
-
-%93
-R2*4 |
+  % --Bar 41-- %
+  a8 r g r |
+  fis r d r |
+  d r a' r |
+  fis r \tuplet 3/2 {e ( cis  a) } |
+  \tuplet 3/2{fis' ( d  a) g'(e cis) }
+  fis r d r |
 
 
-% Bar 97
+  % --Bar 47-- %
+  fis r fis r |
+  e r fis8. e16 |
+  d8. g16 e8. a,16 |
+  a8 r d r|
+  d r fis r |
+  b,2 ~ |
+  b |
 
- r8 r16 fis cis'8. gis16 |
+  % --Bar 54-- %
+  a~ |
+  a |
+  e' ~ |
+  e |
+  e8 r fis r |
+  fis r e r |
+  e r d r |
+
+  %61
+  d4 r |
+  r8 r16 a'  fis8. d16 |
+  \tuplet 3/2 { d8 (cis) b e( fis) g } |
+  fis8. \noBeam a16 d8. a16 |
+  \tuplet 3/2 { b8( a) g  fis( g) a } |
+  d, r d r |
+  \tuplet 3/2 { d(c) b  a(b) cis} |
+
+  % --Bar 68-- %
+  \tuplet 3/2 { b(d)cis  b(d)cis } |
+  b2 ~|
+  \tuplet 3/2 { b8 \noBeam gis a  b gis a} |
+  b4 ~ b8. gis'16 |
+  a8. e16 a8 r |
+  r8 r16 fis b8 r |
+  r r16 a cis8 r |
+  r4 d,8 r |
+
+  %76
+  d r a' r |
+  fis8. g16 e8. fis16 |
+  fis2|
+  R2*6 |
+
+  %85
+  R2*2 |
+  r8 r16 b fis8. cis'16 |
+  \tuplet 3/2 { d8(cis) b ais(b) cis} |
+  a r r4 |
+  R2*3 |
+
+  %93
+  R2*4 |
+
+
+  % Bar 97
+
+  r8 r16 fis cis'8. gis16 |
   \tuplet 3/2 { a8(  gis) fis eis(  fis) gis }  |
- cis,8 r fis,_\pianoissimoB r |
- r4 fis8 r |
- r4 fis8 r |
- r4 fis8 r |
- r4 fis8 r |
- r4 fis8 r |
- r4 fis8 r |
- r2 |
- r4 fis'8_\forteB r |
- cis8 r r4 |
- r e8 r |
- b8 r r4 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- r4 r8 r16 fis' |
+  cis,8 r fis,_\pianoissimoB r |
+  r4 fis8 r |
+  r4 fis8 r |
+  r4 fis8 r |
+  r4 fis8 r |
+  r4 fis8 r |
+  r4 fis8 r |
+  r2 |
+  r4 fis'8_\forteB r |
+  cis8 r r4 |
+  r e8 r |
+  b8 r r4 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  r4 r8 r16 fis' |
   \tuplet 3/2 { fis8 e d }  e4~ |
   \tuplet 3/2 { e8 d cis }  b r |
- b r fis'4~ |
+  b r fis'4~ |
   \tuplet 3/2 { fis8 b, e }  e r |
- e8 r b'4~ |
+  e8 r b'4~ |
   \tuplet 3/2 { b8 e, a }  a r |
- a8 r e4~ |
+  a8 r e4~ |
   \tuplet 3/2 { e8 a, d }  a' r |
- e8 r b' r |
- a8 r cis r |
- fis,8 r d' r |
- cis8 r e r |
- a,8 r fis r |
- b8 r a r |
- d8 r gis, r |
+  e8 r b' r |
+  a8 r cis r |
+  fis,8 r d' r |
+  cis8 r e r |
+  a,8 r fis r |
+  b8 r a r |
+  d8 r gis, r |
   \tuplet 3/2 { a8(  gis) fis e(  fis) gis }  |
- fis4 r8 b |
- b8. gis16 a8. a,16 |
- e'8 r e r |
- e8. \noBeam e16_\cantabile a8. e16 | 
- \appoggiatura e( fis2)~ |
- fis8. fis16 
+  fis4 r8 b |
+  b8. gis16 a8. a,16 |
+  e'8 r e r |
+  e8. \noBeam e16_\cantabile a8. e16 |
+  \appoggiatura e( fis2)~ |
+  fis8. fis16
   \tuplet 3/2 { g!8(  e) fis }  | \appoggiatura
-   fis16( 
+  fis16(
   e2)~ |
- e8. e16 a8. fis16 |
- \appoggiatura e( d2)~ |
+  e8. e16 a8. fis16 |
+  \appoggiatura e( d2)~ |
   \tuplet 3/2 { d8 e fis e(  fis) d }  |
- cis8 r r4 |
- R2 |
- r8 r16 b'_\piano e8. b16 |
+  cis8 r r4 |
+  R2 |
+  r8 r16 b'_\piano e8. b16 |
   \tuplet 3/2 { c8( b) a g( a) b }  |
- e,8 r r4 |
- R2 |
- r8 r16 fis b8. fis16 |
+  e,8 r r4 |
+  R2 |
+  r8 r16 fis b8. fis16 |
   \tuplet 3/2 { g8(  fis) e d(  e) fis }  |
- b,8 r r4 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- r4 fis |
- b4 r |
- r4 e, |
- a4 r |
- r8 r16 a' d8. a16 |
+  b,8 r r4 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  r4 fis |
+  b4 r |
+  r4 e, |
+  a4 r |
+  r8 r16 a' d8. a16 |
   \tuplet 3/2 { b8(  a) g fis(  g) a }  |
- d,4 r |
- R2 |
- r8 r16 e a8. e16 |
+  d,4 r |
+  R2 |
+  r8 r16 e a8. e16 |
   \tuplet 3/2 { fis8(  e) d cis(  d) e }  |
- a,4 r |
- R2 |
- r8 r16 e' a8. e16 |
- cis2~ |
-\tuplet 3/2 { cis8 \noBeam cis d e(  cis) d }  |
- a8 r r4 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- eis'8 r r4 |
- cis8 r r4 |
- b'8 r r4 |
- a8 r r4 |
- fis8 r r4 |
- cis8 r r4 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- r8 r16 b fis'8. cis16 |
+  a,4 r |
+  R2 |
+  r8 r16 e' a8. e16 |
+  cis2~ |
+  \tuplet 3/2 { cis8 \noBeam cis d e(  cis) d }  |
+  a8 r r4 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  eis'8 r r4 |
+  cis8 r r4 |
+  b'8 r r4 |
+  a8 r r4 |
+  fis8 r r4 |
+  cis8 r r4 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  r8 r16 b fis'8. cis16 |
   \tuplet 3/2 { d8( cis) b ais( b) cis }  |
- a8. fis'16 
+  a8. fis'16
   \tuplet 3/2 { fis8(  d) e }  |
   \tuplet 3/2 { fis8(  e) d e(  d) cis }  |
- b8 r r4 |
- R2 |
- R2 |
- R2 |
- R2 |
- r8 r16 g' fis8. e16 |
- d8 r fis r |
- d4 r |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- r8 r16 a' d8. a16 | \tripletsShow
-  \tuplet 3/2 { b8(  a) g fis(  g) a }  | 
- d,8 r e r |
- a,8 r e' r |
+  b8 r r4 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  r8 r16 g' fis8. e16 |
+  d8 r fis r |
+  d4 r |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  r8 r16 a' d8. a16 | \tripletsShow
+  \tuplet 3/2 { b8(  a) g fis(  g) a }  |
+  d,8 r e r |
+  a,8 r e' r |
   \tuplet 3/2 { cis8(  d) e fis(  g) a }  | \tripletsHide
- d,8 r a' r |
- fis8 r 
+  d,8 r a' r |
+  fis8 r
   \tuplet 3/2 { a(  g) a }  |
   \tuplet 3/2 { fis8(  e) d }  a'8 r|
- a8 r cis, r |
- d8 r e r |
- 
- %Bar 271
- fis8. cis'16 a8. g16 |
- fis8. g16 a8. a16 |
- a8 r g r |
- fis8 r d r |
- d8 r a' r |
- fis8 r 
+  a8 r cis, r |
+  d8 r e r |
+
+  %Bar 271
+  fis8. cis'16 a8. g16 |
+  fis8. g16 a8. a16 |
+  a8 r g r |
+  fis8 r d r |
+  d8 r a' r |
+  fis8 r
   \tuplet 3/2 { e( cis  a) }  |
   \tuplet 3/2 { fis'8( d  a) g'( e  cis) }  |
- fis8 r d r |
- fis8 r fis r |
- e8 r fis8. e16 |
- d8. g16 e8. a,16 |
- a8 r d r |
- d8 r fis r |
- b,2~ |
- b |
- a~ |
- a |
- e'~ |
- e |
- e8 r fis r |
- fis8 r e r |
- e8 r d r |
- d4 r |
- r8 r16 a' fis8. e16 |
+  fis8 r d r |
+  fis8 r fis r |
+  e8 r fis8. e16 |
+  d8. g16 e8. a,16 |
+  a8 r d r |
+  d8 r fis r |
+  b,2~ |
+  b |
+  a~ |
+  a |
+  e'~ |
+  e |
+  e8 r fis r |
+  fis8 r e r |
+  e8 r d r |
+  d4 r |
+  r8 r16 a' fis8. e16 |
   \tuplet 3/2 { d8(  cis) b e(  fis) g }  |
- fis8. \noBeam a16 d8. a16 |
+  fis8. \noBeam a16 d8. a16 |
   \tuplet 3/2 { b8(  a) g fis(  g) a }  |
- d,8 r d r |
+  d,8 r d r |
   \tuplet 3/2 { d8(  c) b a(  b) cis }  |
   \tuplet 3/2 { b8(  d) cis b(  d) cis }  |
- b2~ |
+  b2~ |
   \tuplet 3/2 { b8 \noBeam gis a b gis a }  |
- b4 ~ b8. gis'16 |
- a8. e16 a8 r |
- r8 r16 fis b8 r |
- r8 r16 a cis8 r |
- r4 d,8 r |
- d8 r a' r |
- fis8. g16 e8. fis16 |
- fis2-\fermata  \bar "|." 
+  b4 ~ b8. gis'16 |
+  a8. e16 a8 r |
+  r8 r16 fis b8 r |
+  r8 r16 a cis8 r |
+  r4 d,8 r |
+  d8 r a' r |
+  fis8. g16 e8. fis16 |
+  fis2-\fermata  \bar "|."
 }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola.ly
@@ -1,7 +1,7 @@
 \version "2.18.0"
 
 
-viola =  \relative c'' {
+viola = \relative c'' {
   \clef alto \key d \major
   \time 2/4
 
@@ -9,11 +9,11 @@ viola =  \relative c'' {
 
 
   % --Bar 1-- %
-  \repeat unfold 28 R2|
+  \repeat unfold 28 R2 |
 
   % --Bar 29-- %
   r8 r16 a16 d8. a16 |
-  \tuplet 3/2 { b8( a) g  fis( g) a } |
+  \tuplet 3/2 { b8( a) g fis( g) a } |
   d, r e r |
   a, r e' r |
 
@@ -31,8 +31,8 @@ viola =  \relative c'' {
   a8 r g r |
   fis r d r |
   d r a' r |
-  fis r \tuplet 3/2 {e ( cis  a) } |
-  \tuplet 3/2{fis' ( d  a) g'(e cis) }
+  fis r \tuplet 3/2 { e ( cis a) } |
+  \tuplet 3/2 { fis' ( d a) g'(e cis) }
   fis r d r |
 
 
@@ -40,13 +40,13 @@ viola =  \relative c'' {
   fis r fis r |
   e r fis8. e16 |
   d8. g16 e8. a,16 |
-  a8 r d r|
+  a8 r d r |
   d r fis r |
   b,2 ~ |
   b |
 
   % --Bar 54-- %
-  a~ |
+  a ~ |
   a |
   e' ~ |
   e |
@@ -56,17 +56,17 @@ viola =  \relative c'' {
 
   %61
   d4 r |
-  r8 r16 a'  fis8. d16 |
+  r8 r16 a' fis8. d16 |
   \tuplet 3/2 { d8 (cis) b e( fis) g } |
   fis8. \noBeam a16 d8. a16 |
-  \tuplet 3/2 { b8( a) g  fis( g) a } |
+  \tuplet 3/2 { b8( a) g fis( g) a } |
   d, r d r |
-  \tuplet 3/2 { d(c) b  a(b) cis} |
+  \tuplet 3/2 { d(c) b a(b) cis} |
 
   % --Bar 68-- %
-  \tuplet 3/2 { b(d)cis  b(d)cis } |
-  b2 ~|
-  \tuplet 3/2 { b8 \noBeam gis a  b gis a} |
+  \tuplet 3/2 { b(d)cis b(d)cis } |
+  b2 ~ |
+  \tuplet 3/2 { b8 \noBeam gis a b gis a} |
   b4 ~ b8. gis'16 |
   a8. e16 a8 r |
   r8 r16 fis b8 r |
@@ -76,7 +76,7 @@ viola =  \relative c'' {
   %76
   d r a' r |
   fis8. g16 e8. fis16 |
-  fis2|
+  fis2 |
   R2*6 |
 
   %85
@@ -93,7 +93,7 @@ viola =  \relative c'' {
   % Bar 97
 
   r8 r16 fis cis'8. gis16 |
-  \tuplet 3/2 { a8(  gis) fis eis(  fis) gis }  |
+  \tuplet 3/2 { a8( gis) fis eis( fis) gis } |
   cis,8 r fis,_\pianoissimoB r |
   r4 fis8 r |
   r4 fis8 r |
@@ -124,14 +124,14 @@ viola =  \relative c'' {
   R2 |
   R2 |
   r4 r8 r16 fis' |
-  \tuplet 3/2 { fis8 e d }  e4~ |
-  \tuplet 3/2 { e8 d cis }  b r |
-  b r fis'4~ |
-  \tuplet 3/2 { fis8 b, e }  e r |
-  e8 r b'4~ |
-  \tuplet 3/2 { b8 e, a }  a r |
-  a8 r e4~ |
-  \tuplet 3/2 { e8 a, d }  a' r |
+  \tuplet 3/2 { fis8 e d } e4 ~ |
+  \tuplet 3/2 { e8 d cis } b r |
+  b r fis'4 ~ |
+  \tuplet 3/2 { fis8 b, e } e r |
+  e8 r b'4 ~ |
+  \tuplet 3/2 { b8 e, a } a r |
+  a8 r e4 ~ |
+  \tuplet 3/2 { e8 a, d } a' r |
   e8 r b' r |
   a8 r cis r |
   fis,8 r d' r |
@@ -139,27 +139,27 @@ viola =  \relative c'' {
   a,8 r fis r |
   b8 r a r |
   d8 r gis, r |
-  \tuplet 3/2 { a8(  gis) fis e(  fis) gis }  |
+  \tuplet 3/2 { a8( gis) fis e( fis) gis } |
   fis4 r8 b |
   b8. gis16 a8. a,16 |
   e'8 r e r |
   e8. \noBeam e16_\cantabile a8. e16 |
-  \appoggiatura e( fis2)~ |
+  \appoggiatura e( fis2) ~ |
   fis8. fis16
-  \tuplet 3/2 { g!8(  e) fis }  | \appoggiatura
+  \tuplet 3/2 { g!8( e) fis } | \appoggiatura
   fis16(
-  e2)~ |
+  e2) ~ |
   e8. e16 a8. fis16 |
-  \appoggiatura e( d2)~ |
-  \tuplet 3/2 { d8 e fis e(  fis) d }  |
+  \appoggiatura e( d2) ~ |
+  \tuplet 3/2 { d8 e fis e( fis) d } |
   cis8 r r4 |
   R2 |
   r8 r16 b'_\piano e8. b16 |
-  \tuplet 3/2 { c8( b) a g( a) b }  |
+  \tuplet 3/2 { c8( b) a g( a) b } |
   e,8 r r4 |
   R2 |
   r8 r16 fis b8. fis16 |
-  \tuplet 3/2 { g8(  fis) e d(  e) fis }  |
+  \tuplet 3/2 { g8( fis) e d( e) fis } |
   b,8 r r4 |
   R2 |
   R2 |
@@ -179,16 +179,16 @@ viola =  \relative c'' {
   r4 e, |
   a4 r |
   r8 r16 a' d8. a16 |
-  \tuplet 3/2 { b8(  a) g fis(  g) a }  |
+  \tuplet 3/2 { b8( a) g fis( g) a } |
   d,4 r |
   R2 |
   r8 r16 e a8. e16 |
-  \tuplet 3/2 { fis8(  e) d cis(  d) e }  |
+  \tuplet 3/2 { fis8( e) d cis( d) e } |
   a,4 r |
   R2 |
   r8 r16 e' a8. e16 |
-  cis2~ |
-  \tuplet 3/2 { cis8 \noBeam cis d e(  cis) d }  |
+  cis2 ~ |
+  \tuplet 3/2 { cis8 \noBeam cis d e( cis) d } |
   a8 r r4 |
   R2 |
   R2 |
@@ -219,10 +219,10 @@ viola =  \relative c'' {
   R2 |
   R2 |
   r8 r16 b fis'8. cis16 |
-  \tuplet 3/2 { d8( cis) b ais( b) cis }  |
+  \tuplet 3/2 { d8( cis) b ais( b) cis } |
   a8. fis'16
-  \tuplet 3/2 { fis8(  d) e }  |
-  \tuplet 3/2 { fis8(  e) d e(  d) cis }  |
+  \tuplet 3/2 { fis8( d) e } |
+  \tuplet 3/2 { fis8( e) d e( d) cis } |
   b8 r r4 |
   R2 |
   R2 |
@@ -260,14 +260,14 @@ viola =  \relative c'' {
   R2 |
   R2 |
   r8 r16 a' d8. a16 | \tripletsShow
-  \tuplet 3/2 { b8(  a) g fis(  g) a }  |
+  \tuplet 3/2 { b8( a) g fis( g) a } |
   d,8 r e r |
   a,8 r e' r |
-  \tuplet 3/2 { cis8(  d) e fis(  g) a }  | \tripletsHide
+  \tuplet 3/2 { cis8( d) e fis( g) a } | \tripletsHide
   d,8 r a' r |
   fis8 r
-  \tuplet 3/2 { a(  g) a }  |
-  \tuplet 3/2 { fis8(  e) d }  a'8 r|
+  \tuplet 3/2 { a( g) a } |
+  \tuplet 3/2 { fis8( e) d } a'8 r |
   a8 r cis, r |
   d8 r e r |
 
@@ -278,33 +278,33 @@ viola =  \relative c'' {
   fis8 r d r |
   d8 r a' r |
   fis8 r
-  \tuplet 3/2 { e( cis  a) }  |
-  \tuplet 3/2 { fis'8( d  a) g'( e  cis) }  |
+  \tuplet 3/2 { e( cis a) } |
+  \tuplet 3/2 { fis'8( d a) g'( e cis) } |
   fis8 r d r |
   fis8 r fis r |
   e8 r fis8. e16 |
   d8. g16 e8. a,16 |
   a8 r d r |
   d8 r fis r |
-  b,2~ |
+  b,2 ~ |
   b |
-  a~ |
+  a ~ |
   a |
-  e'~ |
+  e' ~ |
   e |
   e8 r fis r |
   fis8 r e r |
   e8 r d r |
   d4 r |
   r8 r16 a' fis8. e16 |
-  \tuplet 3/2 { d8(  cis) b e(  fis) g }  |
+  \tuplet 3/2 { d8( cis) b e( fis) g } |
   fis8. \noBeam a16 d8. a16 |
-  \tuplet 3/2 { b8(  a) g fis(  g) a }  |
+  \tuplet 3/2 { b8( a) g fis( g) a } |
   d,8 r d r |
-  \tuplet 3/2 { d8(  c) b a(  b) cis }  |
-  \tuplet 3/2 { b8(  d) cis b(  d) cis }  |
-  b2~ |
-  \tuplet 3/2 { b8 \noBeam gis a b gis a }  |
+  \tuplet 3/2 { d8( c) b a( b) cis } |
+  \tuplet 3/2 { b8( d) cis b( d) cis } |
+  b2 ~ |
+  \tuplet 3/2 { b8 \noBeam gis a b gis a } |
   b4 ~ b8. gis'16 |
   a8. e16 a8 r |
   r8 r16 fis b8 r |
@@ -312,5 +312,5 @@ viola =  \relative c'' {
   r4 d,8 r |
   d8 r a' r |
   fis8. g16 e8. fis16 |
-  fis2-\fermata  \bar "|."
+  fis2-\fermata \bar "|."
 }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola.ly
@@ -43,13 +43,13 @@ viola = \relative c'' {
     a8 r d r |
     d8 r fis r |
     b,2 ~ |
-    b |
+    b2 |
 
     % --Bar 54-- %
-    a ~ |
-    a |
-    e' ~ |
-    e |
+    a2 ~ |
+    a2 |
+    e'2 ~ |
+    e2 |
     e8 r fis r |
     fis8 r e r |
     e8 r d r |
@@ -85,7 +85,7 @@ viola = \relative c'' {
       %87
       r8 r16 b fis8. cis'16 |
       \tuplet 3/2 { d8( cis) b ais( b) cis| }
-      a r r4 |
+      a8 r r4 |
 
       %90
       R2*7 |
@@ -98,14 +98,14 @@ viola = \relative c'' {
       R2 |
       r4 fis'8_\forteB r |
       cis8 r r4 |
-      r e8 r |
+      r4 e8 r |
       b8 r r4 |
 
       R2*17 |
       r4 r8 r16 fis' |
       \tuplet 3/2 { fis8 e d } e4 ~ |
       \tuplet 3/2 { e8 d cis } b r |
-      b r fis'4 ~ |
+      b8 r fis'4 ~ |
       \tuplet 3/2 { fis8 b, e } e r |
       e8 r b'4 ~ |
       \tuplet 3/2 { b8 e, a } a r |
@@ -123,12 +123,12 @@ viola = \relative c'' {
       b8. gis16 a8. a,16 |
       e'8 r e r |
       e8. \noBeam e16_\cantabile a8. e16 |
-      \appoggiatura e( fis2) ~ |
+      \appoggiatura e16( fis2) ~ |
       fis8. fis16
       \tuplet 3/2 { g!8( e) fis | }
       \appoggiatura fis16( e2) ~ |
       e8. e16 a8. fis16 |
-      \appoggiatura e( d2) ~ |
+      \appoggiatura e16( d2) ~ |
       \tuplet 3/2 { d8 e fis e( fis) d | }
       cis8 r r4 |
       R2 |

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola.ly
@@ -18,10 +18,10 @@ viola = \relative c'' {
   a, r e' r |
 
   % --Bar 33-- %
-  \tuplet 3/2 { cis ( d) e fis( g) a } | \tripletsHide
+  \tuplet 3/2 { cis(  d) e fis( g) a } | \tripletsHide
   d, r a' r |
   fis r \tuplet 3/2 { a( g) a } |
-  \tuplet 3/2 { fis ( e) d } a' r |
+  \tuplet 3/2 { fis( e) d } a' r |
   a r cis, r |
   d r e r |
   fis8. cis'16 a8. g16 |
@@ -31,8 +31,8 @@ viola = \relative c'' {
   a8 r g r |
   fis r d r |
   d r a' r |
-  fis r \tuplet 3/2 { e ( cis a) } |
-  \tuplet 3/2 { fis' ( d a) g'(e cis) }
+  fis r \tuplet 3/2 { e( cis a) } |
+  \tuplet 3/2 { fis'( d a) g'(e cis) }
   fis r d r |
 
 
@@ -57,7 +57,7 @@ viola = \relative c'' {
   %61
   d4 r |
   r8 r16 a' fis8. d16 |
-  \tuplet 3/2 { d8 (cis) b e( fis) g } |
+  \tuplet 3/2 { d8( cis) b e( fis) g } |
   fis8. \noBeam a16 d8. a16 |
   \tuplet 3/2 { b8( a) g fis( g) a } |
   d, r d r |
@@ -82,7 +82,7 @@ viola = \relative c'' {
   %85
   R2*2 |
   r8 r16 b fis8. cis'16 |
-  \tuplet 3/2 { d8(cis) b ais(b) cis} |
+  \tuplet 3/2 { d8( cis) b ais( b) cis} |
   a r r4 |
   R2*3 |
 

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola.ly
@@ -1,26 +1,25 @@
 \version "2.18.0"
-
+\include "header.ly"
 
 viola = \relative c'' {
-  \clef alto \key d \major
+  \clef alto  
+  \key d \major
   \time 2/4
 
-  \commonSettings
-
-
   % --Bar 1-- %
-  \repeat unfold 28 R2 |
+  R2*28 |
 
   % --Bar 29-- %
   r8 r16 a16 d8. a16 |
-  \tuplet 3/2 { b8( a) g fis( g) a } |
+  \tuplet 3/2 { b8(a) g fis( g) a } |
   d, r e r |
   a, r e' r |
 
   % --Bar 33-- %
-  \tuplet 3/2 { cis(  d) e fis( g) a } | \tripletsHide
+  \tuplet 3/2 { cis(  d) e fis( g) a | }
+  \omit TupletNumber
   d, r a' r |
-  fis r \tuplet 3/2 { a( g) a } |
+  fis r \tuplet 3/2 { a( g) a | }
   \tuplet 3/2 { fis( e) d } a' r |
   a r cis, r |
   d r e r |
@@ -31,7 +30,7 @@ viola = \relative c'' {
   a8 r g r |
   fis r d r |
   d r a' r |
-  fis r \tuplet 3/2 { e( cis a) } |
+  fis r \tuplet 3/2 { e( cis a) | }
   \tuplet 3/2 { fis'( d a) g'(e cis) }
   fis r d r |
 
@@ -57,16 +56,16 @@ viola = \relative c'' {
   %61
   d4 r |
   r8 r16 a' fis8. d16 |
-  \tuplet 3/2 { d8( cis) b e( fis) g } |
+  \tuplet 3/2 { d8( cis) b e( fis) g | }
   fis8. \noBeam a16 d8. a16 |
-  \tuplet 3/2 { b8( a) g fis( g) a } |
+  \tuplet 3/2 { b8( a) g fis( g) a | }
   d, r d r |
-  \tuplet 3/2 { d(c) b a(b) cis} |
+  \tuplet 3/2 { d(c) b a(b) cis| }
 
   % --Bar 68-- %
-  \tuplet 3/2 { b(d)cis b(d)cis } |
+  \tuplet 3/2 { b(d)cis b(d)cis | }
   b2 ~ |
-  \tuplet 3/2 { b8 \noBeam gis a b gis a} |
+  \tuplet 3/2 { b8 \noBeam gis a b gis a| }
   b4 ~ b8. gis'16 |
   a8. e16 a8 r |
   r8 r16 fis b8 r |
@@ -80,9 +79,10 @@ viola = \relative c'' {
   R2*6 |
 
   %85
-  R2*2 |
+  R2 |
+  R2 |
   r8 r16 b fis8. cis'16 |
-  \tuplet 3/2 { d8( cis) b ais( b) cis} |
+  \tuplet 3/2 { d8( cis) b ais( b) cis| }
   a r r4 |
   R2*3 |
 
@@ -93,36 +93,15 @@ viola = \relative c'' {
   % Bar 97
 
   r8 r16 fis cis'8. gis16 |
-  \tuplet 3/2 { a8( gis) fis eis( fis) gis } |
-  cis,8 r fis,_\pianoissimoB r |
-  r4 fis8 r |
-  r4 fis8 r |
-  r4 fis8 r |
-  r4 fis8 r |
-  r4 fis8 r |
-  r4 fis8 r |
-  r2 |
+  \tuplet 3/2 { a8( gis) fis eis( fis) gis | }
+  cis,8 r fis,_\pianissimoB r |
+  \repeat unfold 6 { r4 fis8 r | }
+  R2 |
   r4 fis'8_\forteB r |
   cis8 r r4 |
   r e8 r |
   b8 r r4 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
+  R2*17 |
   r4 r8 r16 fis' |
   \tuplet 3/2 { fis8 e d } e4 ~ |
   \tuplet 3/2 { e8 d cis } b r |
@@ -139,134 +118,73 @@ viola = \relative c'' {
   a,8 r fis r |
   b8 r a r |
   d8 r gis, r |
-  \tuplet 3/2 { a8( gis) fis e( fis) gis } |
+  \tuplet 3/2 { a8( gis) fis e( fis) gis | }
   fis4 r8 b |
   b8. gis16 a8. a,16 |
   e'8 r e r |
   e8. \noBeam e16_\cantabile a8. e16 |
   \appoggiatura e( fis2) ~ |
   fis8. fis16
-  \tuplet 3/2 { g!8( e) fis } | \appoggiatura
-  fis16(
-  e2) ~ |
+  \tuplet 3/2 { g!8( e) fis | } 
+  \appoggiatura fis16( e2) ~ |
   e8. e16 a8. fis16 |
   \appoggiatura e( d2) ~ |
-  \tuplet 3/2 { d8 e fis e( fis) d } |
+  \tuplet 3/2 { d8 e fis e( fis) d | }
   cis8 r r4 |
   R2 |
   r8 r16 b'_\piano e8. b16 |
-  \tuplet 3/2 { c8( b) a g( a) b } |
+  \tuplet 3/2 { c8( b) a g( a) b | }
   e,8 r r4 |
   R2 |
   r8 r16 fis b8. fis16 |
-  \tuplet 3/2 { g8( fis) e d( e) fis } |
+  \tuplet 3/2 { g8( fis) e d( e) fis | }
   b,8 r r4 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
+  R2*13 |
   r4 fis |
   b4 r |
   r4 e, |
   a4 r |
   r8 r16 a' d8. a16 |
-  \tuplet 3/2 { b8( a) g fis( g) a } |
+  \tuplet 3/2 { b8( a) g fis( g) a | }
   d,4 r |
   R2 |
   r8 r16 e a8. e16 |
-  \tuplet 3/2 { fis8( e) d cis( d) e } |
+  \tuplet 3/2 { fis8( e) d cis( d) e | }
   a,4 r |
   R2 |
   r8 r16 e' a8. e16 |
   cis2 ~ |
-  \tuplet 3/2 { cis8 \noBeam cis d e( cis) d } |
+  \tuplet 3/2 { cis8 \noBeam cis d e( cis) d | }
   a8 r r4 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
+  R2*5 |
   eis'8 r r4 |
   cis8 r r4 |
   b'8 r r4 |
   a8 r r4 |
   fis8 r r4 |
   cis8 r r4 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
+  R2*17 |
   r8 r16 b fis'8. cis16 |
-  \tuplet 3/2 { d8( cis) b ais( b) cis } |
+  \tuplet 3/2 { d8( cis) b ais( b) cis | }
   a8. fis'16
-  \tuplet 3/2 { fis8( d) e } |
-  \tuplet 3/2 { fis8( e) d e( d) cis } |
+  \tuplet 3/2 { fis8( d) e | }
+  \tuplet 3/2 { fis8( e) d e( d) cis | }
   b8 r r4 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
+  R2*4 |
   r8 r16 g' fis8. e16 |
   d8 r fis r |
   d4 r |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  r8 r16 a' d8. a16 | \tripletsShow
-  \tuplet 3/2 { b8( a) g fis( g) a } |
+  R2*28 |
+  r8 r16 a' d8. a16 | 
+  \undo \omit TupletNumber
+  \tuplet 3/2 { b8( a) g fis( g) a | }
   d,8 r e r |
   a,8 r e' r |
-  \tuplet 3/2 { cis8( d) e fis( g) a } | \tripletsHide
+  \tuplet 3/2 { cis8( d) e fis( g) a | } 
+  \omit TupletNumber
   d,8 r a' r |
   fis8 r
-  \tuplet 3/2 { a( g) a } |
+  \tuplet 3/2 { a( g) a | }
   \tuplet 3/2 { fis8( e) d } a'8 r |
   a8 r cis, r |
   d8 r e r |
@@ -278,8 +196,8 @@ viola = \relative c'' {
   fis8 r d r |
   d8 r a' r |
   fis8 r
-  \tuplet 3/2 { e( cis a) } |
-  \tuplet 3/2 { fis'8( d a) g'( e cis) } |
+  \tuplet 3/2 { e( cis a) | }
+  \tuplet 3/2 { fis'8( d a) g'( e cis) | }
   fis8 r d r |
   fis8 r fis r |
   e8 r fis8. e16 |
@@ -297,14 +215,14 @@ viola = \relative c'' {
   e8 r d r |
   d4 r |
   r8 r16 a' fis8. e16 |
-  \tuplet 3/2 { d8( cis) b e( fis) g } |
+  \tuplet 3/2 { d8( cis) b e( fis) g | }
   fis8. \noBeam a16 d8. a16 |
-  \tuplet 3/2 { b8( a) g fis( g) a } |
+  \tuplet 3/2 { b8( a) g fis( g) a | }
   d,8 r d r |
-  \tuplet 3/2 { d8( c) b a( b) cis } |
-  \tuplet 3/2 { b8( d) cis b( d) cis } |
+  \tuplet 3/2 { d8( c) b a( b) cis | }
+  \tuplet 3/2 { b8( d) cis b( d) cis | }
   b2 ~ |
-  \tuplet 3/2 { b8 \noBeam gis a b gis a } |
+  \tuplet 3/2 { b8 \noBeam gis a b gis a | }
   b4 ~ b8. gis'16 |
   a8. e16 a8 r |
   r8 r16 fis b8 r |
@@ -312,5 +230,5 @@ viola = \relative c'' {
   r4 d,8 r |
   d8 r a' r |
   fis8. g16 e8. fis16 |
-  fis2-\fermata \bar "|."
+  fis2\fermata\bar "|."
 }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola.ly
@@ -99,7 +99,7 @@ viola = \relative c'' {
       cis8 r r4 |
       r e8 r |
       b8 r r4 |
-      
+
       R2*17 |
       r4 r8 r16 fis' |
       \tuplet 3/2 { fis8 e d } e4 ~ |
@@ -155,7 +155,7 @@ viola = \relative c'' {
       cis2 ~ |
       \tuplet 3/2 { cis8 \noBeam cis d e( cis) d | }
       a8 r r4 |
-      
+
       R2*5 |
       eis'8 r r4 |
       cis8 r r4 |
@@ -163,7 +163,7 @@ viola = \relative c'' {
       a8 r r4 |
       fis8 r r4 |
       cis8 r r4 |
-      
+
       R2*17 |
       r8 r16 b fis'8. cis16 |
       \tuplet 3/2 { d8( cis) b ais( b) cis | }
@@ -171,7 +171,7 @@ viola = \relative c'' {
       \tuplet 3/2 { fis8( d) e | }
       \tuplet 3/2 { fis8( e) d e( d) cis | }
       b8 r r4 |
-      
+
       R2*4 |
       r8 r16 g' fis8. e16 |
       d8 r fis r |

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/viola.ly
@@ -2,6 +2,7 @@
 \include "header.ly"
 
 viola = \relative c'' {
+  \tempo "Allegro."
   \clef alto
   \key d \major
   \time 2/4

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin-score.ly
@@ -1,23 +1,9 @@
 \version "2.18.0"
 
 \include "violin.ly"
-%{
-	\appoggiatura f8 e4
-            \acciaccatura g8 f4
 
-
-%}
-
-\score
-{
-  %
+\score {
   \violin
   \midi {}
-  \layout
-  {
-  }
-  \header
-  {
-  }
-
+  \layout {}
 }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin-score.ly
@@ -2,22 +2,22 @@
 
 \include "violin.ly"
 %{
-	\appoggiatura f8 e4 
-            \acciaccatura g8 f4 
+	\appoggiatura f8 e4
+            \acciaccatura g8 f4
 
 
 %}
 
-\score 
+\score
 {
-	% 
-	\violin
-	\midi {}
- 	\layout 
-	{
-	}
-	\header
-	{
-	}
+  %
+  \violin
+  \midi {}
+  \layout
+  {
+  }
+  \header
+  {
+  }
 
-}	
+}

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin-score.ly
@@ -1,4 +1,4 @@
-\version "2.4.0"
+\version "2.18.0"
 
 \include "violin.ly"
 %{

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin-score.ly
@@ -1,6 +1,9 @@
 \version "2.18.0"
-
 \include "violin.ly"
+
+\header {
+  instrument = "Violino di ripieno"
+}
 
 \score {
   \violin

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin.ly
@@ -6,246 +6,205 @@ violin = \relative c'' {
   \key d \major
   \time 2/4
 
-  % --Bar 1-- %
-  R2*30 |
-  r8 r16 d16 a'8. e16 |
-  \tuplet 3/2 { fis8( e) d cis( d) e } |
-  \omit TupletNumber
+  \repeat unfold 2 {
+    R2*30 |
+    r8 r16 d a'8. e16 |
+    \tuplet 3/2 { fis8( e) d cis( d) e } |
+    \omit TupletNumber
 
-  % --Bar 33-- %
-  \tuplet 3/2 { a,( b) cis d( e) fis } |
-  d r e r |
-  \tuplet 3/2 { b( d) fis fis( e) fis } |
-  \tuplet 3/2 { d( g) fis e( a) g } |
-  fis r e r |
-  e r d r |
-  \tuplet 3/2 { cis( d) e fis( g) a } |
-  d,4 ~ d8. a16 |
+    % --Bar 33-- %
+    \tuplet 3/2 { a,8( b) cis d( e) fis } |
+    b,8 r cis r |
+    \tuplet 3/2 { b8( d) fis fis( e) fis } |
+    \tuplet 3/2 { d8( g) fis e( a) g } |
+    fis8 r e r |
+    e8 r d r |
+    \tuplet 3/2 { cis8( d) e fis( g) a } |
+    d,4 ~ d8. cis16 |
 
-  % --Bar 41-- %
-  d8 r cis r |
-  d r a r |
-  g r fis r |
-  b r \tuplet 3/2 { cis,( e a) } |
-  \tuplet 3/2 { d,( fis a) a,( cis e) } |
-  d r d' r |
+    % --Bar 41-- %
+    d8 r cis r |
+    d8 r a r |
+    g8 r fis r |
+    b8 r \tuplet 3/2 { cis,( e a) } |
+    \tuplet 3/2 { d,8( fis a) a,( cis e) } |
+    d8 r d' r |
 
-  % --Bar 47-- %
-  cis r b r |
-  e r d8. cis16 |
-  b8. d,16 fis8. e16 |
-  d8 r a' r |
-  g r cis, r |
-  \tuplet 3/2 { fis( d) e fis( d) e } |
-  fis2 ~ |
+    % --Bar 47-- %
+    cis8 r b r |
+    e8 r d8. cis16 |
+    b8. d,16 fis8. e16 |
+    d8 r a' r |
+    g8 r cis, r |
+    \tuplet 3/2 { fis8( d) e fis( d) e } |
+    fis2 ~ |
 
-  % --Bar 54-- %
-  \tuplet 3/2 { fis8 \noBeam d e fis( d) e | }
-  fis8. a16 \tuplet 3/2 { d8(cis ) d }
-  b2 ~ |
-  b |
-  cis8 r cis r |
-  b r b r |
-  a r a r |
+    % --Bar 54-- %
+    \tuplet 3/2 { fis8 \noBeam d e fis( d) e } |
+    fis8. a16 \tuplet 3/2 { d8( cis) d } |
+    b2 ~ |
+    b |
+    cis8 r cis r |
+    b8 r b r |
+    a8 r a r |
 
-  % --Bar 61-- %
-  b4 r |
-  r8 r16 cis d8. cis16 |
-  b8. b16 a8. a16 |
-  a8 r r4 |
-  r8 r16 g d'8. a16 |
-  \tuplet 3/2 { b8( a) g fis( g) a } |
-  d, r a' r |
+    % --Bar 61-- %
+    b4 r |
+    r8 r16 cis d8. cis16 |
+    b8. b16 a8. a16 |
+    a8 r r4 |
+    r8 r16 g d'8. a16 |
+    \tuplet 3/2 { b8( a) g fis( g) a } |
+    d,8 r a' r |
 
-  % --Bar 68-- %
-  e2 ~ |
-  \tuplet 3/2 { e8 \noBeam gis a b( gis) a } |
-  b2 ~ |
-  \tuplet 3/2 { b8 \noBeam gis a } b8. b16 |
-  cis8 r r r16 fis |
-  d8 r r r16 g |
-  e8 r r r16 a |
-  fis8 r a r |
-  d, r cis r |
-  b8. b16 a8. a16 |
-  a2 |
-  R2*8 |
+    % --Bar 68-- %
+    e2 ~ |
+    \tuplet 3/2 { e8 \noBeam gis a b( gis) a } |
+    b2 ~ |
+    \tuplet 3/2 { b8 \noBeam gis a } b8. b16 |
+    cis8 r r r16 fis |
+    d8 r r r16 g |
+    e8 r r r16 a |
+    fis8 r a r |
+    d,8 r cis r |
+    b8. b16 a8. a16 |
+  }
+  \alternative {
+    {
+      a2 |
+      R2*8 |
 
-  % --Bar 87-- %
-  r8 r16 b fis'8. cis16 |
-  \tuplet 3/2 {
-    d8( cis) b ais( b) cis |
-    fis,(-\pianissimo^"Solo" b d) d( cis d) | %\italics
-    fis,( b d ) d( cis d ) |
-    g,!( ais b) cis( ais b) |
-    e,( ais cis) cis( b cis) |
+      % --Bar 87-- %
+      r8 r16 b fis'8. cis16 |
+      \tuplet 3/2 {
+        d8( cis) b ais( b) cis |
+        fis,(-\pianissimo^"Solo" b d) d( cis d) | %\italics
+        fis,( b d ) d( cis d ) |
+        g,!( ais b) cis( ais b) |
+        e,( ais cis) cis( b cis) |
+      }
+
+
+      % \tuplet 3/2 { } |
+
+      % --Bar 93 -- %
+      % Bar 93
+      \tuplet 3/2 { fis,8( b d) d( cis d) } |
+      \tuplet 3/2 { e,8( g cis) cis( ais) b } |
+      \tuplet 3/2 { cis8( ais) b fis( b) ais } |
+      b8 r r4 |
+      r8 r16 fis-\forte cis'8. gis16 |
+      \tuplet 3/2 { a8( gis) fis eis( fis) gis } |
+      \tuplet 3/2 { cis,8-\pianissimo^"Solo"( fis a) a( gis a) } |
+      \tuplet 3/2 { cis,8( fis a) a( gis) a } |
+      \tuplet 3/2 { d,!8( eis fis) gis( eis fis) } |
+      \tuplet 3/2 { b,8( eis gis) gis( fis gis) } |
+      \tuplet 3/2 { cis,8( fis a) a( gis a) } |
+      \tuplet 3/2 { b,8( d gis) gis( eis fis) } |
+      \tuplet 3/2 { gis8( eis fis) cis( fis ) eis } |
+      fis8 r r4 |
+      r a8-\forte r |
+      gis8 r r4 |
+      r gis8 r |
+      fis8 r r4 |
+      R2*3 |
+      r4 cis'8 r |
+      r4 d8 r |
+      r4 e8 r |
+      r4 fis8 r |
+      R2*10 |
+      r8 r16 cis fis8. cis16 |
+      \tuplet 3/2 { d8( cis) b ais( b) cis } |
+      \tuplet 3/2 { fis,8( b) d fis( e) fis } |
+      \tuplet 3/2 { b,8( a) g } a4 ~ |
+      \tuplet 3/2 { a8 g b } e8. b16 |
+      \tuplet 3/2 { cis8( b) a gis( a) b } |
+      \tuplet 3/2 { e,8( a) cis e( d) e } |
+      \tuplet 3/2 { a,8( gis) fis } gis4 ~ |
+      \tuplet 3/2 { gis8 fis a } d8. a16 |
+      \tuplet 3/2 { b8( gis) b } e8. b16 |
+      \tuplet 3/2 { cis8( a) cis } fis8. cis16 |
+      \tuplet 3/2 { d8( b) d } gis8. d16 |
+      \tuplet 3/2 { e8( cis) e } a8. e16 |
+      \tuplet 3/2 { fis8 d fis } b8. fis16 |
+      \tuplet 3/2 { gis8 fis e } a8. e16 |
+      \tuplet 3/2 { fis8( e) d cis( d) e } |
+      a,8 r cis r |
+      b r r dis |
+      e8. b16
+      \tuplet 3/2 { e8( cis) a } |
+      a8 r gis r |
+      a8. \noBeam e16_\cantabile a8. e16 | \appoggiatura
+      e
+
+      fis2 ~ |
+      fis8. fis16
+      \tuplet 3/2 { g!8( e) fis } |
+      \appoggiatura
+
+      fis16
+
+      e2 ~ |
+      e8. e16 a8. fis16 |
+      \appoggiatura
+
+      e
+
+      d2 ~ |
+      \tuplet 3/2 { d8 e fis e( fis) d } |
+      cis8 r r4 |
+      R2 |
+      r8 r16 b'_\piano e8. b16 |
+      \tuplet 3/2 { c8( b) a g( a) b } |
+      e,8 r r4 |
+      R2 |
+      r8 r16 fis b8. fis16 |
+      \tuplet 3/2 { g8( fis) e d( e) fis } |
+      b,8 r r4 |
+      R2*13
+      r8 r16 fis' a8. fis16 |
+      b,4 r |
+      r8 r16 e g8. e16 |
+      a,4 r |
+      r8 r16 a' d8. a16 |
+      \tuplet 3/2 { b8( a) g fis( g) a } |
+      d,4 r |
+      R2 |
+      r8 r16 e a8. e16 |
+      \tuplet 3/2 { fis8( e) d cis( d) e } |
+      a,4 r |
+      R2 |
+      r8 r16 e' a8. e16 |
+      cis2 ~ |
+      \tuplet 3/2 { cis8 \noBeam cis d e( cis) d } |
+      a8 r r4 |
+      R2*5
+      b'8 r r4 |
+      a8 r r4 |
+      eis'8 r r4 |
+      fis8 r r4 |
+      fis8 r r4 |
+      gis8 r r4 |
+      R2*16
+      r8 r16 cis, fis8. cis16 |
+      \tuplet 3/2 { d8( cis) b ais( b) cis } |
+      fis,4 ~ fis8. e16 |
+      d8. d'16
+      \tuplet 3/2 { cis8( d) b } |
+      ais8. b16
+      \tuplet 3/2 { cis8( d) e } |
+      fis8 r r4 |
+      R2*4
+      r8 r16 b, b8. b16 |
+      b8 r ais r |
+      fis4 r |
+    }
+    {
+      a2-\fermata \bar "|."
+    }
   }
 
 
-  % \tuplet 3/2 { } |
 
-  % --Bar 93 -- %
-  % Bar 93
-  \tuplet 3/2 { fis,8( b d) d( cis d) } |
-  \tuplet 3/2 { e,8( g cis) cis( ais) b } |
-  \tuplet 3/2 { cis8( ais) b fis( b) ais } |
-  b8 r r4 |
-  r8 r16 fis-\forte cis'8. gis16 |
-  \tuplet 3/2 { a8( gis) fis eis( fis) gis } |
-  \tuplet 3/2 { cis,8-\pianissimo^"Solo"( fis a) a( gis a) } |
-  \tuplet 3/2 { cis,8( fis a) a( gis) a } |
-  \tuplet 3/2 { d,!8( eis fis) gis( eis fis) } |
-  \tuplet 3/2 { b,8( eis gis) gis( fis gis) } |
-  \tuplet 3/2 { cis,8( fis a) a( gis a) } |
-  \tuplet 3/2 { b,8( d gis) gis( eis fis) } |
-  \tuplet 3/2 { gis8( eis fis) cis( fis ) eis } |
-  fis8 r r4 |
-  r a8-\forte r |
-  gis8 r r4 |
-  r gis8 r |
-  fis8 r r4 |
-  R2*3 |
-  r4 cis'8 r |
-  r4 d8 r |
-  r4 e8 r |
-  r4 fis8 r |
-  R2*10 |
-  r8 r16 cis fis8. cis16 |
-  \tuplet 3/2 { d8( cis) b ais( b) cis } |
-  \tuplet 3/2 { fis,8( b) d fis( e) fis } |
-  \tuplet 3/2 { b,8( a) g } a4 ~ |
-  \tuplet 3/2 { a8 g b } e8. b16 |
-  \tuplet 3/2 { cis8( b) a gis( a) b } |
-  \tuplet 3/2 { e,8( a) cis e( d) e } |
-  \tuplet 3/2 { a,8( gis) fis } gis4 ~ |
-  \tuplet 3/2 { gis8 fis a } d8. a16 |
-  \tuplet 3/2 { b8( gis) b } e8. b16 |
-  \tuplet 3/2 { cis8( a) cis } fis8. cis16 |
-  \tuplet 3/2 { d8( b) d } gis8. d16 |
-  \tuplet 3/2 { e8( cis) e } a8. e16 |
-  \tuplet 3/2 { fis8 d fis } b8. fis16 |
-  \tuplet 3/2 { gis8 fis e } a8. e16 |
-  \tuplet 3/2 { fis8( e) d cis( d) e } |
-  a,8 r cis r |
-  b r r dis |
-  e8. b16
-  \tuplet 3/2 { e8( cis) a } |
-  a8 r gis r |
-  a8. \noBeam e16_\cantabile a8. e16 | \appoggiatura
-  e
 
-  fis2 ~ |
-  fis8. fis16
-  \tuplet 3/2 { g!8( e) fis } |
-  \appoggiatura
-
-  fis16
-
-  e2 ~ |
-  e8. e16 a8. fis16 |
-  \appoggiatura
-
-  e
-
-  d2 ~ |
-  \tuplet 3/2 { d8 e fis e( fis) d } |
-  cis8 r r4 |
-  R2 |
-  r8 r16 b'_\piano e8. b16 |
-  \tuplet 3/2 { c8( b) a g( a) b } |
-  e,8 r r4 |
-  R2 |
-  r8 r16 fis b8. fis16 |
-  \tuplet 3/2 { g8( fis) e d( e) fis } |
-  b,8 r r4 |
-  R2*13
-  r8 r16 fis' a8. fis16 |
-  b,4 r |
-  r8 r16 e g8. e16 |
-  a,4 r |
-  r8 r16 a' d8. a16 |
-  \tuplet 3/2 { b8( a) g fis( g) a } |
-  d,4 r |
-  R2 |
-  r8 r16 e a8. e16 |
-  \tuplet 3/2 { fis8( e) d cis( d) e } |
-  a,4 r |
-  R2 |
-  r8 r16 e' a8. e16 |
-  cis2 ~ |
-  \tuplet 3/2 { cis8 \noBeam cis d e( cis) d } |
-  a8 r r4 |
-  R2*5
-  b'8 r r4 |
-  a8 r r4 |
-  eis'8 r r4 |
-  fis8 r r4 |
-  fis8 r r4 |
-  gis8 r r4 |
-  R2*16
-  r8 r16 cis, fis8. cis16 |
-  \tuplet 3/2 { d8( cis) b ais( b) cis } |
-  fis,4 ~ fis8. e16 |
-  d8. d'16
-  \tuplet 3/2 { cis8( d) b } |
-  ais8. b16
-  \tuplet 3/2 { cis8( d) e } |
-  fis8 r r4 |
-  R2*4
-  r8 r16 b, b8. b16 |
-  b8 r ais r |
-  fis4 r |
-  R2*30
-  r8 r16 d' a'8. d,16 |
-  \undo \omit TupletNumber
-  \tuplet 3/2 { fis8( e) d cis( d) e } |
-  \omit TupletNumber
-  \tuplet 3/2 { a,8( b) cis d( e) fis } |
-  b,8 r cis r |
-  \tuplet 3/2 { b8( d) fis fis( e) fis } |
-  \tuplet 3/2 { d8( g) fis e( a) g } |
-  fis8 r e r |
-  e8 r d r |
-  \tuplet 3/2 { cis8( d) e fis( g) a } |
-  d,4 ~ d8. cis16 |
-  d8 r cis r |
-  d8 r a r |
-  g8 r fis r |
-  b8 r
-  \tuplet 3/2 { cis,( e a) } |
-  \tuplet 3/2 { d,8( fis a) a,( cis e) } |
-  d8 r d' r |
-  cis8 r b r |
-  e8 r d8. cis16 |
-  d8. d,16 fis8. e16 |
-  d8 r a' r |
-  g8 r cis, r |
-  \tuplet 3/2 { fis8( d) e fis( d) e } |
-  fis2 ~ |
-  \tuplet 3/2 { fis8 \noBeam d e fis( d) e } |
-  fis8. a16
-  \tuplet 3/2 { d8( cis) d } |
-  b2 ~ |
-  b |
-  cis8 r cis r |
-  b8 r b r |
-  a8 r a r |
-  b4 r |
-  r8 r16 cis d8. cis16 |
-  b8. b16 a8. a16 |
-  a8 r r4 |
-  r8 r16 g d'8. a16 |
-  \tuplet 3/2 { b8( a) g fis( g) a } |
-  d,8 r a' r |
-  e2 ~ |
-  \tuplet 3/2 { e8 \noBeam gis a b( gis) a } |
-  b2 ~ |
-  \tuplet 3/2 { b8 \noBeam gis a } b8. b16 |
-  cis8 r r8 r16 fis |
-  d8 r r8 r16 g |
-  e8 r r8 r16 a |
-  fis8 r a r |
-  d,8 r cis r |
-  b8. b16 a8. a16 |
-  a2-\fermata \bar "|."
 }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin.ly
@@ -1,7 +1,7 @@
 \include "header.ly"
 
 
-\version "2.4.0"
+\version "2.18.0"
 
 
 violin =  \relative c'' {
@@ -50,25 +50,25 @@ R2 |
 R2 |
 R2 |
 r8 r16 d16 a'8. e16 |
-\times 2/3 { fis8( e) d  cis( d) e } |
+\tuplet 3/2 { fis8( e) d  cis( d) e } |
 \tripletsHide
 
 % --Bar 33-- %
-\times 2/3 { a,( b) cis  d( e) fis } |
+\tuplet 3/2 { a,( b) cis  d( e) fis } |
 d r e r |
-\times 2/3 { b( d) fis  fis( e) fis } |
-\times 2/3 { d( g) fis  e( a) g } |
+\tuplet 3/2 { b( d) fis  fis( e) fis } |
+\tuplet 3/2 { d( g) fis  e( a) g } |
 fis r e r |
 e r d r |
-\times 2/3 { cis( d) e  fis( g) a } |
+\tuplet 3/2 { cis( d) e  fis( g) a } |
 d,4 ~ d8. a16 |
 
 % --Bar 41-- %
 d8 r cis r |
 d r a r |
 g r fis r |
-b r \times 2/3 { cis, (e a) } |
-\times 2/3 { d, (fis  a)   a, (cis  e) } |
+b r \tuplet 3/2 { cis, (e a) } |
+\tuplet 3/2 { d, (fis  a)   a, (cis  e) } |
 d r d' r |
 
 % --Bar 47-- %
@@ -77,12 +77,12 @@ e r d8. cis16 |
 b8. d,16 fis8. e16 |
 d8 r a' r |
 g r cis, r |
-\times 2/3 { fis (d)  e   fis (d)  e } |
+\tuplet 3/2 { fis (d)  e   fis (d)  e } |
 fis2~ |
 
 % --Bar 54-- %
-\times 2/3 { fis8 \noBeam d e  fis( d) e | } 
-fis8.  a16 \times 2/3 {d8(cis) d } 
+\tuplet 3/2 { fis8 \noBeam d e  fis( d) e | } 
+fis8.  a16 \tuplet 3/2 {d8(cis) d } 
 b2 ~|
 b |
 cis8 r cis r |
@@ -95,14 +95,14 @@ r8 r16 cis d8. cis16 |
 b8. b16 a8. a16 |
 a8 r r4 |
 r8 r16 g d'8. a16 |
-\times 2/3 { b8 (a) g  fis( g) a } |
+\tuplet 3/2 { b8 (a) g  fis( g) a } |
 d, r a' r |
 
 % --Bar 68-- %
 e2 ~|
-\times 2/3 { e8 \noBeam gis a  b ( gis) a } |
+\tuplet 3/2 { e8 \noBeam gis a  b ( gis) a } |
 b2 ~ |
-\times 2/3 { b8 \noBeam gis a } b8. b16 |
+\tuplet 3/2 { b8 \noBeam gis a } b8. b16 |
 cis8 r r r16 fis |
 d8 r r r16 g |
 e8 r r r16 a |
@@ -115,7 +115,7 @@ R2*6 |
 % --Bar 85-- %
 R2*2 |
 r8 r16 b fis'8. cis16 |
-  \times 2/3 { d8 (cis) b ais( b) cis |
+  \tuplet 3/2 { d8 (cis) b ais( b) cis |
     fis,-\pianoissimo^"Solo" (b d ) d( cis d ) |%\italics
     fis, (b d ) d( cis d ) | 
     g,! (ais b)  cis( ais b) |
@@ -123,23 +123,23 @@ r8 r16 b fis'8. cis16 |
   } 
 
 
-% \times 2/3 {  } |
+% \tuplet 3/2 {  } |
 
 % --Bar 93 -- %
 % Bar 93
-  \times 2/3 { fis,8( b  d) d( cis  d) }  |
-  \times 2/3 { e,8( g  cis) cis(  ais) b }  |
-  \times 2/3 { cis8(  ais) b fis(  b) ais }  |
+  \tuplet 3/2 { fis,8( b  d) d( cis  d) }  |
+  \tuplet 3/2 { e,8( g  cis) cis(  ais) b }  |
+  \tuplet 3/2 { cis8(  ais) b fis(  b) ais }  |
  b8 r r4 |
  r8 r16 fis-\forte cis'8. gis16 |
-  \times 2/3 { a8(  gis) fis eis(  fis) gis }  |
-  \times 2/3 { cis,8-\pianoissimo^"Solo"( fis  a) a( gis  a) }  |
-  \times 2/3 { cis,8( fis  a) a(  gis) a }  |
-  \times 2/3 { d,!8( eis  fis) gis( eis  fis) }  |
-  \times 2/3 { b,8( eis  gis) gis( fis  gis) }  |
-  \times 2/3 { cis,8( fis  a) a( gis  a) }  |
-  \times 2/3 { b,8( d  gis) gis( eis  fis) }  |
-  \times 2/3 { gis8( eis  fis) cis( fis ) eis }  |
+  \tuplet 3/2 { a8(  gis) fis eis(  fis) gis }  |
+  \tuplet 3/2 { cis,8-\pianoissimo^"Solo"( fis  a) a( gis  a) }  |
+  \tuplet 3/2 { cis,8( fis  a) a(  gis) a }  |
+  \tuplet 3/2 { d,!8( eis  fis) gis( eis  fis) }  |
+  \tuplet 3/2 { b,8( eis  gis) gis( fis  gis) }  |
+  \tuplet 3/2 { cis,8( fis  a) a( gis  a) }  |
+  \tuplet 3/2 { b,8( d  gis) gis( eis  fis) }  |
+  \tuplet 3/2 { gis8( eis  fis) cis( fis ) eis }  |
  fis8 r r4 |
  r a8-\forte r |
  gis8 r r4 |
@@ -154,32 +154,32 @@ r8 r16 b fis'8. cis16 |
  r4 fis8 r |
  R2 *10 |
  r8 r16 cis fis8. cis16 |
-  \times 2/3 { d8(  cis) b ais( b) cis }  |
-  \times 2/3 { fis,8(  b) d fis(  e) fis }  |
-  \times 2/3 { b,8(  a) g }  a4~ |
-  \times 2/3 { a8 g b }  e8. b16 |
-  \times 2/3 { cis8(  b) a gis( a) b }  |
-  \times 2/3 { e,8(  a) cis e(  d) e }  |
-  \times 2/3 { a,8(  gis) fis }  gis4~ |
-  \times 2/3 { gis8 fis a }  d8. a16 |
-  \times 2/3 { b8(  gis) b }  e8. b16 |
-  \times 2/3 { cis8(  a) cis }  fis8. cis16 |
-  \times 2/3 { d8(  b) d }  gis8. d16 |
-  \times 2/3 { e8(  cis) e }  a8. e16 |
-  \times 2/3 { fis8 d fis }  b8. fis16 |
-  \times 2/3 { gis8 fis e }  a8. e16 |
-  \times 2/3 { fis8( e) d cis( d) e }  |
+  \tuplet 3/2 { d8(  cis) b ais( b) cis }  |
+  \tuplet 3/2 { fis,8(  b) d fis(  e) fis }  |
+  \tuplet 3/2 { b,8(  a) g }  a4~ |
+  \tuplet 3/2 { a8 g b }  e8. b16 |
+  \tuplet 3/2 { cis8(  b) a gis( a) b }  |
+  \tuplet 3/2 { e,8(  a) cis e(  d) e }  |
+  \tuplet 3/2 { a,8(  gis) fis }  gis4~ |
+  \tuplet 3/2 { gis8 fis a }  d8. a16 |
+  \tuplet 3/2 { b8(  gis) b }  e8. b16 |
+  \tuplet 3/2 { cis8(  a) cis }  fis8. cis16 |
+  \tuplet 3/2 { d8(  b) d }  gis8. d16 |
+  \tuplet 3/2 { e8(  cis) e }  a8. e16 |
+  \tuplet 3/2 { fis8 d fis }  b8. fis16 |
+  \tuplet 3/2 { gis8 fis e }  a8. e16 |
+  \tuplet 3/2 { fis8( e) d cis( d) e }  |
  a,8 r cis r |
  b r r dis |
  e8. b16
-  \times 2/3 { e8(  cis) a }  |
+  \tuplet 3/2 { e8(  cis) a }  |
  a8 r gis r |
  a8. \noBeam e16_\cantabile  a8. e16 |  \appoggiatura 
    e
   
   fis2~ |
  fis8. fis16
-  \times 2/3 { g!8(  e) fis }  |
+  \tuplet 3/2 { g!8(  e) fis }  |
  \appoggiatura
   
    fis16
@@ -191,15 +191,15 @@ r8 r16 b fis'8. cis16 |
    e
   
   d2~ |
-  \times 2/3 { d8 e fis e(  fis) d }  |
+  \tuplet 3/2 { d8 e fis e(  fis) d }  |
  cis8 r r4 |
  R2 |
  r8 r16 b'_\piano e8. b16 |
-  \times 2/3 { c8( b) a g( a) b }  |
+  \tuplet 3/2 { c8( b) a g( a) b }  |
  e,8 r r4 |
  R2 |
  r8 r16 fis b8. fis16 |
-  \times 2/3 { g8(  fis) e d(  e) fis }  |
+  \tuplet 3/2 { g8(  fis) e d(  e) fis }  |
  b,8 r r4 |
  R2 |
  R2 |
@@ -219,16 +219,16 @@ r8 r16 b fis'8. cis16 |
  r8 r16 e g8. e16 |
  a,4 r |
  r8 r16 a' d8. a16 |
-  \times 2/3 { b8(  a) g fis(  g) a }  |
+  \tuplet 3/2 { b8(  a) g fis(  g) a }  |
  d,4 r |
  R2 |
  r8 r16 e a8. e16 |
-  \times 2/3 { fis8(  e) d cis(  d) e }  |
+  \tuplet 3/2 { fis8(  e) d cis(  d) e }  |
  a,4 r |
  R2 |
  r8 r16 e' a8. e16 |
  cis2~ |
-  \times 2/3 { cis8 \noBeam cis d e(  cis) d }  |
+  \tuplet 3/2 { cis8 \noBeam cis d e(  cis) d }  |
  a8 r r4 |
  R2 |
  R2 |
@@ -258,12 +258,12 @@ r8 r16 b fis'8. cis16 |
  R2 |
  R2 |
  r8 r16 cis, fis8. cis16 |
-  \times 2/3 { d8(  cis) b ais( b) cis }  |
+  \tuplet 3/2 { d8(  cis) b ais( b) cis }  |
  fis,4~ fis8. e16 |
  d8. d'16
-  \times 2/3 { cis8(  d) b }  |
+  \tuplet 3/2 { cis8(  d) b }  |
  ais8. b16
-  \times 2/3 { cis8(  d) e }  |
+  \tuplet 3/2 { cis8(  d) e }  |
  fis8 r r4 |
  R2 |
  R2 |
@@ -303,32 +303,32 @@ r8 r16 b fis'8. cis16 |
  R2 |
  R2 |
  r8 r16 d' a'8. d,16 | \tripletsShow
-  \times 2/3 { fis8(  e) d cis(  d) e }  | \tripletsHide
-  \times 2/3 { a,8(  b) cis d(  e) fis }  |
+  \tuplet 3/2 { fis8(  e) d cis(  d) e }  | \tripletsHide
+  \tuplet 3/2 { a,8(  b) cis d(  e) fis }  |
  b,8 r cis r |
-  \times 2/3 { b8(  d) fis fis(  e) fis }  |
-  \times 2/3 { d8(  g) fis e(  a) g }  |
+  \tuplet 3/2 { b8(  d) fis fis(  e) fis }  |
+  \tuplet 3/2 { d8(  g) fis e(  a) g }  |
  fis8 r e r |
  e8 r d r |
-  \times 2/3 { cis8(  d) e fis(  g) a }  |
+  \tuplet 3/2 { cis8(  d) e fis(  g) a }  |
  d,4~ d8. cis16 |
  d8 r cis r |
  d8 r a r |
  g8 r fis r |
  b8 r
-  \times 2/3 { cis,( e  a) }  |
-  \times 2/3 { d,8( fis  a) a,( cis  e) }  |
+  \tuplet 3/2 { cis,( e  a) }  |
+  \tuplet 3/2 { d,8( fis  a) a,( cis  e) }  |
  d8 r d' r |
  cis8 r b r |
  e8 r d8. cis16 |
  d8. d,16 fis8. e16 |
  d8 r a' r |
  g8 r cis, r |
-  \times 2/3 { fis8(  d) e fis(  d) e }  |
+  \tuplet 3/2 { fis8(  d) e fis(  d) e }  |
  fis2~ |
-  \times 2/3 { fis8 \noBeam d e fis(  d) e }  |
+  \tuplet 3/2 { fis8 \noBeam d e fis(  d) e }  |
  fis8. a16
-  \times 2/3 { d8(  cis) d }  |
+  \tuplet 3/2 { d8(  cis) d }  |
  b2~ |
  b |
  cis8 r cis r |
@@ -339,12 +339,12 @@ r8 r16 b fis'8. cis16 |
  b8. b16 a8. a16 |
  a8 r r4 |
  r8 r16 g d'8. a16 |
-  \times 2/3 { b8(  a) g fis(  g) a }  |
+  \tuplet 3/2 { b8(  a) g fis(  g) a }  |
  d,8 r a' r |
  e2~ |
-  \times 2/3 { e8 \noBeam gis a b(  gis) a }  |
+  \tuplet 3/2 { e8 \noBeam gis a b(  gis) a }  |
  b2~ |
-  \times 2/3 { b8 \noBeam gis a }  b8. b16 |
+  \tuplet 3/2 { b8 \noBeam gis a }  b8. b16 |
  cis8 r r8 r16 fis |
  d8 r r8 r16 g |
  e8 r r8 r16 a |

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin.ly
@@ -6,49 +6,11 @@ violin = \relative c'' {
   \key d \major
   \time 2/4
 
-  \commonSettings
-
-
   % --Bar 1-- %
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-
-  % --Bar 9-- %
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-
-  % --Bar 17-- %
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-
-  % --Bar 26-- %
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
+  R2*30 |
   r8 r16 d16 a'8. e16 |
   \tuplet 3/2 { fis8( e) d cis( d) e } |
-  \tripletsHide
+  \omit TupletNumber
 
   % --Bar 33-- %
   \tuplet 3/2 { a,( b) cis d( e) fis } |
@@ -107,14 +69,13 @@ violin = \relative c'' {
   d, r cis r |
   b8. b16 a8. a16 |
   a2 |
-  R2*6 |
+  R2*8 |
 
-  % --Bar 85-- %
-  R2*2 |
+  % --Bar 87-- %
   r8 r16 b fis'8. cis16 |
   \tuplet 3/2 {
     d8( cis) b ais( b) cis |
-    fis,(-\pianoissimo^"Solo" b d) d( cis d) | %\italics
+    fis,(-\pianissimo^"Solo" b d) d( cis d) | %\italics
     fis,( b d ) d( cis d ) |
     g,!( ais b) cis( ais b) |
     e,( ais cis) cis( b cis) |
@@ -131,7 +92,7 @@ violin = \relative c'' {
   b8 r r4 |
   r8 r16 fis-\forte cis'8. gis16 |
   \tuplet 3/2 { a8( gis) fis eis( fis) gis } |
-  \tuplet 3/2 { cis,8-\pianoissimo^"Solo"( fis a) a( gis a) } |
+  \tuplet 3/2 { cis,8-\pianissimo^"Solo"( fis a) a( gis a) } |
   \tuplet 3/2 { cis,8( fis a) a( gis) a } |
   \tuplet 3/2 { d,!8( eis fis) gis( eis fis) } |
   \tuplet 3/2 { b,8( eis gis) gis( fis gis) } |
@@ -143,14 +104,12 @@ violin = \relative c'' {
   gis8 r r4 |
   r gis8 r |
   fis8 r r4 |
-  R2 |
-  R2 |
-  R2 |
+  R2*3 |
   r4 cis'8 r |
   r4 d8 r |
   r4 e8 r |
   r4 fis8 r |
-  R2 *10 |
+  R2*10 |
   r8 r16 cis fis8. cis16 |
   \tuplet 3/2 { d8( cis) b ais( b) cis } |
   \tuplet 3/2 { fis,8( b) d fis( e) fis } |
@@ -199,19 +158,7 @@ violin = \relative c'' {
   r8 r16 fis b8. fis16 |
   \tuplet 3/2 { g8( fis) e d( e) fis } |
   b,8 r r4 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
+  R2*13
   r8 r16 fis' a8. fis16 |
   b,4 r |
   r8 r16 e g8. e16 |
@@ -228,33 +175,14 @@ violin = \relative c'' {
   cis2 ~ |
   \tuplet 3/2 { cis8 \noBeam cis d e( cis) d } |
   a8 r r4 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
+  R2*5
   b'8 r r4 |
   a8 r r4 |
   eis'8 r r4 |
   fis8 r r4 |
   fis8 r r4 |
   gis8 r r4 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
+  R2*16
   r8 r16 cis, fis8. cis16 |
   \tuplet 3/2 { d8( cis) b ais( b) cis } |
   fis,4 ~ fis8. e16 |
@@ -263,45 +191,15 @@ violin = \relative c'' {
   ais8. b16
   \tuplet 3/2 { cis8( d) e } |
   fis8 r r4 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
+  R2*4
   r8 r16 b, b8. b16 |
   b8 r ais r |
   fis4 r |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  r8 r16 d' a'8. d,16 | \tripletsShow
-  \tuplet 3/2 { fis8( e) d cis( d) e } | \tripletsHide
+  R2*30
+  r8 r16 d' a'8. d,16 |
+  \undo \omit TupletNumber
+  \tuplet 3/2 { fis8( e) d cis( d) e } |
+  \omit TupletNumber
   \tuplet 3/2 { a,8( b) cis d( e) fis } |
   b,8 r cis r |
   \tuplet 3/2 { b8( d) fis fis( e) fis } |

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin.ly
@@ -4,7 +4,7 @@
 \version "2.18.0"
 
 
-violin =  \relative c'' {
+violin = \relative c'' {
   \clef violin
   \key d \major
   \time 2/4
@@ -50,17 +50,17 @@ violin =  \relative c'' {
   R2 |
   R2 |
   r8 r16 d16 a'8. e16 |
-  \tuplet 3/2 { fis8( e) d  cis( d) e } |
+  \tuplet 3/2 { fis8( e) d cis( d) e } |
   \tripletsHide
 
   % --Bar 33-- %
-  \tuplet 3/2 { a,( b) cis  d( e) fis } |
+  \tuplet 3/2 { a,( b) cis d( e) fis } |
   d r e r |
-  \tuplet 3/2 { b( d) fis  fis( e) fis } |
-  \tuplet 3/2 { d( g) fis  e( a) g } |
+  \tuplet 3/2 { b( d) fis fis( e) fis } |
+  \tuplet 3/2 { d( g) fis e( a) g } |
   fis r e r |
   e r d r |
-  \tuplet 3/2 { cis( d) e  fis( g) a } |
+  \tuplet 3/2 { cis( d) e fis( g) a } |
   d,4 ~ d8. a16 |
 
   % --Bar 41-- %
@@ -68,7 +68,7 @@ violin =  \relative c'' {
   d r a r |
   g r fis r |
   b r \tuplet 3/2 { cis, (e a) } |
-  \tuplet 3/2 { d, (fis  a)   a, (cis  e) } |
+  \tuplet 3/2 { d, (fis a) a, (cis e) } |
   d r d' r |
 
   % --Bar 47-- %
@@ -77,13 +77,13 @@ violin =  \relative c'' {
   b8. d,16 fis8. e16 |
   d8 r a' r |
   g r cis, r |
-  \tuplet 3/2 { fis (d)  e   fis (d)  e } |
-  fis2~ |
+  \tuplet 3/2 { fis (d) e fis (d) e } |
+  fis2 ~ |
 
   % --Bar 54-- %
-  \tuplet 3/2 { fis8 \noBeam d e  fis( d) e | }
-  fis8.  a16 \tuplet 3/2 {d8(cis) d }
-  b2 ~|
+  \tuplet 3/2 { fis8 \noBeam d e fis( d) e | }
+  fis8. a16 \tuplet 3/2 { d8(cis) d }
+  b2 ~ |
   b |
   cis8 r cis r |
   b r b r |
@@ -95,12 +95,12 @@ violin =  \relative c'' {
   b8. b16 a8. a16 |
   a8 r r4 |
   r8 r16 g d'8. a16 |
-  \tuplet 3/2 { b8 (a) g  fis( g) a } |
+  \tuplet 3/2 { b8 (a) g fis( g) a } |
   d, r a' r |
 
   % --Bar 68-- %
-  e2 ~|
-  \tuplet 3/2 { e8 \noBeam gis a  b ( gis) a } |
+  e2 ~ |
+  \tuplet 3/2 { e8 \noBeam gis a b ( gis) a } |
   b2 ~ |
   \tuplet 3/2 { b8 \noBeam gis a } b8. b16 |
   cis8 r r r16 fis |
@@ -117,30 +117,30 @@ violin =  \relative c'' {
   r8 r16 b fis'8. cis16 |
   \tuplet 3/2 {
     d8 (cis) b ais( b) cis |
-    fis,-\pianoissimo^"Solo" (b d ) d( cis d ) |%\italics
+    fis,-\pianoissimo^"Solo" (b d ) d( cis d ) | %\italics
     fis, (b d ) d( cis d ) |
-    g,! (ais b)  cis( ais b) |
+    g,! (ais b) cis( ais b) |
     e,( ais cis) cis( b cis) |
   }
 
 
-  % \tuplet 3/2 {  } |
+  % \tuplet 3/2 { } |
 
   % --Bar 93 -- %
   % Bar 93
-  \tuplet 3/2 { fis,8( b  d) d( cis  d) }  |
-  \tuplet 3/2 { e,8( g  cis) cis(  ais) b }  |
-  \tuplet 3/2 { cis8(  ais) b fis(  b) ais }  |
+  \tuplet 3/2 { fis,8( b d) d( cis d) } |
+  \tuplet 3/2 { e,8( g cis) cis( ais) b } |
+  \tuplet 3/2 { cis8( ais) b fis( b) ais } |
   b8 r r4 |
   r8 r16 fis-\forte cis'8. gis16 |
-  \tuplet 3/2 { a8(  gis) fis eis(  fis) gis }  |
-  \tuplet 3/2 { cis,8-\pianoissimo^"Solo"( fis  a) a( gis  a) }  |
-  \tuplet 3/2 { cis,8( fis  a) a(  gis) a }  |
-  \tuplet 3/2 { d,!8( eis  fis) gis( eis  fis) }  |
-  \tuplet 3/2 { b,8( eis  gis) gis( fis  gis) }  |
-  \tuplet 3/2 { cis,8( fis  a) a( gis  a) }  |
-  \tuplet 3/2 { b,8( d  gis) gis( eis  fis) }  |
-  \tuplet 3/2 { gis8( eis  fis) cis( fis ) eis }  |
+  \tuplet 3/2 { a8( gis) fis eis( fis) gis } |
+  \tuplet 3/2 { cis,8-\pianoissimo^"Solo"( fis a) a( gis a) } |
+  \tuplet 3/2 { cis,8( fis a) a( gis) a } |
+  \tuplet 3/2 { d,!8( eis fis) gis( eis fis) } |
+  \tuplet 3/2 { b,8( eis gis) gis( fis gis) } |
+  \tuplet 3/2 { cis,8( fis a) a( gis a) } |
+  \tuplet 3/2 { b,8( d gis) gis( eis fis) } |
+  \tuplet 3/2 { gis8( eis fis) cis( fis ) eis } |
   fis8 r r4 |
   r a8-\forte r |
   gis8 r r4 |
@@ -155,52 +155,52 @@ violin =  \relative c'' {
   r4 fis8 r |
   R2 *10 |
   r8 r16 cis fis8. cis16 |
-  \tuplet 3/2 { d8(  cis) b ais( b) cis }  |
-  \tuplet 3/2 { fis,8(  b) d fis(  e) fis }  |
-  \tuplet 3/2 { b,8(  a) g }  a4~ |
-  \tuplet 3/2 { a8 g b }  e8. b16 |
-  \tuplet 3/2 { cis8(  b) a gis( a) b }  |
-  \tuplet 3/2 { e,8(  a) cis e(  d) e }  |
-  \tuplet 3/2 { a,8(  gis) fis }  gis4~ |
-  \tuplet 3/2 { gis8 fis a }  d8. a16 |
-  \tuplet 3/2 { b8(  gis) b }  e8. b16 |
-  \tuplet 3/2 { cis8(  a) cis }  fis8. cis16 |
-  \tuplet 3/2 { d8(  b) d }  gis8. d16 |
-  \tuplet 3/2 { e8(  cis) e }  a8. e16 |
-  \tuplet 3/2 { fis8 d fis }  b8. fis16 |
-  \tuplet 3/2 { gis8 fis e }  a8. e16 |
-  \tuplet 3/2 { fis8( e) d cis( d) e }  |
+  \tuplet 3/2 { d8( cis) b ais( b) cis } |
+  \tuplet 3/2 { fis,8( b) d fis( e) fis } |
+  \tuplet 3/2 { b,8( a) g } a4 ~ |
+  \tuplet 3/2 { a8 g b } e8. b16 |
+  \tuplet 3/2 { cis8( b) a gis( a) b } |
+  \tuplet 3/2 { e,8( a) cis e( d) e } |
+  \tuplet 3/2 { a,8( gis) fis } gis4 ~ |
+  \tuplet 3/2 { gis8 fis a } d8. a16 |
+  \tuplet 3/2 { b8( gis) b } e8. b16 |
+  \tuplet 3/2 { cis8( a) cis } fis8. cis16 |
+  \tuplet 3/2 { d8( b) d } gis8. d16 |
+  \tuplet 3/2 { e8( cis) e } a8. e16 |
+  \tuplet 3/2 { fis8 d fis } b8. fis16 |
+  \tuplet 3/2 { gis8 fis e } a8. e16 |
+  \tuplet 3/2 { fis8( e) d cis( d) e } |
   a,8 r cis r |
   b r r dis |
   e8. b16
-  \tuplet 3/2 { e8(  cis) a }  |
+  \tuplet 3/2 { e8( cis) a } |
   a8 r gis r |
-  a8. \noBeam e16_\cantabile  a8. e16 |  \appoggiatura
+  a8. \noBeam e16_\cantabile a8. e16 | \appoggiatura
   e
 
-  fis2~ |
+  fis2 ~ |
   fis8. fis16
-  \tuplet 3/2 { g!8(  e) fis }  |
+  \tuplet 3/2 { g!8( e) fis } |
   \appoggiatura
 
   fis16
 
-  e2~ |
+  e2 ~ |
   e8. e16 a8. fis16 |
   \appoggiatura
 
   e
 
-  d2~ |
-  \tuplet 3/2 { d8 e fis e(  fis) d }  |
+  d2 ~ |
+  \tuplet 3/2 { d8 e fis e( fis) d } |
   cis8 r r4 |
   R2 |
   r8 r16 b'_\piano e8. b16 |
-  \tuplet 3/2 { c8( b) a g( a) b }  |
+  \tuplet 3/2 { c8( b) a g( a) b } |
   e,8 r r4 |
   R2 |
   r8 r16 fis b8. fis16 |
-  \tuplet 3/2 { g8(  fis) e d(  e) fis }  |
+  \tuplet 3/2 { g8( fis) e d( e) fis } |
   b,8 r r4 |
   R2 |
   R2 |
@@ -220,16 +220,16 @@ violin =  \relative c'' {
   r8 r16 e g8. e16 |
   a,4 r |
   r8 r16 a' d8. a16 |
-  \tuplet 3/2 { b8(  a) g fis(  g) a }  |
+  \tuplet 3/2 { b8( a) g fis( g) a } |
   d,4 r |
   R2 |
   r8 r16 e a8. e16 |
-  \tuplet 3/2 { fis8(  e) d cis(  d) e }  |
+  \tuplet 3/2 { fis8( e) d cis( d) e } |
   a,4 r |
   R2 |
   r8 r16 e' a8. e16 |
-  cis2~ |
-  \tuplet 3/2 { cis8 \noBeam cis d e(  cis) d }  |
+  cis2 ~ |
+  \tuplet 3/2 { cis8 \noBeam cis d e( cis) d } |
   a8 r r4 |
   R2 |
   R2 |
@@ -259,12 +259,12 @@ violin =  \relative c'' {
   R2 |
   R2 |
   r8 r16 cis, fis8. cis16 |
-  \tuplet 3/2 { d8(  cis) b ais( b) cis }  |
-  fis,4~ fis8. e16 |
+  \tuplet 3/2 { d8( cis) b ais( b) cis } |
+  fis,4 ~ fis8. e16 |
   d8. d'16
-  \tuplet 3/2 { cis8(  d) b }  |
+  \tuplet 3/2 { cis8( d) b } |
   ais8. b16
-  \tuplet 3/2 { cis8(  d) e }  |
+  \tuplet 3/2 { cis8( d) e } |
   fis8 r r4 |
   R2 |
   R2 |
@@ -304,33 +304,33 @@ violin =  \relative c'' {
   R2 |
   R2 |
   r8 r16 d' a'8. d,16 | \tripletsShow
-  \tuplet 3/2 { fis8(  e) d cis(  d) e }  | \tripletsHide
-  \tuplet 3/2 { a,8(  b) cis d(  e) fis }  |
+  \tuplet 3/2 { fis8( e) d cis( d) e } | \tripletsHide
+  \tuplet 3/2 { a,8( b) cis d( e) fis } |
   b,8 r cis r |
-  \tuplet 3/2 { b8(  d) fis fis(  e) fis }  |
-  \tuplet 3/2 { d8(  g) fis e(  a) g }  |
+  \tuplet 3/2 { b8( d) fis fis( e) fis } |
+  \tuplet 3/2 { d8( g) fis e( a) g } |
   fis8 r e r |
   e8 r d r |
-  \tuplet 3/2 { cis8(  d) e fis(  g) a }  |
-  d,4~ d8. cis16 |
+  \tuplet 3/2 { cis8( d) e fis( g) a } |
+  d,4 ~ d8. cis16 |
   d8 r cis r |
   d8 r a r |
   g8 r fis r |
   b8 r
-  \tuplet 3/2 { cis,( e  a) }  |
-  \tuplet 3/2 { d,8( fis  a) a,( cis  e) }  |
+  \tuplet 3/2 { cis,( e a) } |
+  \tuplet 3/2 { d,8( fis a) a,( cis e) } |
   d8 r d' r |
   cis8 r b r |
   e8 r d8. cis16 |
   d8. d,16 fis8. e16 |
   d8 r a' r |
   g8 r cis, r |
-  \tuplet 3/2 { fis8(  d) e fis(  d) e }  |
-  fis2~ |
-  \tuplet 3/2 { fis8 \noBeam d e fis(  d) e }  |
+  \tuplet 3/2 { fis8( d) e fis( d) e } |
+  fis2 ~ |
+  \tuplet 3/2 { fis8 \noBeam d e fis( d) e } |
   fis8. a16
-  \tuplet 3/2 { d8(  cis) d }  |
-  b2~ |
+  \tuplet 3/2 { d8( cis) d } |
+  b2 ~ |
   b |
   cis8 r cis r |
   b8 r b r |
@@ -340,12 +340,12 @@ violin =  \relative c'' {
   b8. b16 a8. a16 |
   a8 r r4 |
   r8 r16 g d'8. a16 |
-  \tuplet 3/2 { b8(  a) g fis(  g) a }  |
+  \tuplet 3/2 { b8( a) g fis( g) a } |
   d,8 r a' r |
-  e2~ |
-  \tuplet 3/2 { e8 \noBeam gis a b(  gis) a }  |
-  b2~ |
-  \tuplet 3/2 { b8 \noBeam gis a }  b8. b16 |
+  e2 ~ |
+  \tuplet 3/2 { e8 \noBeam gis a b( gis) a } |
+  b2 ~ |
+  \tuplet 3/2 { b8 \noBeam gis a } b8. b16 |
   cis8 r r8 r16 fis |
   d8 r r8 r16 g |
   e8 r r8 r16 a |

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin.ly
@@ -5,133 +5,134 @@
 
 
 violin =  \relative c'' {
- \clef violin
- \key d \major
- \time 2/4
+  \clef violin
+  \key d \major
+  \time 2/4
 
   \commonSettings
 
 
- % --Bar 1-- %
-R2 |
-R2 |
-R2 |
-R2 |
-R2 |
-R2 |
-R2 |
-R2 |
+  % --Bar 1-- %
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
 
-% --Bar 9-- %
-R2 |
-R2 |
-R2 |
-R2 |
-R2 |
-R2 |
-R2 |
-R2 |
+  % --Bar 9-- %
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
 
-% --Bar 17-- %
-R2 |
-R2 |
-R2 |
-R2 |
-R2 |
-R2 |
-R2 |
-R2 |
-R2 |
+  % --Bar 17-- %
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
 
-% --Bar 26-- %
-R2 |
-R2 |
-R2 |
-R2 |
-R2 |
-r8 r16 d16 a'8. e16 |
-\tuplet 3/2 { fis8( e) d  cis( d) e } |
-\tripletsHide
+  % --Bar 26-- %
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  r8 r16 d16 a'8. e16 |
+  \tuplet 3/2 { fis8( e) d  cis( d) e } |
+  \tripletsHide
 
-% --Bar 33-- %
-\tuplet 3/2 { a,( b) cis  d( e) fis } |
-d r e r |
-\tuplet 3/2 { b( d) fis  fis( e) fis } |
-\tuplet 3/2 { d( g) fis  e( a) g } |
-fis r e r |
-e r d r |
-\tuplet 3/2 { cis( d) e  fis( g) a } |
-d,4 ~ d8. a16 |
+  % --Bar 33-- %
+  \tuplet 3/2 { a,( b) cis  d( e) fis } |
+  d r e r |
+  \tuplet 3/2 { b( d) fis  fis( e) fis } |
+  \tuplet 3/2 { d( g) fis  e( a) g } |
+  fis r e r |
+  e r d r |
+  \tuplet 3/2 { cis( d) e  fis( g) a } |
+  d,4 ~ d8. a16 |
 
-% --Bar 41-- %
-d8 r cis r |
-d r a r |
-g r fis r |
-b r \tuplet 3/2 { cis, (e a) } |
-\tuplet 3/2 { d, (fis  a)   a, (cis  e) } |
-d r d' r |
+  % --Bar 41-- %
+  d8 r cis r |
+  d r a r |
+  g r fis r |
+  b r \tuplet 3/2 { cis, (e a) } |
+  \tuplet 3/2 { d, (fis  a)   a, (cis  e) } |
+  d r d' r |
 
-% --Bar 47-- %
-cis r b r |
-e r d8. cis16 |
-b8. d,16 fis8. e16 |
-d8 r a' r |
-g r cis, r |
-\tuplet 3/2 { fis (d)  e   fis (d)  e } |
-fis2~ |
+  % --Bar 47-- %
+  cis r b r |
+  e r d8. cis16 |
+  b8. d,16 fis8. e16 |
+  d8 r a' r |
+  g r cis, r |
+  \tuplet 3/2 { fis (d)  e   fis (d)  e } |
+  fis2~ |
 
-% --Bar 54-- %
-\tuplet 3/2 { fis8 \noBeam d e  fis( d) e | } 
-fis8.  a16 \tuplet 3/2 {d8(cis) d } 
-b2 ~|
-b |
-cis8 r cis r |
-b r b r |
-a r a r |
+  % --Bar 54-- %
+  \tuplet 3/2 { fis8 \noBeam d e  fis( d) e | }
+  fis8.  a16 \tuplet 3/2 {d8(cis) d }
+  b2 ~|
+  b |
+  cis8 r cis r |
+  b r b r |
+  a r a r |
 
-% --Bar 61-- %
-b4 r |
-r8 r16 cis d8. cis16 |
-b8. b16 a8. a16 |
-a8 r r4 |
-r8 r16 g d'8. a16 |
-\tuplet 3/2 { b8 (a) g  fis( g) a } |
-d, r a' r |
+  % --Bar 61-- %
+  b4 r |
+  r8 r16 cis d8. cis16 |
+  b8. b16 a8. a16 |
+  a8 r r4 |
+  r8 r16 g d'8. a16 |
+  \tuplet 3/2 { b8 (a) g  fis( g) a } |
+  d, r a' r |
 
-% --Bar 68-- %
-e2 ~|
-\tuplet 3/2 { e8 \noBeam gis a  b ( gis) a } |
-b2 ~ |
-\tuplet 3/2 { b8 \noBeam gis a } b8. b16 |
-cis8 r r r16 fis |
-d8 r r r16 g |
-e8 r r r16 a |
-fis8 r a r |
-d, r cis r |
-b8. b16 a8. a16 |
-a2 |
-R2*6 |
+  % --Bar 68-- %
+  e2 ~|
+  \tuplet 3/2 { e8 \noBeam gis a  b ( gis) a } |
+  b2 ~ |
+  \tuplet 3/2 { b8 \noBeam gis a } b8. b16 |
+  cis8 r r r16 fis |
+  d8 r r r16 g |
+  e8 r r r16 a |
+  fis8 r a r |
+  d, r cis r |
+  b8. b16 a8. a16 |
+  a2 |
+  R2*6 |
 
-% --Bar 85-- %
-R2*2 |
-r8 r16 b fis'8. cis16 |
-  \tuplet 3/2 { d8 (cis) b ais( b) cis |
+  % --Bar 85-- %
+  R2*2 |
+  r8 r16 b fis'8. cis16 |
+  \tuplet 3/2 {
+    d8 (cis) b ais( b) cis |
     fis,-\pianoissimo^"Solo" (b d ) d( cis d ) |%\italics
-    fis, (b d ) d( cis d ) | 
+    fis, (b d ) d( cis d ) |
     g,! (ais b)  cis( ais b) |
     e,( ais cis) cis( b cis) |
-  } 
+  }
 
 
-% \tuplet 3/2 {  } |
+  % \tuplet 3/2 {  } |
 
-% --Bar 93 -- %
-% Bar 93
+  % --Bar 93 -- %
+  % Bar 93
   \tuplet 3/2 { fis,8( b  d) d( cis  d) }  |
   \tuplet 3/2 { e,8( g  cis) cis(  ais) b }  |
   \tuplet 3/2 { cis8(  ais) b fis(  b) ais }  |
- b8 r r4 |
- r8 r16 fis-\forte cis'8. gis16 |
+  b8 r r4 |
+  r8 r16 fis-\forte cis'8. gis16 |
   \tuplet 3/2 { a8(  gis) fis eis(  fis) gis }  |
   \tuplet 3/2 { cis,8-\pianoissimo^"Solo"( fis  a) a( gis  a) }  |
   \tuplet 3/2 { cis,8( fis  a) a(  gis) a }  |
@@ -140,20 +141,20 @@ r8 r16 b fis'8. cis16 |
   \tuplet 3/2 { cis,8( fis  a) a( gis  a) }  |
   \tuplet 3/2 { b,8( d  gis) gis( eis  fis) }  |
   \tuplet 3/2 { gis8( eis  fis) cis( fis ) eis }  |
- fis8 r r4 |
- r a8-\forte r |
- gis8 r r4 |
- r gis8 r |
- fis8 r r4 |
- R2 |
- R2 |
- R2 |
- r4 cis'8 r |
- r4 d8 r |
- r4 e8 r |
- r4 fis8 r |
- R2 *10 |
- r8 r16 cis fis8. cis16 |
+  fis8 r r4 |
+  r a8-\forte r |
+  gis8 r r4 |
+  r gis8 r |
+  fis8 r r4 |
+  R2 |
+  R2 |
+  R2 |
+  r4 cis'8 r |
+  r4 d8 r |
+  r4 e8 r |
+  r4 fis8 r |
+  R2 *10 |
+  r8 r16 cis fis8. cis16 |
   \tuplet 3/2 { d8(  cis) b ais( b) cis }  |
   \tuplet 3/2 { fis,8(  b) d fis(  e) fis }  |
   \tuplet 3/2 { b,8(  a) g }  a4~ |
@@ -169,187 +170,187 @@ r8 r16 b fis'8. cis16 |
   \tuplet 3/2 { fis8 d fis }  b8. fis16 |
   \tuplet 3/2 { gis8 fis e }  a8. e16 |
   \tuplet 3/2 { fis8( e) d cis( d) e }  |
- a,8 r cis r |
- b r r dis |
- e8. b16
+  a,8 r cis r |
+  b r r dis |
+  e8. b16
   \tuplet 3/2 { e8(  cis) a }  |
- a8 r gis r |
- a8. \noBeam e16_\cantabile  a8. e16 |  \appoggiatura 
-   e
-  
+  a8 r gis r |
+  a8. \noBeam e16_\cantabile  a8. e16 |  \appoggiatura
+  e
+
   fis2~ |
- fis8. fis16
+  fis8. fis16
   \tuplet 3/2 { g!8(  e) fis }  |
- \appoggiatura
-  
-   fis16
-  
+  \appoggiatura
+
+  fis16
+
   e2~ |
- e8. e16 a8. fis16 |
- \appoggiatura
-  
-   e
-  
+  e8. e16 a8. fis16 |
+  \appoggiatura
+
+  e
+
   d2~ |
   \tuplet 3/2 { d8 e fis e(  fis) d }  |
- cis8 r r4 |
- R2 |
- r8 r16 b'_\piano e8. b16 |
+  cis8 r r4 |
+  R2 |
+  r8 r16 b'_\piano e8. b16 |
   \tuplet 3/2 { c8( b) a g( a) b }  |
- e,8 r r4 |
- R2 |
- r8 r16 fis b8. fis16 |
+  e,8 r r4 |
+  R2 |
+  r8 r16 fis b8. fis16 |
   \tuplet 3/2 { g8(  fis) e d(  e) fis }  |
- b,8 r r4 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- r8 r16 fis' a8. fis16 |
- b,4 r |
- r8 r16 e g8. e16 |
- a,4 r |
- r8 r16 a' d8. a16 |
+  b,8 r r4 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  r8 r16 fis' a8. fis16 |
+  b,4 r |
+  r8 r16 e g8. e16 |
+  a,4 r |
+  r8 r16 a' d8. a16 |
   \tuplet 3/2 { b8(  a) g fis(  g) a }  |
- d,4 r |
- R2 |
- r8 r16 e a8. e16 |
+  d,4 r |
+  R2 |
+  r8 r16 e a8. e16 |
   \tuplet 3/2 { fis8(  e) d cis(  d) e }  |
- a,4 r |
- R2 |
- r8 r16 e' a8. e16 |
- cis2~ |
+  a,4 r |
+  R2 |
+  r8 r16 e' a8. e16 |
+  cis2~ |
   \tuplet 3/2 { cis8 \noBeam cis d e(  cis) d }  |
- a8 r r4 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- b'8 r r4 |
- a8 r r4 |
- eis'8 r r4 |
- fis8 r r4 |
- fis8 r r4 |
- gis8 r r4 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- r8 r16 cis, fis8. cis16 |
+  a8 r r4 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  b'8 r r4 |
+  a8 r r4 |
+  eis'8 r r4 |
+  fis8 r r4 |
+  fis8 r r4 |
+  gis8 r r4 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  r8 r16 cis, fis8. cis16 |
   \tuplet 3/2 { d8(  cis) b ais( b) cis }  |
- fis,4~ fis8. e16 |
- d8. d'16
+  fis,4~ fis8. e16 |
+  d8. d'16
   \tuplet 3/2 { cis8(  d) b }  |
- ais8. b16
+  ais8. b16
   \tuplet 3/2 { cis8(  d) e }  |
- fis8 r r4 |
- R2 |
- R2 |
- R2 |
- R2 |
- r8 r16 b, b8. b16 |
- b8 r ais r |
- fis4 r |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- r8 r16 d' a'8. d,16 | \tripletsShow
+  fis8 r r4 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  r8 r16 b, b8. b16 |
+  b8 r ais r |
+  fis4 r |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  r8 r16 d' a'8. d,16 | \tripletsShow
   \tuplet 3/2 { fis8(  e) d cis(  d) e }  | \tripletsHide
   \tuplet 3/2 { a,8(  b) cis d(  e) fis }  |
- b,8 r cis r |
+  b,8 r cis r |
   \tuplet 3/2 { b8(  d) fis fis(  e) fis }  |
   \tuplet 3/2 { d8(  g) fis e(  a) g }  |
- fis8 r e r |
- e8 r d r |
+  fis8 r e r |
+  e8 r d r |
   \tuplet 3/2 { cis8(  d) e fis(  g) a }  |
- d,4~ d8. cis16 |
- d8 r cis r |
- d8 r a r |
- g8 r fis r |
- b8 r
+  d,4~ d8. cis16 |
+  d8 r cis r |
+  d8 r a r |
+  g8 r fis r |
+  b8 r
   \tuplet 3/2 { cis,( e  a) }  |
   \tuplet 3/2 { d,8( fis  a) a,( cis  e) }  |
- d8 r d' r |
- cis8 r b r |
- e8 r d8. cis16 |
- d8. d,16 fis8. e16 |
- d8 r a' r |
- g8 r cis, r |
+  d8 r d' r |
+  cis8 r b r |
+  e8 r d8. cis16 |
+  d8. d,16 fis8. e16 |
+  d8 r a' r |
+  g8 r cis, r |
   \tuplet 3/2 { fis8(  d) e fis(  d) e }  |
- fis2~ |
+  fis2~ |
   \tuplet 3/2 { fis8 \noBeam d e fis(  d) e }  |
- fis8. a16
+  fis8. a16
   \tuplet 3/2 { d8(  cis) d }  |
- b2~ |
- b |
- cis8 r cis r |
- b8 r b r |
- a8 r a r |
- b4 r |
- r8 r16 cis d8. cis16 |
- b8. b16 a8. a16 |
- a8 r r4 |
- r8 r16 g d'8. a16 |
+  b2~ |
+  b |
+  cis8 r cis r |
+  b8 r b r |
+  a8 r a r |
+  b4 r |
+  r8 r16 cis d8. cis16 |
+  b8. b16 a8. a16 |
+  a8 r r4 |
+  r8 r16 g d'8. a16 |
   \tuplet 3/2 { b8(  a) g fis(  g) a }  |
- d,8 r a' r |
- e2~ |
+  d,8 r a' r |
+  e2~ |
   \tuplet 3/2 { e8 \noBeam gis a b(  gis) a }  |
- b2~ |
+  b2~ |
   \tuplet 3/2 { b8 \noBeam gis a }  b8. b16 |
- cis8 r r8 r16 fis |
- d8 r r8 r16 g |
- e8 r r8 r16 a |
- fis8 r a r |
- d,8 r cis r |
- b8. b16 a8. a16 |
- a2-\fermata \bar "|."
+  cis8 r r8 r16 fis |
+  d8 r r8 r16 g |
+  e8 r r8 r16 a |
+  fis8 r a r |
+  d,8 r cis r |
+  b8. b16 a8. a16 |
+  a2-\fermata \bar "|."
 }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin.ly
@@ -1,8 +1,5 @@
-\include "header.ly"
-
-
 \version "2.18.0"
-
+\include "header.ly"
 
 violin = \relative c'' {
   \clef violin

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin.ly
@@ -67,8 +67,8 @@ violin = \relative c'' {
   d8 r cis r |
   d r a r |
   g r fis r |
-  b r \tuplet 3/2 { cis, (e a) } |
-  \tuplet 3/2 { d, (fis a) a, (cis e) } |
+  b r \tuplet 3/2 { cis,( e a) } |
+  \tuplet 3/2 { d,( fis a) a,( cis e) } |
   d r d' r |
 
   % --Bar 47-- %
@@ -77,12 +77,12 @@ violin = \relative c'' {
   b8. d,16 fis8. e16 |
   d8 r a' r |
   g r cis, r |
-  \tuplet 3/2 { fis (d) e fis (d) e } |
+  \tuplet 3/2 { fis( d) e fis( d) e } |
   fis2 ~ |
 
   % --Bar 54-- %
   \tuplet 3/2 { fis8 \noBeam d e fis( d) e | }
-  fis8. a16 \tuplet 3/2 { d8(cis) d }
+  fis8. a16 \tuplet 3/2 { d8(cis ) d }
   b2 ~ |
   b |
   cis8 r cis r |
@@ -95,12 +95,12 @@ violin = \relative c'' {
   b8. b16 a8. a16 |
   a8 r r4 |
   r8 r16 g d'8. a16 |
-  \tuplet 3/2 { b8 (a) g fis( g) a } |
+  \tuplet 3/2 { b8( a) g fis( g) a } |
   d, r a' r |
 
   % --Bar 68-- %
   e2 ~ |
-  \tuplet 3/2 { e8 \noBeam gis a b ( gis) a } |
+  \tuplet 3/2 { e8 \noBeam gis a b( gis) a } |
   b2 ~ |
   \tuplet 3/2 { b8 \noBeam gis a } b8. b16 |
   cis8 r r r16 fis |
@@ -116,10 +116,10 @@ violin = \relative c'' {
   R2*2 |
   r8 r16 b fis'8. cis16 |
   \tuplet 3/2 {
-    d8 (cis) b ais( b) cis |
-    fis,-\pianoissimo^"Solo" (b d ) d( cis d ) | %\italics
-    fis, (b d ) d( cis d ) |
-    g,! (ais b) cis( ais b) |
+    d8( cis) b ais( b) cis |
+    fis,(-\pianoissimo^"Solo" b d) d( cis d) | %\italics
+    fis,( b d ) d( cis d ) |
+    g,!( ais b) cis( ais b) |
     e,( ais cis) cis( b cis) |
   }
 

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin.ly
@@ -2,6 +2,7 @@
 \include "header.ly"
 
 violin = \relative c'' {
+  \tempo "Allegro."
   \clef violin
   \key d \major
   \time 2/4

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violin.ly
@@ -44,7 +44,7 @@ violin = \relative c'' {
     \tuplet 3/2 { fis8 \noBeam d e fis( d) e } |
     fis8. a16 \tuplet 3/2 { d8( cis) d } |
     b2 ~ |
-    b |
+    b2 |
     cis8 r cis r |
     b8 r b r |
     a8 r a r |
@@ -79,10 +79,10 @@ violin = \relative c'' {
       r8 r16 b fis'8. cis16 |
       \tuplet 3/2 {
         d8( cis) b ais( b) cis |
-        fis,(-\pianissimo^"Solo" b d) d( cis d) | %\italics
-        fis,( b d ) d( cis d ) |
-        g,!( ais b) cis( ais b) |
-        e,( ais cis) cis( b cis) |
+        fis,8(-\pianissimo^"Solo" b d) d( cis d) | %\italics
+        fis,8( b d ) d( cis d ) |
+        g,!8( ais b) cis( ais b) |
+        e,8( ais cis) cis( b cis) |
       }
 
 
@@ -104,9 +104,9 @@ violin = \relative c'' {
       \tuplet 3/2 { b,8( d gis) gis( eis fis) } |
       \tuplet 3/2 { gis8( eis fis) cis( fis ) eis } |
       fis8 r r4 |
-      r a8-\forte r |
+      r4 a8-\forte r |
       gis8 r r4 |
-      r gis8 r |
+      r4 gis8 r |
       fis8 r r4 |
       R2*3 |
       r4 cis'8 r |
@@ -131,12 +131,12 @@ violin = \relative c'' {
       \tuplet 3/2 { gis8 fis e } a8. e16 |
       \tuplet 3/2 { fis8( e) d cis( d) e } |
       a,8 r cis r |
-      b r r dis |
+      b8 r r dis |
       e8. b16
       \tuplet 3/2 { e8( cis) a } |
       a8 r gis r |
       a8. \noBeam e16_\cantabile a8. e16 | \appoggiatura
-      e
+      e16
 
       fis2 ~ |
       fis8. fis16
@@ -149,7 +149,7 @@ violin = \relative c'' {
       e8. e16 a8. fis16 |
       \appoggiatura
 
-      e
+      e16
 
       d2 ~ |
       \tuplet 3/2 { d8 e fis e( fis) d } |

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP-score.ly
@@ -1,6 +1,9 @@
 \version "2.18.0"
-
 \include "violinP.ly"
+
+\header {
+  instrument = "Violino principate"
+}
 
 \score {
   \violinP

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP-score.ly
@@ -1,14 +1,14 @@
 \version "2.18.0"
 \include "violinP.ly"
 
-\score 
+\score
 {
-	\violinP
-	\midi {}
- 	\layout 
-	{
-	}
-	\header
-	{
-	}
+  \violinP
+  \midi {}
+  \layout
+  {
+  }
+  \header
+  {
+  }
 }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP-score.ly
@@ -1,4 +1,4 @@
-\version "2.4.0"
+\version "2.18.0"
 \include "violinP.ly"
 
 \score 

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP-score.ly
@@ -1,14 +1,9 @@
 \version "2.18.0"
+
 \include "violinP.ly"
 
-\score
-{
+\score {
   \violinP
   \midi {}
-  \layout
-  {
-  }
-  \header
-  {
-  }
+  \layout {}
 }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP.ly
@@ -280,8 +280,7 @@ violinP = \relative c'' {
       b4 r |
     }
     {
-      d2-\fermata \bar "|."
+      d2\fermata \bar "|."
     }
   }
 }
-

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP.ly
@@ -3,7 +3,7 @@
 
 
 
-violinP =  \relative c'' {
+violinP = \relative c'' {
   \clef violin
   \key d \major
   \time 2/4
@@ -12,102 +12,102 @@ violinP =  \relative c'' {
 
   % --Bar 1-- %
   r8 r16 a16 d8. a16 |
-  \tuplet 3/2 { b8( a) g  fis( g) a } |
+  \tuplet 3/2 { b8( a) g fis( g) a } |
   d, r cis r |
   d r e r |
   \tuplet 3/2 {
-    fis( a) d  d( cis) d  |
-    b( e) d cis(  fis) e|
+    fis( a) d d( cis) d |
+    b( e) d cis( fis) e |
   }
   d r a r |
   b r cis r |
 
   % --Bar 9-- %
-  \tuplet 3/2 { d( fis) e  d( fis) e } |
+  \tuplet 3/2 { d( fis) e d( fis) e } |
   d4( d8.) cis 16 |
   \tripletsHide \tuplet 3/2 {
-    d8( e) fis  e( fis) g |
-    fis( g) fis  e( fis) d |
-    cis( e) d  cis( d) e|
+    d8( e) fis e( fis) g |
+    fis( g) fis e( fis) d |
+    cis( e) d cis( d) e |
   }
   b r cis r |
-  d2~|
-  d~|
+  d2 ~ |
+  d ~ |
 
   % --Bar 17-- %
-  \tuplet 3/2 { d8 e d  cis( d) e | }
+  \tuplet 3/2 { d8 e d cis( d) e | }
   a,8. fis'16 e8. d16 |
-  \tuplet 3/2 { cis8( e) d  cis( e) d | }
+  \tuplet 3/2 { cis8( e) d cis( e) d | }
   cis2 ~ |
-  \tuplet 3/2 {cis8 e, d  cis( e) d |}
+  \tuplet 3/2 { cis8 e, d cis( e) d | }
   cis2 |
   b |
   fis'' ~ |
-  fis4 \tripletsShowOnce \tuplet 3/2{ e8 fis gis } |
+  fis4 \tripletsShowOnce \tuplet 3/2 { e8 fis gis } |
 
   % --Bar 26-- %
   a4 ~ \tuplet 3/2 { a8 b a } |
   \tuplet 3/2 { gis( fis) e } a4 ~ |
   a gis |
-  a ~ \tuplet 3/2 {a8 g! fis } | % remind natural
+  a ~ \tuplet 3/2 { a8 g! fis } | % remind natural
   e4 ~ \tuplet 3/2 { e8 d cis } |
-  \tuplet 3/2 { d( cis) b  a( e') g} |
+  \tuplet 3/2 { d( cis) b a( e') g} |
   fis r gis r |
 
   % --Bar 33-- %
   a8. a16 d8. a16 |
-  \tuplet 3/2 { b8 ( a) g   fis ( g) a } |
+  \tuplet 3/2 { b8 ( a) g fis ( g) a } |
   d, r cis r |
   d r e r |
-  \tuplet 3/2 { d ( fis) a   a( g) a } |
-  \tuplet 3/2 { fis( b) a   gis( cis) b } |
+  \tuplet 3/2 { d ( fis) a a( g) a } |
+  \tuplet 3/2 { fis( b) a gis( cis) b } |
   a4 ~ \tuplet 3/2 { a8 b cis } |
-  \tuplet 3/2 { d cis b   a b g } |
+  \tuplet 3/2 { d cis b a b g } |
 
   %--Bar 41--%
   fis r g r |
   a r c, r |
   b r cis! r |
-  d r \tuplet 3/2 { e,( a  cis) } |
-  \tuplet 3/2 { fis, ( a) d   e,( a) cis } |
+  d r \tuplet 3/2 { e,( a cis) } |
+  \tuplet 3/2 { fis, ( a) d e,( a) cis } |
   d r g r |
 
   %--Bar 47--%
   fis r d r |
   a r a8. g16 |
-  fis8. g16 a4~|
-  \tuplet 3/2 { a8 a g  fis( g) a } |
+  fis8. g16 a4 ~ |
+  \tuplet 3/2 { a8 a g fis( g) a } |
   d,8. b'16 a8. g16 |
   \tuplet 3/2 { fis8(a)g fis(a) g} |
-  fis2~ |
+  fis2 ~ |
 
   %--Bar 54--%
-  \tuplet 3/2 { fis8  \noBeam fis' e  d(fis) e } |
-  d2~|
-  d~ |
+  \tuplet 3/2 { fis8 \noBeam fis' e d(fis) e } |
+  d2 ~ |
+  d ~ |
   d |
-  \tuplet 3/2 { cis8 (b) a } a'4~ |
-  \tuplet 3/2 { a8 b a } g4~ |
-  \tuplet 3/2 { g8 a g } fis4~ |
+  \tuplet 3/2 { cis8 (b) a } a'4 ~ |
+  \tuplet 3/2 { a8 b a } g4 ~ |
+  \tuplet 3/2 { g8 a g } fis4 ~ |
 
   %--Bar 61--%
-  \tuplet 3/2 { fis8 b, d  e(fis) g } |
-  \tuplet 3/2 { cis,( e) cis  a(b) cis } |
+  \tuplet 3/2 { fis8 b, d e(fis) g } |
+  \tuplet 3/2 { cis,( e) cis a(b) cis } |
   a8. g16 e8. d16 |
-  d2~ |
-  d~ |
-  d~|
+  d2 ~ |
+  d ~ |
+  d ~ |
   d4 ~ \tuplet 3/2 { d8 e fis } |
 
   %--Bar 68--%
-  e2~ |
+  e2 ~ |
   e ~ |
-  e ~|
-  e4 e' ~|
-  e fis~|
-  fis g~|
-  g a~|
-  a8. \noBeam a16 d8. a16|
+  e ~ |
+  e4 e' ~ |
+  e fis ~ |
+  fis g ~ |
+  g a ~ |
+  a8. \noBeam a16 d8. a16 |
 
   %--Bar 76--%
   \tuplet 3/2 { b8( a) g fis(g) a } |
@@ -117,20 +117,20 @@ violinP =  \relative c'' {
     b8-\piano ( d fis) fis( e fis) |
     b,( d fis) fis( e fis) |
     b,( dis e) e( dis e) |
-    ais,( cis e)  e( d! e) |
+    ais,( cis e) e( d! e) |
     b( d fis) fis( e fis) |
     cis( e g) g( fis g) |
   }
 
   %--Bar 85--%
-  \tuplet 3/2 { ais,(fis) e'  d(e)cis }|
+  \tuplet 3/2 { ais,(fis) e' d(e)cis } |
   b r fis r |
-  b r \tuplet 3/2 { cis d e }|
-  \tuplet 3/2 { fis(e) d  cis(b) ais }|
-  b8. fis'16-\forte  b8. fis16 |
-  g2~|
-  g8. g16  \tuplet 3/2 {a8( fis) g } |
-  fis2~ |
+  b r \tuplet 3/2 { cis d e } |
+  \tuplet 3/2 { fis(e) d cis(b) ais } |
+  b8. fis'16-\forte b8. fis16 |
+  g2 ~ |
+  g8. g16 \tuplet 3/2 { a8( fis) g } |
+  fis2 ~ |
 
   %--Bar 93 --%
   fis8. fis16 b8. g16 |
@@ -138,83 +138,83 @@ violinP =  \relative c'' {
   % \tuplet 3/2 { } |
   \appoggiatura
   fis16(
-  e2)~ |
-  \tuplet 3/2 { e8 fis g fis(  g) e }  |
-  \tuplet 3/2 { d8( b  cis) d( fis  eis) }  |
-  \tuplet 3/2 { fis8(  gis) a gis(  a) fis }  |
-  \tuplet 3/2 { eis8(  gis) cis b(  a) gis }  |
+  e2) ~ |
+  \tuplet 3/2 { e8 fis g fis( g) e } |
+  \tuplet 3/2 { d8( b cis) d( fis eis) } |
+  \tuplet 3/2 { fis8( gis) a gis( a) fis } |
+  \tuplet 3/2 { eis8( gis) cis b( a) gis } |
   fis8. \noBeam cis16-\piano
-  \tuplet 3/2 { cis8( b  cis) }  |
-  \tuplet 3/2 { fis,8( a  cis) cis( b  cis) }  |
-  \tuplet 3/2 { fis,8( ais  b) b( ais  b) }  |
-  \tuplet 3/2 { eis,8( gis  b) b( a  b) }  |
-  \tuplet 3/2 { fis8( a  cis) cis( b  cis) }  |
-  \tuplet 3/2 { gis8 b d d cis d }  |
-  \tuplet 3/2 { eis,8 cis b' a b gis }  |
+  \tuplet 3/2 { cis8( b cis) } |
+  \tuplet 3/2 { fis,8( a cis) cis( b cis) } |
+  \tuplet 3/2 { fis,8( ais b) b( ais b) } |
+  \tuplet 3/2 { eis,8( gis b) b( a b) } |
+  \tuplet 3/2 { fis8( a cis) cis( b cis) } |
+  \tuplet 3/2 { gis8 b d d cis d } |
+  \tuplet 3/2 { eis,8 cis b' a b gis } |
   fis8 r r4 |
-  \tuplet 3/2 { r8 fis-\forte gis a cis b }  |
+  \tuplet 3/2 { r8 fis-\forte gis a cis b } |
   cis4 r |
-  \tuplet 3/2 { r8 e, fis gis b a }  |
+  \tuplet 3/2 { r8 e, fis gis b a } |
   b2\trill |
   a\trill |
-  gis~ |
-  \tuplet 3/2 { gis8 eis fis gis(  eis) fis }  |
-  gis4 gis'~ |
-  gis4 fis~ |
-  fis4 b~ |
-  b4 a~ |
-  a4 d~ |
+  gis ~ |
+  \tuplet 3/2 { gis8 eis fis gis( eis) fis } |
+  gis4 gis' ~ |
+  gis4 fis ~ |
+  fis4 b ~ |
+  b4 a ~ |
+  a4 d ~ |
   d4 cis8. b16 |
-  a2~ |
+  a2 ~ |
   a4 gis8. fis16 |
-  eis4 e~ |
+  eis4 e ~ |
   e8. \noBeam cis16 fis8. cis16 |
-  \tuplet 3/2 { d8(  cis) b a(  b) cis }  |
-  fis,4 b~ |
-  \tuplet 3/2 { b8 a gis a(  b) cis }  |
-  \tuplet 3/2 { d8(  b) a }  gis8. fis16 |
-  fis2~ |
+  \tuplet 3/2 { d8( cis) b a( b) cis } |
+  fis,4 b ~ |
+  \tuplet 3/2 { b8 a gis a( b) cis } |
+  \tuplet 3/2 { d8( b) a } gis8. fis16 |
+  fis2 ~ |
   fis |
   r8 r16 fis' b8. fis16 |
-  \tuplet 3/2 { g!8(  fis) e dis(  e) fis }  |
-  \tuplet 3/2 { b,8(  e) g b(  a) b }  |
-  \tuplet 3/2 { e,8(  d) cis }  d4~ |
-  \tuplet 6/4 { d8 cis e }  a8. e16 |
-  \tuplet 3/2 { fis8(  e) d cis d e }  |
+  \tuplet 3/2 { g!8( fis) e dis( e) fis } |
+  \tuplet 3/2 { b,8( e) g b( a) b } |
+  \tuplet 3/2 { e,8( d) cis } d4 ~ |
+  \tuplet 6/4 { d8 cis e } a8. e16 |
+  \tuplet 3/2 { fis8( e) d cis d e } |
   a,8. gis16
-  \tuplet 3/2 { fis8( a) d }  |
+  \tuplet 3/2 { fis8( a) d } |
   d8.
-  \tuplet 3/2 { cis32 b a gis8 b e }  |
+  \tuplet 3/2 { cis32 b a gis8 b e } |
   e8.
-  \tuplet 3/2 { d32 cis b a8(  cis) fis }  |
+  \tuplet 3/2 { d32 cis b a8( cis) fis } |
   fis8.
-  \tuplet 3/2 { e32 d cis b8(  d) gis }  |
+  \tuplet 3/2 { e32 d cis b8( d) gis } |
   gis8.
-  \tuplet 3/2 { fis32 e d cis8(  e) a }  |
+  \tuplet 3/2 { fis32 e d cis8( e) a } |
   a8.
-  \tuplet 3/2 { g32 fis e d8 fis b }  |
-  \tuplet 3/2 { e,8(  fis ) gis }  a4~ |
-  a2~ |
-  a~ |
-  \tuplet 3/2 { a8 gis fis b(  cis) a }  |
-  \tuplet 3/2 { gis8(  fis) e }  a8. d,16 |
+  \tuplet 3/2 { g32 fis e d8 fis b } |
+  \tuplet 3/2 { e,8( fis ) gis } a4 ~ |
+  a2 ~ |
+  a ~ |
+  \tuplet 3/2 { a8 gis fis b( cis) a } |
+  \tuplet 3/2 { gis8( fis) e } a8. d,16 |
   cis8 r b\trill r |
   a8.-\piano cis16
-  \tuplet 3/2 { cis8 b cis }  |
-  \tuplet 3/2 { e,8( a  cis) cis( b  cis) }  |
-  \tuplet 3/2 { fis,8( g!  a) b( cis  a) }  |
-  \tuplet 3/2 { d,8( gis  b) b( a  b) }  |
-  \tuplet 3/2 { e,8( a  cis) cis( b  cis) }  |
-  \tuplet 3/2 { d,8( fis  b) b( gis  a) }  |
-  \tuplet 3/2 { b8(  gis ) a e(  a) gis }  |
+  \tuplet 3/2 { cis8 b cis } |
+  \tuplet 3/2 { e,8( a cis) cis( b cis) } |
+  \tuplet 3/2 { fis,8( g! a) b( cis a) } |
+  \tuplet 3/2 { d,8( gis b) b( a b) } |
+  \tuplet 3/2 { e,8( a cis) cis( b cis) } |
+  \tuplet 3/2 { d,8( fis b) b( gis a) } |
+  \tuplet 3/2 { b8( gis ) a e( a) gis } |
   a8 r r4 |
   R2 |
   r8 r16 b-\piano e8. b16 |
-  \tuplet 3/2 { c8(  b) a g a b }  |
+  \tuplet 3/2 { c8( b) a g a b } |
   e,4 r |
   R2 |
   r8 r16 fis b8. fis16 |
-  \tuplet 3/2 { g8(  fis) e d(  e) fis }  |
+  \tuplet 3/2 { g8( fis) e d( e) fis } |
   b,4 r |
   R2 |
   R2 |
@@ -234,51 +234,51 @@ violinP =  \relative c'' {
   r8 r16 g b8. g16 |
   e4 r |
   r8 r16 a d8. a16 |
-  \tuplet 3/2 { b8(  a) g fis(  g) a }  |
+  \tuplet 3/2 { b8( a) g fis( g) a } |
   d,4 r |
   R2 |
   r8 r16 e a8. e16 |
-  \tuplet 3/2 { fis8(  e) d cis(  d) e }  |
+  \tuplet 3/2 { fis8( e) d cis( d) e } |
   a,4 r |
   R2 |
-  \tuplet 3/2 { cis'8-\piano(  a) b cis(  a) b }  |
+  \tuplet 3/2 { cis'8-\piano( a) b cis( a) b } |
   cis2 ~ |
-  \tuplet 3/2 { cis8 \noBeam e d cis(  e) d }  |
+  \tuplet 3/2 { cis8 \noBeam e d cis( e) d } |
   cis4 r |
   r4 r8 r16 b |
-  e4~ e8. a,16 |
-  d4~ d8. e16 |
-  cis4~ cis8. cis16 |
-  \tuplet 3/2 { \tripletsShowOnce d8(  cis) b  \tripletsShowOnce a(  gis) fis }  |
-  e8. cis'16 gis'4~ |
-  \tuplet 3/2 { gis8 fis eis fis(  gis) a }  |
-  b2~ |
-  \tuplet 3/2 { b8 a gis a b cis }  |
-  d2~ |
-  \tuplet 3/2 { d8 cis b cis(  d) e }  |
-  ais,4 b~ |
-  \tuplet 3/2 { b8 a! gis a b c }  |
-  dis,4 e~ |
-  \tuplet 3/2 { e8 fis e dis cis b }  |
-  g'2~ |
-  \tuplet 3/2 { g8 fis, g a b c }  |
-  d2~ |
-  \tuplet 3/2 { d8 c b }  c4~ |
-  \tuplet 3/2 { c8 b a b( c) a }  |
-  a4 a'~ |
-  \tuplet 3/2 { a8 g fis g( a) g }  |
-  fis2~ |
-  \tuplet 3/2 { fis8 e d }  e4~ |
-  \tuplet 3/2 { e8 fis e d(  cis) b }  |
-  \tuplet 3/2 { ais8( gis  ais) b( cis  d) }  |
-  \tuplet 3/2 { e8( fis  e) d( cis  b) }  |
-  ais4~
-  \tuplet 3/2 { ais8 b cis }  |
-  \tuplet 3/2 { b8( cis  d) cis( d  e) }  |
+  e4 ~ e8. a,16 |
+  d4 ~ d8. e16 |
+  cis4 ~ cis8. cis16 |
+  \tuplet 3/2 { \tripletsShowOnce d8( cis) b \tripletsShowOnce a( gis) fis } |
+  e8. cis'16 gis'4 ~ |
+  \tuplet 3/2 { gis8 fis eis fis( gis) a } |
+  b2 ~ |
+  \tuplet 3/2 { b8 a gis a b cis } |
+  d2 ~ |
+  \tuplet 3/2 { d8 cis b cis( d) e } |
+  ais,4 b ~ |
+  \tuplet 3/2 { b8 a! gis a b c } |
+  dis,4 e ~ |
+  \tuplet 3/2 { e8 fis e dis cis b } |
+  g'2 ~ |
+  \tuplet 3/2 { g8 fis, g a b c } |
+  d2 ~ |
+  \tuplet 3/2 { d8 c b } c4 ~ |
+  \tuplet 3/2 { c8 b a b( c) a } |
+  a4 a' ~ |
+  \tuplet 3/2 { a8 g fis g( a) g } |
+  fis2 ~ |
+  \tuplet 3/2 { fis8 e d } e4 ~ |
+  \tuplet 3/2 { e8 fis e d( cis) b } |
+  \tuplet 3/2 { ais8( gis ais) b( cis d) } |
+  \tuplet 3/2 { e8( fis e) d( cis b) } |
+  ais4 ~
+  \tuplet 3/2 { ais8 b cis } |
+  \tuplet 3/2 { b8( cis d) cis( d e) } |
   ais,8. b16
-  \tripletsShowOnce \tuplet 3/2 { cis8( d e) }  |
-  \tripletsShowOnce \tuplet 3/2 { fis8( ais,) b }  fis'8. cis16 |
-  \tuplet 3/2 { d8(  cis) b ais(  b) cis }  |
+  \tripletsShowOnce \tuplet 3/2 { cis8( d e) } |
+  \tripletsShowOnce \tuplet 3/2 { fis8( ais,) b } fis'8. cis16 |
+  \tuplet 3/2 { d8( cis) b ais( b) cis } |
   fis,2 |
   gis |
   ais |
@@ -288,88 +288,88 @@ violinP =  \relative c'' {
   d8 r d\trill r |
   b4 r |
   r8 r16 a d8. a16 |
-  \tripletsShow \tuplet 3/2 { b8(  a) g fis(  g) a }  |
+  \tripletsShow \tuplet 3/2 { b8( a) g fis( g) a } |
   d,8 r cis r |
   d8 r e r |
-  \tuplet 3/2 { fis8(  a) d d(  cis) d }  |
-  \tuplet 3/2 { b8( e) d cis( fis) e }  |
+  \tuplet 3/2 { fis8( a) d d( cis) d } |
+  \tuplet 3/2 { b8( e) d cis( fis) e } |
   d8 r a r |
   b8 r cis r |
-  \tuplet 3/2 { d8(  fis) e d(  fis) e }  | \tripletsHide
-  d4~ d8. cis16 |
-  \tuplet 3/2 { d8(  e) fis e(  fis) g }  |
-  \tuplet 3/2 { fis8(  g) fis e(  fis) d }  |
-  \tuplet 3/2 { cis8(  e) d cis(  d) e }  |
+  \tuplet 3/2 { d8( fis) e d( fis) e } | \tripletsHide
+  d4 ~ d8. cis16 |
+  \tuplet 3/2 { d8( e) fis e( fis) g } |
+  \tuplet 3/2 { fis8( g) fis e( fis) d } |
+  \tuplet 3/2 { cis8( e) d cis( d) e } |
   b8 r cis r |
-  d2~ |
-  d~ |
-  \tuplet 3/2 { d8 e d cis( d) e }  |
+  d2 ~ |
+  d ~ |
+  \tuplet 3/2 { d8 e d cis( d) e } |
   a,8. fis'16 e8. d16 |
-  \tuplet 3/2 { cis8( e) d cis( e) d }  |
-  cis2~ |
-  \tuplet 3/2 { cis8 e, d cis(  e) d }  |
+  \tuplet 3/2 { cis8( e) d cis( e) d } |
+  cis2 ~ |
+  \tuplet 3/2 { cis8 e, d cis( e) d } |
   cis2 |
   b |
-  fis''~ |
+  fis'' ~ |
   fis4
-  \tripletsShowOnce \tuplet 3/2 { e8 fis gis }  |
-  a4~
-  \tuplet 6/4 { a8 b a }  |
-  \tuplet 3/2 { gis8(  fis) e }  a4~ |
+  \tripletsShowOnce \tuplet 3/2 { e8 fis gis } |
+  a4 ~
+  \tuplet 6/4 { a8 b a } |
+  \tuplet 3/2 { gis8( fis) e } a4 ~ |
   a gis |
-  a4~
-  \tuplet 6/4 { a8 g! fis }  |
-  e4~
-  \tuplet 6/4 { e8 d cis }  |
-  \tuplet 3/2 { d8(  cis) b a(  e') g }  |
+  a4 ~
+  \tuplet 6/4 { a8 g! fis } |
+  e4 ~
+  \tuplet 6/4 { e8 d cis } |
+  \tuplet 3/2 { d8( cis) b a( e') g } |
   fis8 r gis r |
   a8. \noBeam a16 d8. a16 |
-  \tuplet 3/2 { b8(  a) g fis(  g) a }  |
+  \tuplet 3/2 { b8( a) g fis( g) a } |
   d,8 r cis r |
   b8 r e r |
-  \tuplet 3/2 { d8(  fis) a a(  g) a }  |
-  \tuplet 3/2 { fis8(  b) a gis(  cis) b }  |
-  a4~
-  \tuplet 3/2 { a8 b cis }  |
-  \tuplet 3/2 { d8(  cis) b a(  b) g }  |
+  \tuplet 3/2 { d8( fis) a a( g) a } |
+  \tuplet 3/2 { fis8( b) a gis( cis) b } |
+  a4 ~
+  \tuplet 3/2 { a8 b cis } |
+  \tuplet 3/2 { d8( cis) b a( b) g } |
   fis8 r g r |
   a8 r c, r |
   b8 r cis! r |
   d8 r
-  \tuplet 3/2 { e,( a  cis) }  |
-  \tuplet 3/2 { fis,8( a  d) e,( a  cis) }  |
+  \tuplet 3/2 { e,( a cis) } |
+  \tuplet 3/2 { fis,8( a d) e,( a cis) } |
   d8 r g r |
   fis8 r d r |
   a8 r a8. g16 |
-  fis8. g16 a4~ |
-  \tuplet 3/2 { a8 a g fis( g) a }  |
+  fis8. g16 a4 ~ |
+  \tuplet 3/2 { a8 a g fis( g) a } |
   d,8. b'16 a8. g16 |
-  \tuplet 3/2 { fis8(  a) g fis(  a) g }  |
-  fis2~ |
-  \tuplet 3/2 { fis8 \noBeam fis' e d(  fis) e }  |
-  d2~ |
-  d~ |
+  \tuplet 3/2 { fis8( a) g fis( a) g } |
+  fis2 ~ |
+  \tuplet 3/2 { fis8 \noBeam fis' e d( fis) e } |
+  d2 ~ |
+  d ~ |
   d |
-  \tuplet 3/2 { cis8(  b) a }  a'4~ |
-  \tuplet 3/2 { a8 b a }  g4~ |
-  \tuplet 3/2 { g8 a g }  fis4~ |
-  \tuplet 3/2 { fis8 b, d e(  fis) g }  |
-  \tuplet 3/2 { cis,8(  e) cis a b cis }  |
+  \tuplet 3/2 { cis8( b) a } a'4 ~ |
+  \tuplet 3/2 { a8 b a } g4 ~ |
+  \tuplet 3/2 { g8 a g } fis4 ~ |
+  \tuplet 3/2 { fis8 b, d e( fis) g } |
+  \tuplet 3/2 { cis,8( e) cis a b cis } |
   fis,8. g16 e8. d16 |
-  d2~ |
-  d~ |
-  d~ |
-  d4~
-  \tuplet 3/2 { d8 e fis }  |
-  e2~ |
-  e~ |
-  e~ |
-  e4 e'~ |
-  e fis~ |
-  fis4 g~ |
-  g4 a~ |
+  d2 ~ |
+  d ~ |
+  d ~ |
+  d4 ~
+  \tuplet 3/2 { d8 e fis } |
+  e2 ~ |
+  e ~ |
+  e ~ |
+  e4 e' ~ |
+  e fis ~ |
+  fis4 g ~ |
+  g4 a ~ |
   a8. \noBeam a16 d8. a16 |
-  \tuplet 3/2 { b8(  a) g fis(  g) a }  |
+  \tuplet 3/2 { b8( a) g fis( g) a } |
   d,8. e16 cis8. d16 |
   d2-\fermata \bar "|."
 }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP.ly
@@ -1,8 +1,6 @@
 \version "2.18.0"
 \include "header.ly"
 
-
-
 violinP = \relative c'' {
   \clef violin
   \key d \major
@@ -56,10 +54,10 @@ violinP = \relative c'' {
 
   % --Bar 33-- %
   a8. a16 d8. a16 |
-  \tuplet 3/2 { b8 ( a) g fis ( g) a } |
+  \tuplet 3/2 { b8( a) g fis( g) a } |
   d, r cis r |
   d r e r |
-  \tuplet 3/2 { d ( fis) a a( g) a } |
+  \tuplet 3/2 { d( fis) a a( g) a } |
   \tuplet 3/2 { fis( b) a gis( cis) b } |
   a4 ~ \tuplet 3/2 { a8 b cis } |
   \tuplet 3/2 { d cis b a b g } |
@@ -69,7 +67,7 @@ violinP = \relative c'' {
   a r c, r |
   b r cis! r |
   d r \tuplet 3/2 { e,( a cis) } |
-  \tuplet 3/2 { fis, ( a) d e,( a) cis } |
+  \tuplet 3/2 { fis,( a) d e,( a) cis } |
   d r g r |
 
   %--Bar 47--%
@@ -78,21 +76,21 @@ violinP = \relative c'' {
   fis8. g16 a4 ~ |
   \tuplet 3/2 { a8 a g fis( g) a } |
   d,8. b'16 a8. g16 |
-  \tuplet 3/2 { fis8(a)g fis(a) g} |
+  \tuplet 3/2 { fis8( a)g fis( a) g} |
   fis2 ~ |
 
   %--Bar 54--%
-  \tuplet 3/2 { fis8 \noBeam fis' e d(fis) e } |
+  \tuplet 3/2 { fis8 \noBeam fis' e d( fis) e } |
   d2 ~ |
   d ~ |
   d |
-  \tuplet 3/2 { cis8 (b) a } a'4 ~ |
+  \tuplet 3/2 { cis8( b) a } a'4 ~ |
   \tuplet 3/2 { a8 b a } g4 ~ |
   \tuplet 3/2 { g8 a g } fis4 ~ |
 
   %--Bar 61--%
   \tuplet 3/2 { fis8 b, d e(fis) g } |
-  \tuplet 3/2 { cis,( e) cis a(b) cis } |
+  \tuplet 3/2 { cis,( e) cis a( b) cis } |
   a8. g16 e8. d16 |
   d2 ~ |
   d ~ |
@@ -114,7 +112,7 @@ violinP = \relative c'' {
   d,8. e16 cis8. d16 |
   d2 |
   \tuplet 3/2 {
-    b8-\piano ( d fis) fis( e fis) |
+    b8(-\piano d fis) fis( e fis) |
     b,( d fis) fis( e fis) |
     b,( dis e) e( dis e) |
     ais,( cis e) e( d! e) |
@@ -123,10 +121,10 @@ violinP = \relative c'' {
   }
 
   %--Bar 85--%
-  \tuplet 3/2 { ais,(fis) e' d(e)cis } |
+  \tuplet 3/2 { ais,( fis) e' d( e)cis } |
   b r fis r |
   b r \tuplet 3/2 { cis d e } |
-  \tuplet 3/2 { fis(e) d cis(b) ais } |
+  \tuplet 3/2 { fis( e) d cis( b) ais } |
   b8. fis'16-\forte b8. fis16 |
   g2 ~ |
   g8. g16 \tuplet 3/2 { a8( fis) g } |

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP.ly
@@ -1,7 +1,7 @@
-\version "2.4.0"
+\version "2.18.0"
 \include "header.ly"
 
-#(ly:set-point-and-click 'line-column)
+
 
 violinP =  \relative c'' {
  \clef violin
@@ -12,18 +12,18 @@ violinP =  \relative c'' {
 
  % --Bar 1-- %
 r8 r16 a16 d8. a16 |
-\times 2/3 { b8( a) g  fis( g) a } |
+\tuplet 3/2 { b8( a) g  fis( g) a } |
 d, r cis r |
 d r e r |
-\times 2/3 { fis( a) d  d( cis) d  |
+\tuplet 3/2 { fis( a) d  d( cis) d  |
 b( e) d cis(  fis) e| }
 d r a r |
 b r cis r |
 
 % --Bar 9-- %
-\times 2/3 { d( fis) e  d( fis) e } |
+\tuplet 3/2 { d( fis) e  d( fis) e } |
 d4( d8.) cis 16 |
-\tripletsHide \times 2/3 { d8( e) fis  e( fis) g |
+\tripletsHide \tuplet 3/2 { d8( e) fis  e( fis) g |
 fis( g) fis  e( fis) d |
 cis( e) d  cis( d) e| }
 b r cis r |
@@ -31,69 +31,69 @@ d2~|
 d~|
 
 % --Bar 17-- %
-\times 2/3 { d8 e d  cis( d) e | }
+\tuplet 3/2 { d8 e d  cis( d) e | }
 a,8. fis'16 e8. d16 |
-\times 2/3 { cis8( e) d  cis( e) d | }
+\tuplet 3/2 { cis8( e) d  cis( e) d | }
 cis2 ~ |
-\times 2/3 {cis8 e, d  cis( e) d |}
+\tuplet 3/2 {cis8 e, d  cis( e) d |}
 cis2 |
 b |
 fis'' ~ |
-fis4 \tripletsShowOnce \times 2/3{ e8 fis gis } |
+fis4 \tripletsShowOnce \tuplet 3/2{ e8 fis gis } |
 
 % --Bar 26-- %
-a4 ~ \times 2/3 { a8 b a } |
- \times 2/3 { gis( fis) e } a4 ~ |
+a4 ~ \tuplet 3/2 { a8 b a } |
+ \tuplet 3/2 { gis( fis) e } a4 ~ |
 a gis |
-a ~ \times 2/3 {a8 g! fis } | % remind natural
-e4 ~ \times 2/3 { e8 d cis } |
-\times 2/3 { d( cis) b  a( e') g} |
+a ~ \tuplet 3/2 {a8 g! fis } | % remind natural
+e4 ~ \tuplet 3/2 { e8 d cis } |
+\tuplet 3/2 { d( cis) b  a( e') g} |
 fis r gis r |
 
 % --Bar 33-- %
 a8. a16 d8. a16 |
-\times 2/3 { b8 ( a) g   fis ( g) a } |
+\tuplet 3/2 { b8 ( a) g   fis ( g) a } |
 d, r cis r |
 d r e r |
-\times 2/3 { d ( fis) a   a( g) a } |
-\times 2/3 { fis( b) a   gis( cis) b } |
-a4 ~ \times 2/3 { a8 b cis } |
-\times 2/3 { d cis b   a b g } |
+\tuplet 3/2 { d ( fis) a   a( g) a } |
+\tuplet 3/2 { fis( b) a   gis( cis) b } |
+a4 ~ \tuplet 3/2 { a8 b cis } |
+\tuplet 3/2 { d cis b   a b g } |
 
 %--Bar 41--%
 fis r g r |
 a r c, r |
 b r cis! r |
-d r \times 2/3 { e,( a  cis) } |
-\times 2/3 { fis, ( a) d   e,( a) cis } |
+d r \tuplet 3/2 { e,( a  cis) } |
+\tuplet 3/2 { fis, ( a) d   e,( a) cis } |
 d r g r |
 
 %--Bar 47--%
 fis r d r |
 a r a8. g16 |
 fis8. g16 a4~|
-\times 2/3 { a8 a g  fis( g) a } |
+\tuplet 3/2 { a8 a g  fis( g) a } |
 d,8. b'16 a8. g16 |
-\times 2/3 { fis8(a)g fis(a) g} |
+\tuplet 3/2 { fis8(a)g fis(a) g} |
 fis2~ |
 
 %--Bar 54--%
-\times 2/3 { fis8  \noBeam fis' e  d(fis) e } |
+\tuplet 3/2 { fis8  \noBeam fis' e  d(fis) e } |
 d2~|
 d~ |
 d |
-\times 2/3 { cis8 (b) a } a'4~ |
-\times 2/3 { a8 b a } g4~ |
-\times 2/3 { g8 a g } fis4~ |
+\tuplet 3/2 { cis8 (b) a } a'4~ |
+\tuplet 3/2 { a8 b a } g4~ |
+\tuplet 3/2 { g8 a g } fis4~ |
 
 %--Bar 61--%
-\times 2/3 { fis8 b, d  e(fis) g } |
-\times 2/3 { cis,( e) cis  a(b) cis } |
+\tuplet 3/2 { fis8 b, d  e(fis) g } |
+\tuplet 3/2 { cis,( e) cis  a(b) cis } |
 a8. g16 e8. d16 |
 d2~ |
 d~ |
 d~|
-d4 ~ \times 2/3 { d8 e fis } |
+d4 ~ \tuplet 3/2 { d8 e fis } |
 
 %--Bar 68--%
 e2~ |
@@ -106,10 +106,10 @@ g a~|
 a8. \noBeam a16 d8. a16|
 
 %--Bar 76--%
-\times 2/3 { b8( a) g fis(g) a } |
+\tuplet 3/2 { b8( a) g fis(g) a } |
 d,8. e16 cis8. d16 |
 d2 |
- \times 2/3 { b8-\piano ( d fis) fis( e fis) |
+ \tuplet 3/2 { b8-\piano ( d fis) fis( e fis) |
    b,( d fis) fis( e fis) |
    b,( dis e) e( dis e) |
    ais,( cis e)  e( d! e) |
@@ -118,42 +118,42 @@ d2 |
  }
 
 %--Bar 85--%
-\times 2/3 { ais,(fis) e'  d(e)cis }|
+\tuplet 3/2 { ais,(fis) e'  d(e)cis }|
 b r fis r |
-b r \times 2/3 { cis d e }|
-\times 2/3 { fis(e) d  cis(b) ais }|
+b r \tuplet 3/2 { cis d e }|
+\tuplet 3/2 { fis(e) d  cis(b) ais }|
 b8. fis'16-\forte  b8. fis16 |
 g2~|
-g8. g16  \times 2/3 {a8( fis) g } |
+g8. g16  \tuplet 3/2 {a8( fis) g } |
 fis2~ |
 
 %--Bar 93 --%
 fis8. fis16 b8. g16 |
 
-% \times 2/3 { } |
+% \tuplet 3/2 { } |
  \appoggiatura
    fis16( 
   e2)~ |
-  \times 2/3 { e8 fis g fis(  g) e }  |
-  \times 2/3 { d8( b  cis) d( fis  eis) }  |
-  \times 2/3 { fis8(  gis) a gis(  a) fis }  |
-  \times 2/3 { eis8(  gis) cis b(  a) gis }  |
+  \tuplet 3/2 { e8 fis g fis(  g) e }  |
+  \tuplet 3/2 { d8( b  cis) d( fis  eis) }  |
+  \tuplet 3/2 { fis8(  gis) a gis(  a) fis }  |
+  \tuplet 3/2 { eis8(  gis) cis b(  a) gis }  |
  fis8. \noBeam cis16-\piano 
-  \times 2/3 { cis8( b  cis) }  |
-  \times 2/3 { fis,8( a  cis) cis( b  cis) }  |
-  \times 2/3 { fis,8( ais  b) b( ais  b) }  |
-  \times 2/3 { eis,8( gis  b) b( a  b) }  |
-  \times 2/3 { fis8( a  cis) cis( b  cis) }  |
-  \times 2/3 { gis8 b d d cis d }  |
-  \times 2/3 { eis,8 cis b' a b gis }  |
+  \tuplet 3/2 { cis8( b  cis) }  |
+  \tuplet 3/2 { fis,8( a  cis) cis( b  cis) }  |
+  \tuplet 3/2 { fis,8( ais  b) b( ais  b) }  |
+  \tuplet 3/2 { eis,8( gis  b) b( a  b) }  |
+  \tuplet 3/2 { fis8( a  cis) cis( b  cis) }  |
+  \tuplet 3/2 { gis8 b d d cis d }  |
+  \tuplet 3/2 { eis,8 cis b' a b gis }  |
  fis8 r r4 |
-  \times 2/3 { r8 fis-\forte gis a cis b }  |
+  \tuplet 3/2 { r8 fis-\forte gis a cis b }  |
  cis4 r |
-  \times 2/3 { r8 e, fis gis b a }  |
+  \tuplet 3/2 { r8 e, fis gis b a }  |
  b2\trill |
  a\trill |
  gis~ |
-  \times 2/3 { gis8 eis fis gis(  eis) fis }  |
+  \tuplet 3/2 { gis8 eis fis gis(  eis) fis }  |
  gis4 gis'~ |
  gis4 fis~ |
  fis4 b~ |
@@ -164,52 +164,52 @@ fis8. fis16 b8. g16 |
  a4 gis8. fis16 |
  eis4 e~ |
  e8. \noBeam cis16 fis8. cis16 |
-  \times 2/3 { d8(  cis) b a(  b) cis }  |
+  \tuplet 3/2 { d8(  cis) b a(  b) cis }  |
  fis,4 b~ |
-  \times 2/3 { b8 a gis a(  b) cis }  |
-  \times 2/3 { d8(  b) a }  gis8. fis16 |
+  \tuplet 3/2 { b8 a gis a(  b) cis }  |
+  \tuplet 3/2 { d8(  b) a }  gis8. fis16 |
  fis2~ |
  fis |
  r8 r16 fis' b8. fis16 |
-  \times 2/3 { g!8(  fis) e dis(  e) fis }  |
-  \times 2/3 { b,8(  e) g b(  a) b }  |
-  \times 2/3 { e,8(  d) cis }  d4~ |
-  \times 4/6 { d8 cis e }  a8. e16 |
-  \times 2/3 { fis8(  e) d cis d e }  |
+  \tuplet 3/2 { g!8(  fis) e dis(  e) fis }  |
+  \tuplet 3/2 { b,8(  e) g b(  a) b }  |
+  \tuplet 3/2 { e,8(  d) cis }  d4~ |
+  \tuplet 6/4 { d8 cis e }  a8. e16 |
+  \tuplet 3/2 { fis8(  e) d cis d e }  |
  a,8. gis16 
-  \times 2/3 { fis8( a) d }  |
+  \tuplet 3/2 { fis8( a) d }  |
  d8. 
-  \times 2/3 { cis32 b a gis8 b e }  |
+  \tuplet 3/2 { cis32 b a gis8 b e }  |
  e8. 
-  \times 2/3 { d32 cis b a8(  cis) fis }  |
+  \tuplet 3/2 { d32 cis b a8(  cis) fis }  |
  fis8. 
-  \times 2/3 { e32 d cis b8(  d) gis }  |
+  \tuplet 3/2 { e32 d cis b8(  d) gis }  |
   gis8.
-  \times 2/3 { fis32 e d cis8(  e) a }  |
+  \tuplet 3/2 { fis32 e d cis8(  e) a }  |
  a8. 
-  \times 2/3 { g32 fis e d8 fis b }  |
-  \times 2/3 { e,8(  fis ) gis }  a4~ |
+  \tuplet 3/2 { g32 fis e d8 fis b }  |
+  \tuplet 3/2 { e,8(  fis ) gis }  a4~ |
  a2~ |
  a~ |
-  \times 2/3 { a8 gis fis b(  cis) a }  |
-  \times 2/3 { gis8(  fis) e }  a8. d,16 |
+  \tuplet 3/2 { a8 gis fis b(  cis) a }  |
+  \tuplet 3/2 { gis8(  fis) e }  a8. d,16 |
  cis8 r b\trill r |
  a8.-\piano cis16 
-  \times 2/3 { cis8 b cis }  |
-  \times 2/3 { e,8( a  cis) cis( b  cis) }  |
-  \times 2/3 { fis,8( g!  a) b( cis  a) }  |
-  \times 2/3 { d,8( gis  b) b( a  b) }  |
-  \times 2/3 { e,8( a  cis) cis( b  cis) }  |
-  \times 2/3 { d,8( fis  b) b( gis  a) }  |
-  \times 2/3 { b8(  gis ) a e(  a) gis }  |
+  \tuplet 3/2 { cis8 b cis }  |
+  \tuplet 3/2 { e,8( a  cis) cis( b  cis) }  |
+  \tuplet 3/2 { fis,8( g!  a) b( cis  a) }  |
+  \tuplet 3/2 { d,8( gis  b) b( a  b) }  |
+  \tuplet 3/2 { e,8( a  cis) cis( b  cis) }  |
+  \tuplet 3/2 { d,8( fis  b) b( gis  a) }  |
+  \tuplet 3/2 { b8(  gis ) a e(  a) gis }  |
  a8 r r4 |
  R2 |
  r8 r16 b-\piano e8. b16 |
-  \times 2/3 { c8(  b) a g a b }  |
+  \tuplet 3/2 { c8(  b) a g a b }  |
  e,4 r |
  R2 |
  r8 r16 fis b8. fis16 |
-  \times 2/3 { g8(  fis) e d(  e) fis }  |
+  \tuplet 3/2 { g8(  fis) e d(  e) fis }  |
  b,4 r |
  R2 |
  R2 |
@@ -229,51 +229,51 @@ fis8. fis16 b8. g16 |
  r8 r16 g b8. g16 |
  e4 r |
  r8 r16 a d8. a16 |
-  \times 2/3 { b8(  a) g fis(  g) a }  |
+  \tuplet 3/2 { b8(  a) g fis(  g) a }  |
  d,4 r |
  R2 |
  r8 r16 e a8. e16 |
-  \times 2/3 { fis8(  e) d cis(  d) e }  |
+  \tuplet 3/2 { fis8(  e) d cis(  d) e }  |
  a,4 r |
  R2 |
-  \times 2/3 { cis'8-\piano(  a) b cis(  a) b }  |
+  \tuplet 3/2 { cis'8-\piano(  a) b cis(  a) b }  |
  cis2 ~ |
-  \times 2/3 { cis8 \noBeam e d cis(  e) d }  |
+  \tuplet 3/2 { cis8 \noBeam e d cis(  e) d }  |
  cis4 r |
  r4 r8 r16 b |
  e4~ e8. a,16 |
  d4~ d8. e16 |
  cis4~ cis8. cis16 |
-  \times 2/3 { \tripletsShowOnce d8(  cis) b  \tripletsShowOnce a(  gis) fis }  |
+  \tuplet 3/2 { \tripletsShowOnce d8(  cis) b  \tripletsShowOnce a(  gis) fis }  |
  e8. cis'16 gis'4~ |
-  \times 2/3 { gis8 fis eis fis(  gis) a }  |
+  \tuplet 3/2 { gis8 fis eis fis(  gis) a }  |
  b2~ |
-  \times 2/3 { b8 a gis a b cis }  |
+  \tuplet 3/2 { b8 a gis a b cis }  |
  d2~ |
-  \times 2/3 { d8 cis b cis(  d) e }  |
+  \tuplet 3/2 { d8 cis b cis(  d) e }  |
  ais,4 b~ |
-  \times 2/3 { b8 a! gis a b c }  |
+  \tuplet 3/2 { b8 a! gis a b c }  |
  dis,4 e~ |
-  \times 2/3 { e8 fis e dis cis b }  |
+  \tuplet 3/2 { e8 fis e dis cis b }  |
  g'2~ |
-  \times 2/3 { g8 fis, g a b c }  |
+  \tuplet 3/2 { g8 fis, g a b c }  |
  d2~ |
-  \times 2/3 { d8 c b }  c4~ |
-  \times 2/3 { c8 b a b( c) a }  |
+  \tuplet 3/2 { d8 c b }  c4~ |
+  \tuplet 3/2 { c8 b a b( c) a }  |
  a4 a'~ |
-  \times 2/3 { a8 g fis g( a) g }  |
+  \tuplet 3/2 { a8 g fis g( a) g }  |
  fis2~ |
-  \times 2/3 { fis8 e d }  e4~ |
-  \times 2/3 { e8 fis e d(  cis) b }  |
-  \times 2/3 { ais8( gis  ais) b( cis  d) }  |
-  \times 2/3 { e8( fis  e) d( cis  b) }  |
+  \tuplet 3/2 { fis8 e d }  e4~ |
+  \tuplet 3/2 { e8 fis e d(  cis) b }  |
+  \tuplet 3/2 { ais8( gis  ais) b( cis  d) }  |
+  \tuplet 3/2 { e8( fis  e) d( cis  b) }  |
  ais4~ 
-  \times 2/3 { ais8 b cis }  |
-  \times 2/3 { b8( cis  d) cis( d  e) }  |
+  \tuplet 3/2 { ais8 b cis }  |
+  \tuplet 3/2 { b8( cis  d) cis( d  e) }  |
  ais,8. b16 
-  \tripletsShowOnce \times 2/3 { cis8( d e) }  |
-  \tripletsShowOnce \times 2/3 { fis8( ais,) b }  fis'8. cis16 |
-  \times 2/3 { d8(  cis) b ais(  b) cis }  |
+  \tripletsShowOnce \tuplet 3/2 { cis8( d e) }  |
+  \tripletsShowOnce \tuplet 3/2 { fis8( ais,) b }  fis'8. cis16 |
+  \tuplet 3/2 { d8(  cis) b ais(  b) cis }  |
  fis,2 |
  gis |
  ais |
@@ -283,79 +283,79 @@ fis8. fis16 b8. g16 |
  d8 r d\trill r |
  b4 r |
  r8 r16 a d8. a16 |
-  \tripletsShow \times 2/3 { b8(  a) g fis(  g) a }  |
+  \tripletsShow \tuplet 3/2 { b8(  a) g fis(  g) a }  |
  d,8 r cis r |
  d8 r e r |
-  \times 2/3 { fis8(  a) d d(  cis) d }  |
-  \times 2/3 { b8( e) d cis( fis) e }  |
+  \tuplet 3/2 { fis8(  a) d d(  cis) d }  |
+  \tuplet 3/2 { b8( e) d cis( fis) e }  |
  d8 r a r |
  b8 r cis r |
-  \times 2/3 { d8(  fis) e d(  fis) e }  | \tripletsHide
+  \tuplet 3/2 { d8(  fis) e d(  fis) e }  | \tripletsHide
  d4~ d8. cis16 |
-  \times 2/3 { d8(  e) fis e(  fis) g }  |
-  \times 2/3 { fis8(  g) fis e(  fis) d }  |
-  \times 2/3 { cis8(  e) d cis(  d) e }  |
+  \tuplet 3/2 { d8(  e) fis e(  fis) g }  |
+  \tuplet 3/2 { fis8(  g) fis e(  fis) d }  |
+  \tuplet 3/2 { cis8(  e) d cis(  d) e }  |
  b8 r cis r |
  d2~ |
  d~ |
-  \times 2/3 { d8 e d cis( d) e }  |
+  \tuplet 3/2 { d8 e d cis( d) e }  |
  a,8. fis'16 e8. d16 |
-  \times 2/3 { cis8( e) d cis( e) d }  |
+  \tuplet 3/2 { cis8( e) d cis( e) d }  |
  cis2~ |
-  \times 2/3 { cis8 e, d cis(  e) d }  |
+  \tuplet 3/2 { cis8 e, d cis(  e) d }  |
  cis2 |
  b |
  fis''~ |
  fis4 
-  \tripletsShowOnce \times 2/3 { e8 fis gis }  |
+  \tripletsShowOnce \tuplet 3/2 { e8 fis gis }  |
  a4~ 
-  \times 4/6 { a8 b a }  |
-  \times 2/3 { gis8(  fis) e }  a4~ |
+  \tuplet 6/4 { a8 b a }  |
+  \tuplet 3/2 { gis8(  fis) e }  a4~ |
  a gis |
  a4~ 
-  \times 4/6 { a8 g! fis }  |
+  \tuplet 6/4 { a8 g! fis }  |
  e4~ 
-  \times 4/6 { e8 d cis }  |
-  \times 2/3 { d8(  cis) b a(  e') g }  |
+  \tuplet 6/4 { e8 d cis }  |
+  \tuplet 3/2 { d8(  cis) b a(  e') g }  |
  fis8 r gis r |
  a8. \noBeam a16 d8. a16 |
-  \times 2/3 { b8(  a) g fis(  g) a }  |
+  \tuplet 3/2 { b8(  a) g fis(  g) a }  |
  d,8 r cis r |
  b8 r e r |
-  \times 2/3 { d8(  fis) a a(  g) a }  |
-  \times 2/3 { fis8(  b) a gis(  cis) b }  |
+  \tuplet 3/2 { d8(  fis) a a(  g) a }  |
+  \tuplet 3/2 { fis8(  b) a gis(  cis) b }  |
  a4~ 
-  \times 2/3 { a8 b cis }  |
-  \times 2/3 { d8(  cis) b a(  b) g }  |
+  \tuplet 3/2 { a8 b cis }  |
+  \tuplet 3/2 { d8(  cis) b a(  b) g }  |
  fis8 r g r |
  a8 r c, r |
  b8 r cis! r |
  d8 r 
-  \times 2/3 { e,( a  cis) }  |
-  \times 2/3 { fis,8( a  d) e,( a  cis) }  |
+  \tuplet 3/2 { e,( a  cis) }  |
+  \tuplet 3/2 { fis,8( a  d) e,( a  cis) }  |
  d8 r g r |
  fis8 r d r |
  a8 r a8. g16 |
  fis8. g16 a4~ |
-  \times 2/3 { a8 a g fis( g) a }  |
+  \tuplet 3/2 { a8 a g fis( g) a }  |
  d,8. b'16 a8. g16 |
-  \times 2/3 { fis8(  a) g fis(  a) g }  |
+  \tuplet 3/2 { fis8(  a) g fis(  a) g }  |
  fis2~ |
-  \times 2/3 { fis8 \noBeam fis' e d(  fis) e }  |
+  \tuplet 3/2 { fis8 \noBeam fis' e d(  fis) e }  |
  d2~ |
  d~ |
  d |
-  \times 2/3 { cis8(  b) a }  a'4~ |
-  \times 2/3 { a8 b a }  g4~ |
-  \times 2/3 { g8 a g }  fis4~ |
-  \times 2/3 { fis8 b, d e(  fis) g }  |
-  \times 2/3 { cis,8(  e) cis a b cis }  |
+  \tuplet 3/2 { cis8(  b) a }  a'4~ |
+  \tuplet 3/2 { a8 b a }  g4~ |
+  \tuplet 3/2 { g8 a g }  fis4~ |
+  \tuplet 3/2 { fis8 b, d e(  fis) g }  |
+  \tuplet 3/2 { cis,8(  e) cis a b cis }  |
  fis,8. g16 e8. d16 |
  d2~ |
  d~ |
  d~ |
  d4~ 
-  \times 2/3 { d8 e fis }  |
+  \tuplet 3/2 { d8 e fis }  |
  e2~ |
  e~ |
  e~ |
@@ -364,7 +364,7 @@ fis8. fis16 b8. g16 |
  fis4 g~ |
  g4 a~ |
  a8. \noBeam a16 d8. a16 |
-  \times 2/3 { b8(  a) g fis(  g) a }  |
+  \tuplet 3/2 { b8(  a) g fis(  g) a }  |
  d,8. e16 cis8. d16 |
  d2-\fermata \bar "|." 
 }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP.ly
@@ -6,8 +6,6 @@ violinP = \relative c'' {
   \key d \major
   \time 2/4
 
-  \commonSettings
-
   % --Bar 1-- %
   r8 r16 a16 d8. a16 |
   \tuplet 3/2 { b8( a) g fis( g) a } |
@@ -23,7 +21,8 @@ violinP = \relative c'' {
   % --Bar 9-- %
   \tuplet 3/2 { d( fis) e d( fis) e } |
   d4( d8.) cis 16 |
-  \tripletsHide \tuplet 3/2 {
+  \omit TupletNumber
+  \tuplet 3/2 {
     d8( e) fis e( fis) g |
     fis( g) fis e( fis) d |
     cis( e) d cis( d) e |
@@ -41,7 +40,8 @@ violinP = \relative c'' {
   cis2 |
   b |
   fis'' ~ |
-  fis4 \tripletsShowOnce \tuplet 3/2 { e8 fis gis } |
+  fis4 \onceShowTupletNumber
+  \tuplet 3/2 { e8 fis gis } |
 
   % --Bar 26-- %
   a4 ~ \tuplet 3/2 { a8 b a } |
@@ -134,21 +134,21 @@ violinP = \relative c'' {
   fis8. fis16 b8. g16 |
 
   % \tuplet 3/2 { } |
-  \appoggiatura
-  fis16(
-  e2) ~ |
-  \tuplet 3/2 { e8 fis g fis( g) e } |
-  \tuplet 3/2 { d8( b cis) d( fis eis) } |
-  \tuplet 3/2 { fis8( gis) a gis( a) fis } |
-  \tuplet 3/2 { eis8( gis) cis b( a) gis } |
+  \appoggiatura fis16 e2 ~ |
+  \tuplet 3/2 { e8 fis g fis( g) e |
+  d8( b cis) d( fis eis) |
+  fis8( gis) a gis( a) fis |
+  eis8( gis) cis b( a) gis  |
+  }
   fis8. \noBeam cis16-\piano
-  \tuplet 3/2 { cis8( b cis) } |
-  \tuplet 3/2 { fis,8( a cis) cis( b cis) } |
-  \tuplet 3/2 { fis,8( ais b) b( ais b) } |
-  \tuplet 3/2 { eis,8( gis b) b( a b) } |
-  \tuplet 3/2 { fis8( a cis) cis( b cis) } |
-  \tuplet 3/2 { gis8 b d d cis d } |
-  \tuplet 3/2 { eis,8 cis b' a b gis } |
+  \tuplet 3/2 { cis8( b cis) |
+  fis,8( a cis) cis( b cis)  |
+   fis,8( ais b) b( ais b)  |
+   eis,8( gis b) b( a b)  |
+   fis8( a cis) cis( b cis)  |
+   gis8 b d d cis d  |
+   eis,8 cis b' a b gis  |
+   }
   fis8 r r4 |
   \tuplet 3/2 { r8 fis-\forte gis a cis b } |
   cis4 r |
@@ -174,23 +174,18 @@ violinP = \relative c'' {
   fis2 ~ |
   fis |
   r8 r16 fis' b8. fis16 |
-  \tuplet 3/2 { g!8( fis) e dis( e) fis } |
+  \tuplet 3/2 { g!8( fis) e dis( e) fis |}
   \tuplet 3/2 { b,8( e) g b( a) b } |
   \tuplet 3/2 { e,8( d) cis } d4 ~ |
-  \tuplet 6/4 { d8 cis e } a8. e16 |
+  \tuplet 3/2 { d8 cis e } a8. e16 |
   \tuplet 3/2 { fis8( e) d cis d e } |
   a,8. gis16
   \tuplet 3/2 { fis8( a) d } |
-  d8.
-  \tuplet 3/2 { cis32 b a gis8 b e } |
-  e8.
-  \tuplet 3/2 { d32 cis b a8( cis) fis } |
-  fis8.
-  \tuplet 3/2 { e32 d cis b8( d) gis } |
-  gis8.
-  \tuplet 3/2 { fis32 e d cis8( e) a } |
-  a8.
-  \tuplet 3/2 { g32 fis e d8 fis b } |
+  d8. \tuplet 3/2 16 { cis32 b a } \tuplet 3/2 { gis8 b e } |
+  e8. \tuplet 3/2 16 { d32 cis b } \tuplet 3/2 { a8( cis) fis } |
+  fis8. \tuplet 3/2 16 { e32 d cis } \tuplet 3/2 { b8( d) gis } |
+  gis8. \tuplet 3/2 16 { fis32 e d } \tuplet 3/2 { cis8( e) a } |
+  a8. \tuplet 3/2 { g32 fis e } \tuplet 3/2 { d8 fis b } |
   \tuplet 3/2 { e,8( fis ) gis } a4 ~ |
   a2 ~ |
   a ~ |
@@ -198,13 +193,13 @@ violinP = \relative c'' {
   \tuplet 3/2 { gis8( fis) e } a8. d,16 |
   cis8 r b\trill r |
   a8.-\piano cis16
-  \tuplet 3/2 { cis8 b cis } |
-  \tuplet 3/2 { e,8( a cis) cis( b cis) } |
-  \tuplet 3/2 { fis,8( g! a) b( cis a) } |
-  \tuplet 3/2 { d,8( gis b) b( a b) } |
-  \tuplet 3/2 { e,8( a cis) cis( b cis) } |
-  \tuplet 3/2 { d,8( fis b) b( gis a) } |
-  \tuplet 3/2 { b8( gis ) a e( a) gis } |
+  \tuplet 3/2 { cis8 b cis  |
+   e,8( a cis) cis( b cis)  |
+   fis,8( g! a) b( cis a)  |
+   d,8( gis b) b( a b)  |
+   e,8( a cis) cis( b cis)  |
+   d,8( fis b) b( gis a)  |
+  b8( gis ) a e( a) gis  |}
   a8 r r4 |
   R2 |
   r8 r16 b-\piano e8. b16 |
@@ -214,19 +209,7 @@ violinP = \relative c'' {
   r8 r16 fis b8. fis16 |
   \tuplet 3/2 { g8( fis) e d( e) fis } |
   b,4 r |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
-  R2 |
+  R2*13 |
   r8 r16 a' cis8. a16 |
   fis4 r |
   r8 r16 g b8. g16 |
@@ -247,7 +230,7 @@ violinP = \relative c'' {
   e4 ~ e8. a,16 |
   d4 ~ d8. e16 |
   cis4 ~ cis8. cis16 |
-  \tuplet 3/2 { \tripletsShowOnce d8( cis) b \tripletsShowOnce a( gis) fis } |
+  \tuplet 3/2 { \onceShowTupletNumber d8( cis) b \onceShowTupletNumber a( gis) fis } |
   e8. cis'16 gis'4 ~ |
   \tuplet 3/2 { gis8 fis eis fis( gis) a } |
   b2 ~ |
@@ -274,8 +257,8 @@ violinP = \relative c'' {
   \tuplet 3/2 { ais8 b cis } |
   \tuplet 3/2 { b8( cis d) cis( d e) } |
   ais,8. b16
-  \tripletsShowOnce \tuplet 3/2 { cis8( d e) } |
-  \tripletsShowOnce \tuplet 3/2 { fis8( ais,) b } fis'8. cis16 |
+  \onceShowTupletNumber \tuplet 3/2 { cis8( d e) } |
+  \onceShowTupletNumber \tuplet 3/2 { fis8( ais,) b } fis'8. cis16 |
   \tuplet 3/2 { d8( cis) b ais( b) cis } |
   fis,2 |
   gis |
@@ -286,14 +269,16 @@ violinP = \relative c'' {
   d8 r d\trill r |
   b4 r |
   r8 r16 a d8. a16 |
-  \tripletsShow \tuplet 3/2 { b8( a) g fis( g) a } |
+  \undo \omit TupletNumber
+  \tuplet 3/2 { b8( a) g fis( g) a } |
   d,8 r cis r |
   d8 r e r |
   \tuplet 3/2 { fis8( a) d d( cis) d } |
   \tuplet 3/2 { b8( e) d cis( fis) e } |
   d8 r a r |
   b8 r cis r |
-  \tuplet 3/2 { d8( fis) e d( fis) e } | \tripletsHide
+  \tuplet 3/2 { d8( fis) e d( fis) e } |
+  \omit TupletNumber
   d4 ~ d8. cis16 |
   \tuplet 3/2 { d8( e) fis e( fis) g } |
   \tuplet 3/2 { fis8( g) fis e( fis) d } |
@@ -310,7 +295,8 @@ violinP = \relative c'' {
   b |
   fis'' ~ |
   fis4
-  \tripletsShowOnce \tuplet 3/2 { e8 fis gis } |
+  \onceShowTupletNumber
+  \tuplet 3/2 { e8 fis gis } |
   a4 ~
   \tuplet 6/4 { a8 b a } |
   \tuplet 3/2 { gis8( fis) e } a4 ~ |

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP.ly
@@ -4,141 +4,146 @@
 
 
 violinP =  \relative c'' {
- \clef violin
- \key d \major
- \time 2/4
- 
- \commonSettings
+  \clef violin
+  \key d \major
+  \time 2/4
 
- % --Bar 1-- %
-r8 r16 a16 d8. a16 |
-\tuplet 3/2 { b8( a) g  fis( g) a } |
-d, r cis r |
-d r e r |
-\tuplet 3/2 { fis( a) d  d( cis) d  |
-b( e) d cis(  fis) e| }
-d r a r |
-b r cis r |
+  \commonSettings
 
-% --Bar 9-- %
-\tuplet 3/2 { d( fis) e  d( fis) e } |
-d4( d8.) cis 16 |
-\tripletsHide \tuplet 3/2 { d8( e) fis  e( fis) g |
-fis( g) fis  e( fis) d |
-cis( e) d  cis( d) e| }
-b r cis r |
-d2~|
-d~|
+  % --Bar 1-- %
+  r8 r16 a16 d8. a16 |
+  \tuplet 3/2 { b8( a) g  fis( g) a } |
+  d, r cis r |
+  d r e r |
+  \tuplet 3/2 {
+    fis( a) d  d( cis) d  |
+    b( e) d cis(  fis) e|
+  }
+  d r a r |
+  b r cis r |
 
-% --Bar 17-- %
-\tuplet 3/2 { d8 e d  cis( d) e | }
-a,8. fis'16 e8. d16 |
-\tuplet 3/2 { cis8( e) d  cis( e) d | }
-cis2 ~ |
-\tuplet 3/2 {cis8 e, d  cis( e) d |}
-cis2 |
-b |
-fis'' ~ |
-fis4 \tripletsShowOnce \tuplet 3/2{ e8 fis gis } |
+  % --Bar 9-- %
+  \tuplet 3/2 { d( fis) e  d( fis) e } |
+  d4( d8.) cis 16 |
+  \tripletsHide \tuplet 3/2 {
+    d8( e) fis  e( fis) g |
+    fis( g) fis  e( fis) d |
+    cis( e) d  cis( d) e|
+  }
+  b r cis r |
+  d2~|
+  d~|
 
-% --Bar 26-- %
-a4 ~ \tuplet 3/2 { a8 b a } |
- \tuplet 3/2 { gis( fis) e } a4 ~ |
-a gis |
-a ~ \tuplet 3/2 {a8 g! fis } | % remind natural
-e4 ~ \tuplet 3/2 { e8 d cis } |
-\tuplet 3/2 { d( cis) b  a( e') g} |
-fis r gis r |
+  % --Bar 17-- %
+  \tuplet 3/2 { d8 e d  cis( d) e | }
+  a,8. fis'16 e8. d16 |
+  \tuplet 3/2 { cis8( e) d  cis( e) d | }
+  cis2 ~ |
+  \tuplet 3/2 {cis8 e, d  cis( e) d |}
+  cis2 |
+  b |
+  fis'' ~ |
+  fis4 \tripletsShowOnce \tuplet 3/2{ e8 fis gis } |
 
-% --Bar 33-- %
-a8. a16 d8. a16 |
-\tuplet 3/2 { b8 ( a) g   fis ( g) a } |
-d, r cis r |
-d r e r |
-\tuplet 3/2 { d ( fis) a   a( g) a } |
-\tuplet 3/2 { fis( b) a   gis( cis) b } |
-a4 ~ \tuplet 3/2 { a8 b cis } |
-\tuplet 3/2 { d cis b   a b g } |
+  % --Bar 26-- %
+  a4 ~ \tuplet 3/2 { a8 b a } |
+  \tuplet 3/2 { gis( fis) e } a4 ~ |
+  a gis |
+  a ~ \tuplet 3/2 {a8 g! fis } | % remind natural
+  e4 ~ \tuplet 3/2 { e8 d cis } |
+  \tuplet 3/2 { d( cis) b  a( e') g} |
+  fis r gis r |
 
-%--Bar 41--%
-fis r g r |
-a r c, r |
-b r cis! r |
-d r \tuplet 3/2 { e,( a  cis) } |
-\tuplet 3/2 { fis, ( a) d   e,( a) cis } |
-d r g r |
+  % --Bar 33-- %
+  a8. a16 d8. a16 |
+  \tuplet 3/2 { b8 ( a) g   fis ( g) a } |
+  d, r cis r |
+  d r e r |
+  \tuplet 3/2 { d ( fis) a   a( g) a } |
+  \tuplet 3/2 { fis( b) a   gis( cis) b } |
+  a4 ~ \tuplet 3/2 { a8 b cis } |
+  \tuplet 3/2 { d cis b   a b g } |
 
-%--Bar 47--%
-fis r d r |
-a r a8. g16 |
-fis8. g16 a4~|
-\tuplet 3/2 { a8 a g  fis( g) a } |
-d,8. b'16 a8. g16 |
-\tuplet 3/2 { fis8(a)g fis(a) g} |
-fis2~ |
+  %--Bar 41--%
+  fis r g r |
+  a r c, r |
+  b r cis! r |
+  d r \tuplet 3/2 { e,( a  cis) } |
+  \tuplet 3/2 { fis, ( a) d   e,( a) cis } |
+  d r g r |
 
-%--Bar 54--%
-\tuplet 3/2 { fis8  \noBeam fis' e  d(fis) e } |
-d2~|
-d~ |
-d |
-\tuplet 3/2 { cis8 (b) a } a'4~ |
-\tuplet 3/2 { a8 b a } g4~ |
-\tuplet 3/2 { g8 a g } fis4~ |
+  %--Bar 47--%
+  fis r d r |
+  a r a8. g16 |
+  fis8. g16 a4~|
+  \tuplet 3/2 { a8 a g  fis( g) a } |
+  d,8. b'16 a8. g16 |
+  \tuplet 3/2 { fis8(a)g fis(a) g} |
+  fis2~ |
 
-%--Bar 61--%
-\tuplet 3/2 { fis8 b, d  e(fis) g } |
-\tuplet 3/2 { cis,( e) cis  a(b) cis } |
-a8. g16 e8. d16 |
-d2~ |
-d~ |
-d~|
-d4 ~ \tuplet 3/2 { d8 e fis } |
+  %--Bar 54--%
+  \tuplet 3/2 { fis8  \noBeam fis' e  d(fis) e } |
+  d2~|
+  d~ |
+  d |
+  \tuplet 3/2 { cis8 (b) a } a'4~ |
+  \tuplet 3/2 { a8 b a } g4~ |
+  \tuplet 3/2 { g8 a g } fis4~ |
 
-%--Bar 68--%
-e2~ |
-e ~ |
-e ~|
-e4 e' ~|
-e fis~|
-fis g~|
-g a~|
-a8. \noBeam a16 d8. a16|
+  %--Bar 61--%
+  \tuplet 3/2 { fis8 b, d  e(fis) g } |
+  \tuplet 3/2 { cis,( e) cis  a(b) cis } |
+  a8. g16 e8. d16 |
+  d2~ |
+  d~ |
+  d~|
+  d4 ~ \tuplet 3/2 { d8 e fis } |
 
-%--Bar 76--%
-\tuplet 3/2 { b8( a) g fis(g) a } |
-d,8. e16 cis8. d16 |
-d2 |
- \tuplet 3/2 { b8-\piano ( d fis) fis( e fis) |
-   b,( d fis) fis( e fis) |
-   b,( dis e) e( dis e) |
-   ais,( cis e)  e( d! e) |
-   b( d fis) fis( e fis) |
-   cis( e g) g( fis g) |
- }
+  %--Bar 68--%
+  e2~ |
+  e ~ |
+  e ~|
+  e4 e' ~|
+  e fis~|
+  fis g~|
+  g a~|
+  a8. \noBeam a16 d8. a16|
 
-%--Bar 85--%
-\tuplet 3/2 { ais,(fis) e'  d(e)cis }|
-b r fis r |
-b r \tuplet 3/2 { cis d e }|
-\tuplet 3/2 { fis(e) d  cis(b) ais }|
-b8. fis'16-\forte  b8. fis16 |
-g2~|
-g8. g16  \tuplet 3/2 {a8( fis) g } |
-fis2~ |
+  %--Bar 76--%
+  \tuplet 3/2 { b8( a) g fis(g) a } |
+  d,8. e16 cis8. d16 |
+  d2 |
+  \tuplet 3/2 {
+    b8-\piano ( d fis) fis( e fis) |
+    b,( d fis) fis( e fis) |
+    b,( dis e) e( dis e) |
+    ais,( cis e)  e( d! e) |
+    b( d fis) fis( e fis) |
+    cis( e g) g( fis g) |
+  }
 
-%--Bar 93 --%
-fis8. fis16 b8. g16 |
+  %--Bar 85--%
+  \tuplet 3/2 { ais,(fis) e'  d(e)cis }|
+  b r fis r |
+  b r \tuplet 3/2 { cis d e }|
+  \tuplet 3/2 { fis(e) d  cis(b) ais }|
+  b8. fis'16-\forte  b8. fis16 |
+  g2~|
+  g8. g16  \tuplet 3/2 {a8( fis) g } |
+  fis2~ |
 
-% \tuplet 3/2 { } |
- \appoggiatura
-   fis16( 
+  %--Bar 93 --%
+  fis8. fis16 b8. g16 |
+
+  % \tuplet 3/2 { } |
+  \appoggiatura
+  fis16(
   e2)~ |
   \tuplet 3/2 { e8 fis g fis(  g) e }  |
   \tuplet 3/2 { d8( b  cis) d( fis  eis) }  |
   \tuplet 3/2 { fis8(  gis) a gis(  a) fis }  |
   \tuplet 3/2 { eis8(  gis) cis b(  a) gis }  |
- fis8. \noBeam cis16-\piano 
+  fis8. \noBeam cis16-\piano
   \tuplet 3/2 { cis8( b  cis) }  |
   \tuplet 3/2 { fis,8( a  cis) cis( b  cis) }  |
   \tuplet 3/2 { fis,8( ais  b) b( ais  b) }  |
@@ -146,55 +151,55 @@ fis8. fis16 b8. g16 |
   \tuplet 3/2 { fis8( a  cis) cis( b  cis) }  |
   \tuplet 3/2 { gis8 b d d cis d }  |
   \tuplet 3/2 { eis,8 cis b' a b gis }  |
- fis8 r r4 |
+  fis8 r r4 |
   \tuplet 3/2 { r8 fis-\forte gis a cis b }  |
- cis4 r |
+  cis4 r |
   \tuplet 3/2 { r8 e, fis gis b a }  |
- b2\trill |
- a\trill |
- gis~ |
+  b2\trill |
+  a\trill |
+  gis~ |
   \tuplet 3/2 { gis8 eis fis gis(  eis) fis }  |
- gis4 gis'~ |
- gis4 fis~ |
- fis4 b~ |
- b4 a~ |
- a4 d~ |
- d4 cis8. b16 |
- a2~ |
- a4 gis8. fis16 |
- eis4 e~ |
- e8. \noBeam cis16 fis8. cis16 |
+  gis4 gis'~ |
+  gis4 fis~ |
+  fis4 b~ |
+  b4 a~ |
+  a4 d~ |
+  d4 cis8. b16 |
+  a2~ |
+  a4 gis8. fis16 |
+  eis4 e~ |
+  e8. \noBeam cis16 fis8. cis16 |
   \tuplet 3/2 { d8(  cis) b a(  b) cis }  |
- fis,4 b~ |
+  fis,4 b~ |
   \tuplet 3/2 { b8 a gis a(  b) cis }  |
   \tuplet 3/2 { d8(  b) a }  gis8. fis16 |
- fis2~ |
- fis |
- r8 r16 fis' b8. fis16 |
+  fis2~ |
+  fis |
+  r8 r16 fis' b8. fis16 |
   \tuplet 3/2 { g!8(  fis) e dis(  e) fis }  |
   \tuplet 3/2 { b,8(  e) g b(  a) b }  |
   \tuplet 3/2 { e,8(  d) cis }  d4~ |
   \tuplet 6/4 { d8 cis e }  a8. e16 |
   \tuplet 3/2 { fis8(  e) d cis d e }  |
- a,8. gis16 
+  a,8. gis16
   \tuplet 3/2 { fis8( a) d }  |
- d8. 
+  d8.
   \tuplet 3/2 { cis32 b a gis8 b e }  |
- e8. 
+  e8.
   \tuplet 3/2 { d32 cis b a8(  cis) fis }  |
- fis8. 
+  fis8.
   \tuplet 3/2 { e32 d cis b8(  d) gis }  |
   gis8.
   \tuplet 3/2 { fis32 e d cis8(  e) a }  |
- a8. 
+  a8.
   \tuplet 3/2 { g32 fis e d8 fis b }  |
   \tuplet 3/2 { e,8(  fis ) gis }  a4~ |
- a2~ |
- a~ |
+  a2~ |
+  a~ |
   \tuplet 3/2 { a8 gis fis b(  cis) a }  |
   \tuplet 3/2 { gis8(  fis) e }  a8. d,16 |
- cis8 r b\trill r |
- a8.-\piano cis16 
+  cis8 r b\trill r |
+  a8.-\piano cis16
   \tuplet 3/2 { cis8 b cis }  |
   \tuplet 3/2 { e,8( a  cis) cis( b  cis) }  |
   \tuplet 3/2 { fis,8( g!  a) b( cis  a) }  |
@@ -202,169 +207,169 @@ fis8. fis16 b8. g16 |
   \tuplet 3/2 { e,8( a  cis) cis( b  cis) }  |
   \tuplet 3/2 { d,8( fis  b) b( gis  a) }  |
   \tuplet 3/2 { b8(  gis ) a e(  a) gis }  |
- a8 r r4 |
- R2 |
- r8 r16 b-\piano e8. b16 |
+  a8 r r4 |
+  R2 |
+  r8 r16 b-\piano e8. b16 |
   \tuplet 3/2 { c8(  b) a g a b }  |
- e,4 r |
- R2 |
- r8 r16 fis b8. fis16 |
+  e,4 r |
+  R2 |
+  r8 r16 fis b8. fis16 |
   \tuplet 3/2 { g8(  fis) e d(  e) fis }  |
- b,4 r |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- R2 |
- r8 r16 a' cis8. a16 |
- fis4 r |
- r8 r16 g b8. g16 |
- e4 r |
- r8 r16 a d8. a16 |
+  b,4 r |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  R2 |
+  r8 r16 a' cis8. a16 |
+  fis4 r |
+  r8 r16 g b8. g16 |
+  e4 r |
+  r8 r16 a d8. a16 |
   \tuplet 3/2 { b8(  a) g fis(  g) a }  |
- d,4 r |
- R2 |
- r8 r16 e a8. e16 |
+  d,4 r |
+  R2 |
+  r8 r16 e a8. e16 |
   \tuplet 3/2 { fis8(  e) d cis(  d) e }  |
- a,4 r |
- R2 |
+  a,4 r |
+  R2 |
   \tuplet 3/2 { cis'8-\piano(  a) b cis(  a) b }  |
- cis2 ~ |
+  cis2 ~ |
   \tuplet 3/2 { cis8 \noBeam e d cis(  e) d }  |
- cis4 r |
- r4 r8 r16 b |
- e4~ e8. a,16 |
- d4~ d8. e16 |
- cis4~ cis8. cis16 |
+  cis4 r |
+  r4 r8 r16 b |
+  e4~ e8. a,16 |
+  d4~ d8. e16 |
+  cis4~ cis8. cis16 |
   \tuplet 3/2 { \tripletsShowOnce d8(  cis) b  \tripletsShowOnce a(  gis) fis }  |
- e8. cis'16 gis'4~ |
+  e8. cis'16 gis'4~ |
   \tuplet 3/2 { gis8 fis eis fis(  gis) a }  |
- b2~ |
+  b2~ |
   \tuplet 3/2 { b8 a gis a b cis }  |
- d2~ |
+  d2~ |
   \tuplet 3/2 { d8 cis b cis(  d) e }  |
- ais,4 b~ |
+  ais,4 b~ |
   \tuplet 3/2 { b8 a! gis a b c }  |
- dis,4 e~ |
+  dis,4 e~ |
   \tuplet 3/2 { e8 fis e dis cis b }  |
- g'2~ |
+  g'2~ |
   \tuplet 3/2 { g8 fis, g a b c }  |
- d2~ |
+  d2~ |
   \tuplet 3/2 { d8 c b }  c4~ |
   \tuplet 3/2 { c8 b a b( c) a }  |
- a4 a'~ |
+  a4 a'~ |
   \tuplet 3/2 { a8 g fis g( a) g }  |
- fis2~ |
+  fis2~ |
   \tuplet 3/2 { fis8 e d }  e4~ |
   \tuplet 3/2 { e8 fis e d(  cis) b }  |
   \tuplet 3/2 { ais8( gis  ais) b( cis  d) }  |
   \tuplet 3/2 { e8( fis  e) d( cis  b) }  |
- ais4~ 
+  ais4~
   \tuplet 3/2 { ais8 b cis }  |
   \tuplet 3/2 { b8( cis  d) cis( d  e) }  |
- ais,8. b16 
+  ais,8. b16
   \tripletsShowOnce \tuplet 3/2 { cis8( d e) }  |
   \tripletsShowOnce \tuplet 3/2 { fis8( ais,) b }  fis'8. cis16 |
   \tuplet 3/2 { d8(  cis) b ais(  b) cis }  |
- fis,2 |
- gis |
- ais |
- b |
- cis |
- d8. e16 fis8. g16 |
- d8 r d\trill r |
- b4 r |
- r8 r16 a d8. a16 |
+  fis,2 |
+  gis |
+  ais |
+  b |
+  cis |
+  d8. e16 fis8. g16 |
+  d8 r d\trill r |
+  b4 r |
+  r8 r16 a d8. a16 |
   \tripletsShow \tuplet 3/2 { b8(  a) g fis(  g) a }  |
- d,8 r cis r |
- d8 r e r |
+  d,8 r cis r |
+  d8 r e r |
   \tuplet 3/2 { fis8(  a) d d(  cis) d }  |
   \tuplet 3/2 { b8( e) d cis( fis) e }  |
- d8 r a r |
- b8 r cis r |
+  d8 r a r |
+  b8 r cis r |
   \tuplet 3/2 { d8(  fis) e d(  fis) e }  | \tripletsHide
- d4~ d8. cis16 |
+  d4~ d8. cis16 |
   \tuplet 3/2 { d8(  e) fis e(  fis) g }  |
   \tuplet 3/2 { fis8(  g) fis e(  fis) d }  |
   \tuplet 3/2 { cis8(  e) d cis(  d) e }  |
- b8 r cis r |
- d2~ |
- d~ |
+  b8 r cis r |
+  d2~ |
+  d~ |
   \tuplet 3/2 { d8 e d cis( d) e }  |
- a,8. fis'16 e8. d16 |
+  a,8. fis'16 e8. d16 |
   \tuplet 3/2 { cis8( e) d cis( e) d }  |
- cis2~ |
+  cis2~ |
   \tuplet 3/2 { cis8 e, d cis(  e) d }  |
- cis2 |
- b |
- fis''~ |
- fis4 
+  cis2 |
+  b |
+  fis''~ |
+  fis4
   \tripletsShowOnce \tuplet 3/2 { e8 fis gis }  |
- a4~ 
+  a4~
   \tuplet 6/4 { a8 b a }  |
   \tuplet 3/2 { gis8(  fis) e }  a4~ |
- a gis |
- a4~ 
+  a gis |
+  a4~
   \tuplet 6/4 { a8 g! fis }  |
- e4~ 
+  e4~
   \tuplet 6/4 { e8 d cis }  |
   \tuplet 3/2 { d8(  cis) b a(  e') g }  |
- fis8 r gis r |
- a8. \noBeam a16 d8. a16 |
+  fis8 r gis r |
+  a8. \noBeam a16 d8. a16 |
   \tuplet 3/2 { b8(  a) g fis(  g) a }  |
- d,8 r cis r |
- b8 r e r |
+  d,8 r cis r |
+  b8 r e r |
   \tuplet 3/2 { d8(  fis) a a(  g) a }  |
   \tuplet 3/2 { fis8(  b) a gis(  cis) b }  |
- a4~ 
+  a4~
   \tuplet 3/2 { a8 b cis }  |
   \tuplet 3/2 { d8(  cis) b a(  b) g }  |
- fis8 r g r |
- a8 r c, r |
- b8 r cis! r |
- d8 r 
+  fis8 r g r |
+  a8 r c, r |
+  b8 r cis! r |
+  d8 r
   \tuplet 3/2 { e,( a  cis) }  |
   \tuplet 3/2 { fis,8( a  d) e,( a  cis) }  |
- d8 r g r |
- fis8 r d r |
- a8 r a8. g16 |
- fis8. g16 a4~ |
+  d8 r g r |
+  fis8 r d r |
+  a8 r a8. g16 |
+  fis8. g16 a4~ |
   \tuplet 3/2 { a8 a g fis( g) a }  |
- d,8. b'16 a8. g16 |
+  d,8. b'16 a8. g16 |
   \tuplet 3/2 { fis8(  a) g fis(  a) g }  |
- fis2~ |
+  fis2~ |
   \tuplet 3/2 { fis8 \noBeam fis' e d(  fis) e }  |
- d2~ |
- d~ |
- d |
+  d2~ |
+  d~ |
+  d |
   \tuplet 3/2 { cis8(  b) a }  a'4~ |
   \tuplet 3/2 { a8 b a }  g4~ |
   \tuplet 3/2 { g8 a g }  fis4~ |
   \tuplet 3/2 { fis8 b, d e(  fis) g }  |
   \tuplet 3/2 { cis,8(  e) cis a b cis }  |
- fis,8. g16 e8. d16 |
- d2~ |
- d~ |
- d~ |
- d4~ 
+  fis,8. g16 e8. d16 |
+  d2~ |
+  d~ |
+  d~ |
+  d4~
   \tuplet 3/2 { d8 e fis }  |
- e2~ |
- e~ |
- e~ |
- e4 e'~ |
- e fis~ |
- fis4 g~ |
- g4 a~ |
- a8. \noBeam a16 d8. a16 |
+  e2~ |
+  e~ |
+  e~ |
+  e4 e'~ |
+  e fis~ |
+  fis4 g~ |
+  g4 a~ |
+  a8. \noBeam a16 d8. a16 |
   \tuplet 3/2 { b8(  a) g fis(  g) a }  |
- d,8. e16 cis8. d16 |
- d2-\fermata \bar "|." 
+  d,8. e16 cis8. d16 |
+  d2-\fermata \bar "|."
 }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP.ly
@@ -2,6 +2,7 @@
 \include "header.ly"
 
 violinP = \relative c'' {
+  \tempo "Allegro."
   \clef violin
   \key d \major
   \time 2/4

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP.ly
@@ -6,354 +6,281 @@ violinP = \relative c'' {
   \key d \major
   \time 2/4
 
-  % --Bar 1-- %
-  r8 r16 a16 d8. a16 |
-  \tuplet 3/2 { b8( a) g fis( g) a } |
-  d, r cis r |
-  d r e r |
-  \tuplet 3/2 {
-    fis( a) d d( cis) d |
-    b( e) d cis( fis) e |
+  \repeat unfold 2 {
+    % --Bar 1-- %
+    r8 r16 a d8. a16 |
+    \undo \omit TupletNumber
+    \tuplet 3/2 { b8( a) g fis( g) a } |
+    d,8 r cis r |
+    d8 r e r |
+    \tuplet 3/2 { fis8( a) d d( cis) d } |
+    \tuplet 3/2 { b8( e) d cis( fis) e } |
+    d8 r a r |
+    b8 r cis r |
+
+    % --Bar 9-- %
+    \tuplet 3/2 { d8( fis) e d( fis) e } |
+    \omit TupletNumber
+    d4 ~ d8. cis16 |
+    \tuplet 3/2 { d8( e) fis e( fis) g } |
+    \tuplet 3/2 { fis8( g) fis e( fis) d } |
+    \tuplet 3/2 { cis8( e) d cis( d) e } |
+    b8 r cis r |
+    d2 ~ |
+    d ~ |
+
+    % --Bar 17-- %
+    \tuplet 3/2 { d8 e d cis( d) e } |
+    a,8. fis'16 e8. d16 |
+    \tuplet 3/2 { cis8( e) d cis( e) d } |
+    cis2 ~ |
+    \tuplet 3/2 { cis8 e, d cis( e) d } |
+    cis2 |
+    b |
+    fis'' ~ |
+    fis4
+    \onceShowTupletNumber
+    \tuplet 3/2 { e8 fis gis } |
+
+    % --Bar 26-- %
+    a4 ~ \tuplet 3/2 { a8 b a } |
+    \tuplet 3/2 { gis8( fis) e } a4 ~ |
+    a4 gis |
+    a4 ~ \tuplet 3/2 { a8 g! fis } |
+    e4 ~ \tuplet 3/2 { e8 d cis } |
+    \tuplet 3/2 { d8( cis) b a( e') g } |
+    fis8 r gis r |
+
+    % --Bar 33-- %
+    a8. \noBeam a16 d8. a16 |
+    \tuplet 3/2 { b8( a) g fis( g) a } |
+    d,8 r cis r |
+    b8 r e r |
+    \tuplet 3/2 { d8( fis) a a( g) a } |
+    \tuplet 3/2 { fis8( b) a gis( cis) b } |
+    a4 ~ \tuplet 3/2 { a8 b cis } |
+    \tuplet 3/2 { d8( cis) b a( b) g } |
+
+    %--Bar 41--%
+    fis8 r g r |
+    a8 r c, r |
+    b8 r cis! r |
+    d8 r \tuplet 3/2 { e,( a cis) } |
+    \tuplet 3/2 { fis,8( a d) e,( a cis) } |
+    d8 r g r |
+
+    %--Bar 47--%
+    fis8 r d r |
+    a8 r a8. g16 |
+    fis8. g16 a4 ~ |
+    \tuplet 3/2 { a8 a g fis( g) a } |
+    d,8. b'16 a8. g16 |
+    \tuplet 3/2 { fis8( a) g fis( a) g } |
+    fis2 ~ |
+
+    %--Bar 54--%
+    \tuplet 3/2 { fis8 \noBeam fis' e d( fis) e } |
+    d2 ~ |
+    d ~ |
+    d |
+    \tuplet 3/2 { cis8( b) a } a'4 ~ |
+    \tuplet 3/2 { a8 b a } g4 ~ |
+    \tuplet 3/2 { g8 a g } fis4 ~ |
+
+    %--Bar 61--%
+    \tuplet 3/2 { fis8 b, d e( fis) g } |
+    \tuplet 3/2 { cis,8( e) cis a( b) cis } |
+    fis,8. g16 e8. d16 |
+    d2 ~ |
+    d ~ |
+    d ~ |
+    d4 ~ \tuplet 3/2 { d8 e fis } |
+
+    %--Bar 68--%
+    e2 ~ |
+    e ~ |
+    e ~ |
+    e4 e' ~ |
+    e fis ~ |
+    fis4 g ~ |
+    g4 a ~ |
+    a8. \noBeam a16 d8. a16 |
+
+    %--Bar 76--%
+    \tuplet 3/2 { b8( a) g fis( g) a } |
+    d,8. e16 cis8. d16 |
+
+
   }
-  d r a r |
-  b r cis r |
+  \alternative {
+    {
+      d2 |
 
-  % --Bar 9-- %
-  \tuplet 3/2 { d( fis) e d( fis) e } |
-  d4( d8.) cis 16 |
-  \omit TupletNumber
-  \tuplet 3/2 {
-    d8( e) fis e( fis) g |
-    fis( g) fis e( fis) d |
-    cis( e) d cis( d) e |
+      \tuplet 3/2 {
+        b8(-\piano d fis) fis( e fis) |
+        b,( d fis) fis( e fis) |
+        b,( dis e) e( dis e) |
+        ais,( cis e) e( d! e) |
+        b( d fis) fis( e fis) |
+        cis( e g) g( fis g) |
+      }
+
+      %--Bar 85--%
+      \tuplet 3/2 { ais,( fis) e' d( e)cis } |
+      b r fis r |
+      b r \tuplet 3/2 { cis d e } |
+      \tuplet 3/2 { fis( e) d cis( b) ais } |
+      b8. fis'16-\forte b8. fis16 |
+      g2 ~ |
+      g8. g16 \tuplet 3/2 { a8( fis) g } |
+      fis2 ~ |
+
+      %--Bar 93 --%
+      fis8. fis16 b8. g16 |
+
+      % \tuplet 3/2 { } |
+      \appoggiatura fis16 e2 ~ |
+      \tuplet 3/2 {
+        e8 fis g fis( g) e |
+        d8( b cis) d( fis eis) |
+        fis8( gis) a gis( a) fis |
+        eis8( gis) cis b( a) gis  |
+      }
+      fis8. \noBeam cis16-\piano
+      \tuplet 3/2 {
+        cis8( b cis) |
+        fis,8( a cis) cis( b cis)  |
+        fis,8( ais b) b( ais b)  |
+        eis,8( gis b) b( a b)  |
+        fis8( a cis) cis( b cis)  |
+        gis8 b d d cis d  |
+        eis,8 cis b' a b gis  |
+      }
+      fis8 r r4 |
+      \tuplet 3/2 { r8 fis-\forte gis a cis b } |
+      cis4 r |
+      \tuplet 3/2 { r8 e, fis gis b a } |
+      b2\trill |
+      a\trill |
+      gis ~ |
+      \tuplet 3/2 { gis8 eis fis gis( eis) fis } |
+      gis4 gis' ~ |
+      gis4 fis ~ |
+      fis4 b ~ |
+      b4 a ~ |
+      a4 d ~ |
+      d4 cis8. b16 |
+      a2 ~ |
+      a4 gis8. fis16 |
+      eis4 e ~ |
+      e8. \noBeam cis16 fis8. cis16 |
+      \tuplet 3/2 { d8( cis) b a( b) cis } |
+      fis,4 b ~ |
+      \tuplet 3/2 { b8 a gis a( b) cis } |
+      \tuplet 3/2 { d8( b) a } gis8. fis16 |
+      fis2 ~ |
+      fis |
+      r8 r16 fis' b8. fis16 |
+      \tuplet 3/2 { g!8( fis) e dis( e) fis |}
+      \tuplet 3/2 { b,8( e) g b( a) b } |
+      \tuplet 3/2 { e,8( d) cis } d4 ~ |
+      \tuplet 3/2 { d8 cis e } a8. e16 |
+      \tuplet 3/2 { fis8( e) d cis d e } |
+      a,8. gis16
+      \tuplet 3/2 { fis8( a) d } |
+      d8. \tuplet 3/2 16 { cis32 b a } \tuplet 3/2 { gis8 b e } |
+      e8. \tuplet 3/2 16 { d32 cis b } \tuplet 3/2 { a8( cis) fis } |
+      fis8. \tuplet 3/2 16 { e32 d cis } \tuplet 3/2 { b8( d) gis } |
+      gis8. \tuplet 3/2 16 { fis32 e d } \tuplet 3/2 { cis8( e) a } |
+      a8. \tuplet 3/2 { g32 fis e } \tuplet 3/2 { d8 fis b } |
+      \tuplet 3/2 { e,8( fis ) gis } a4 ~ |
+      a2 ~ |
+      a ~ |
+      \tuplet 3/2 { a8 gis fis b( cis) a } |
+      \tuplet 3/2 { gis8( fis) e } a8. d,16 |
+      cis8 r b\trill r |
+      a8.-\piano cis16
+      \tuplet 3/2 {
+        cis8 b cis  |
+        e,8( a cis) cis( b cis)  |
+        fis,8( g! a) b( cis a)  |
+        d,8( gis b) b( a b)  |
+        e,8( a cis) cis( b cis)  |
+        d,8( fis b) b( gis a)  |
+        b8( gis ) a e( a) gis  |
+      }
+      a8 r r4 |
+      R2 |
+      r8 r16 b-\piano e8. b16 |
+      \tuplet 3/2 { c8( b) a g a b } |
+      e,4 r |
+      R2 |
+      r8 r16 fis b8. fis16 |
+      \tuplet 3/2 { g8( fis) e d( e) fis } |
+      b,4 r |
+      R2*13 |
+      r8 r16 a' cis8. a16 |
+      fis4 r |
+      r8 r16 g b8. g16 |
+      e4 r |
+      r8 r16 a d8. a16 |
+      \tuplet 3/2 { b8( a) g fis( g) a } |
+      d,4 r |
+      R2 |
+      r8 r16 e a8. e16 |
+      \tuplet 3/2 { fis8( e) d cis( d) e } |
+      a,4 r |
+      R2 |
+      \tuplet 3/2 { cis'8-\piano( a) b cis( a) b } |
+      cis2 ~ |
+      \tuplet 3/2 { cis8 \noBeam e d cis( e) d } |
+      cis4 r |
+      r4 r8 r16 b |
+      e4 ~ e8. a,16 |
+      d4 ~ d8. e16 |
+      cis4 ~ cis8. cis16 |
+      \tuplet 3/2 { \onceShowTupletNumber d8( cis) b \onceShowTupletNumber a( gis) fis } |
+      e8. cis'16 gis'4 ~ |
+      \tuplet 3/2 { gis8 fis eis fis( gis) a } |
+      b2 ~ |
+      \tuplet 3/2 { b8 a gis a b cis } |
+      d2 ~ |
+      \tuplet 3/2 { d8 cis b cis( d) e } |
+      ais,4 b ~ |
+      \tuplet 3/2 { b8 a! gis a b c } |
+      dis,4 e ~ |
+      \tuplet 3/2 { e8 fis e dis cis b } |
+      g'2 ~ |
+      \tuplet 3/2 { g8 fis, g a b c } |
+      d2 ~ |
+      \tuplet 3/2 { d8 c b } c4 ~ |
+      \tuplet 3/2 { c8 b a b( c) a } |
+      a4 a' ~ |
+      \tuplet 3/2 { a8 g fis g( a) g } |
+      fis2 ~ |
+      \tuplet 3/2 { fis8 e d } e4 ~ |
+      \tuplet 3/2 { e8 fis e d( cis) b } |
+      \tuplet 3/2 { ais8( gis ais) b( cis d) } |
+      \tuplet 3/2 { e8( fis e) d( cis b) } |
+      ais4 ~
+      \tuplet 3/2 { ais8 b cis } |
+      \tuplet 3/2 { b8( cis d) cis( d e) } |
+      ais,8. b16
+      \onceShowTupletNumber \tuplet 3/2 { cis8( d e) } |
+      \onceShowTupletNumber \tuplet 3/2 { fis8( ais,) b } fis'8. cis16 |
+      \tuplet 3/2 { d8( cis) b ais( b) cis } |
+      fis,2 |
+      gis |
+      ais |
+      b |
+      cis |
+      d8. e16 fis8. g16 |
+      d8 r d\trill r |
+      b4 r |
+    }
+    {
+      d2-\fermata \bar "|."
+    }
   }
-  b r cis r |
-  d2 ~ |
-  d ~ |
-
-  % --Bar 17-- %
-  \tuplet 3/2 { d8 e d cis( d) e | }
-  a,8. fis'16 e8. d16 |
-  \tuplet 3/2 { cis8( e) d cis( e) d | }
-  cis2 ~ |
-  \tuplet 3/2 { cis8 e, d cis( e) d | }
-  cis2 |
-  b |
-  fis'' ~ |
-  fis4 \onceShowTupletNumber
-  \tuplet 3/2 { e8 fis gis } |
-
-  % --Bar 26-- %
-  a4 ~ \tuplet 3/2 { a8 b a } |
-  \tuplet 3/2 { gis( fis) e } a4 ~ |
-  a gis |
-  a ~ \tuplet 3/2 { a8 g! fis } | % remind natural
-  e4 ~ \tuplet 3/2 { e8 d cis } |
-  \tuplet 3/2 { d( cis) b a( e') g} |
-  fis r gis r |
-
-  % --Bar 33-- %
-  a8. a16 d8. a16 |
-  \tuplet 3/2 { b8( a) g fis( g) a } |
-  d, r cis r |
-  d r e r |
-  \tuplet 3/2 { d( fis) a a( g) a } |
-  \tuplet 3/2 { fis( b) a gis( cis) b } |
-  a4 ~ \tuplet 3/2 { a8 b cis } |
-  \tuplet 3/2 { d cis b a b g } |
-
-  %--Bar 41--%
-  fis r g r |
-  a r c, r |
-  b r cis! r |
-  d r \tuplet 3/2 { e,( a cis) } |
-  \tuplet 3/2 { fis,( a) d e,( a) cis } |
-  d r g r |
-
-  %--Bar 47--%
-  fis r d r |
-  a r a8. g16 |
-  fis8. g16 a4 ~ |
-  \tuplet 3/2 { a8 a g fis( g) a } |
-  d,8. b'16 a8. g16 |
-  \tuplet 3/2 { fis8( a)g fis( a) g} |
-  fis2 ~ |
-
-  %--Bar 54--%
-  \tuplet 3/2 { fis8 \noBeam fis' e d( fis) e } |
-  d2 ~ |
-  d ~ |
-  d |
-  \tuplet 3/2 { cis8( b) a } a'4 ~ |
-  \tuplet 3/2 { a8 b a } g4 ~ |
-  \tuplet 3/2 { g8 a g } fis4 ~ |
-
-  %--Bar 61--%
-  \tuplet 3/2 { fis8 b, d e(fis) g } |
-  \tuplet 3/2 { cis,( e) cis a( b) cis } |
-  a8. g16 e8. d16 |
-  d2 ~ |
-  d ~ |
-  d ~ |
-  d4 ~ \tuplet 3/2 { d8 e fis } |
-
-  %--Bar 68--%
-  e2 ~ |
-  e ~ |
-  e ~ |
-  e4 e' ~ |
-  e fis ~ |
-  fis g ~ |
-  g a ~ |
-  a8. \noBeam a16 d8. a16 |
-
-  %--Bar 76--%
-  \tuplet 3/2 { b8( a) g fis(g) a } |
-  d,8. e16 cis8. d16 |
-  d2 |
-  \tuplet 3/2 {
-    b8(-\piano d fis) fis( e fis) |
-    b,( d fis) fis( e fis) |
-    b,( dis e) e( dis e) |
-    ais,( cis e) e( d! e) |
-    b( d fis) fis( e fis) |
-    cis( e g) g( fis g) |
-  }
-
-  %--Bar 85--%
-  \tuplet 3/2 { ais,( fis) e' d( e)cis } |
-  b r fis r |
-  b r \tuplet 3/2 { cis d e } |
-  \tuplet 3/2 { fis( e) d cis( b) ais } |
-  b8. fis'16-\forte b8. fis16 |
-  g2 ~ |
-  g8. g16 \tuplet 3/2 { a8( fis) g } |
-  fis2 ~ |
-
-  %--Bar 93 --%
-  fis8. fis16 b8. g16 |
-
-  % \tuplet 3/2 { } |
-  \appoggiatura fis16 e2 ~ |
-  \tuplet 3/2 { e8 fis g fis( g) e |
-  d8( b cis) d( fis eis) |
-  fis8( gis) a gis( a) fis |
-  eis8( gis) cis b( a) gis  |
-  }
-  fis8. \noBeam cis16-\piano
-  \tuplet 3/2 { cis8( b cis) |
-  fis,8( a cis) cis( b cis)  |
-   fis,8( ais b) b( ais b)  |
-   eis,8( gis b) b( a b)  |
-   fis8( a cis) cis( b cis)  |
-   gis8 b d d cis d  |
-   eis,8 cis b' a b gis  |
-   }
-  fis8 r r4 |
-  \tuplet 3/2 { r8 fis-\forte gis a cis b } |
-  cis4 r |
-  \tuplet 3/2 { r8 e, fis gis b a } |
-  b2\trill |
-  a\trill |
-  gis ~ |
-  \tuplet 3/2 { gis8 eis fis gis( eis) fis } |
-  gis4 gis' ~ |
-  gis4 fis ~ |
-  fis4 b ~ |
-  b4 a ~ |
-  a4 d ~ |
-  d4 cis8. b16 |
-  a2 ~ |
-  a4 gis8. fis16 |
-  eis4 e ~ |
-  e8. \noBeam cis16 fis8. cis16 |
-  \tuplet 3/2 { d8( cis) b a( b) cis } |
-  fis,4 b ~ |
-  \tuplet 3/2 { b8 a gis a( b) cis } |
-  \tuplet 3/2 { d8( b) a } gis8. fis16 |
-  fis2 ~ |
-  fis |
-  r8 r16 fis' b8. fis16 |
-  \tuplet 3/2 { g!8( fis) e dis( e) fis |}
-  \tuplet 3/2 { b,8( e) g b( a) b } |
-  \tuplet 3/2 { e,8( d) cis } d4 ~ |
-  \tuplet 3/2 { d8 cis e } a8. e16 |
-  \tuplet 3/2 { fis8( e) d cis d e } |
-  a,8. gis16
-  \tuplet 3/2 { fis8( a) d } |
-  d8. \tuplet 3/2 16 { cis32 b a } \tuplet 3/2 { gis8 b e } |
-  e8. \tuplet 3/2 16 { d32 cis b } \tuplet 3/2 { a8( cis) fis } |
-  fis8. \tuplet 3/2 16 { e32 d cis } \tuplet 3/2 { b8( d) gis } |
-  gis8. \tuplet 3/2 16 { fis32 e d } \tuplet 3/2 { cis8( e) a } |
-  a8. \tuplet 3/2 { g32 fis e } \tuplet 3/2 { d8 fis b } |
-  \tuplet 3/2 { e,8( fis ) gis } a4 ~ |
-  a2 ~ |
-  a ~ |
-  \tuplet 3/2 { a8 gis fis b( cis) a } |
-  \tuplet 3/2 { gis8( fis) e } a8. d,16 |
-  cis8 r b\trill r |
-  a8.-\piano cis16
-  \tuplet 3/2 { cis8 b cis  |
-   e,8( a cis) cis( b cis)  |
-   fis,8( g! a) b( cis a)  |
-   d,8( gis b) b( a b)  |
-   e,8( a cis) cis( b cis)  |
-   d,8( fis b) b( gis a)  |
-  b8( gis ) a e( a) gis  |}
-  a8 r r4 |
-  R2 |
-  r8 r16 b-\piano e8. b16 |
-  \tuplet 3/2 { c8( b) a g a b } |
-  e,4 r |
-  R2 |
-  r8 r16 fis b8. fis16 |
-  \tuplet 3/2 { g8( fis) e d( e) fis } |
-  b,4 r |
-  R2*13 |
-  r8 r16 a' cis8. a16 |
-  fis4 r |
-  r8 r16 g b8. g16 |
-  e4 r |
-  r8 r16 a d8. a16 |
-  \tuplet 3/2 { b8( a) g fis( g) a } |
-  d,4 r |
-  R2 |
-  r8 r16 e a8. e16 |
-  \tuplet 3/2 { fis8( e) d cis( d) e } |
-  a,4 r |
-  R2 |
-  \tuplet 3/2 { cis'8-\piano( a) b cis( a) b } |
-  cis2 ~ |
-  \tuplet 3/2 { cis8 \noBeam e d cis( e) d } |
-  cis4 r |
-  r4 r8 r16 b |
-  e4 ~ e8. a,16 |
-  d4 ~ d8. e16 |
-  cis4 ~ cis8. cis16 |
-  \tuplet 3/2 { \onceShowTupletNumber d8( cis) b \onceShowTupletNumber a( gis) fis } |
-  e8. cis'16 gis'4 ~ |
-  \tuplet 3/2 { gis8 fis eis fis( gis) a } |
-  b2 ~ |
-  \tuplet 3/2 { b8 a gis a b cis } |
-  d2 ~ |
-  \tuplet 3/2 { d8 cis b cis( d) e } |
-  ais,4 b ~ |
-  \tuplet 3/2 { b8 a! gis a b c } |
-  dis,4 e ~ |
-  \tuplet 3/2 { e8 fis e dis cis b } |
-  g'2 ~ |
-  \tuplet 3/2 { g8 fis, g a b c } |
-  d2 ~ |
-  \tuplet 3/2 { d8 c b } c4 ~ |
-  \tuplet 3/2 { c8 b a b( c) a } |
-  a4 a' ~ |
-  \tuplet 3/2 { a8 g fis g( a) g } |
-  fis2 ~ |
-  \tuplet 3/2 { fis8 e d } e4 ~ |
-  \tuplet 3/2 { e8 fis e d( cis) b } |
-  \tuplet 3/2 { ais8( gis ais) b( cis d) } |
-  \tuplet 3/2 { e8( fis e) d( cis b) } |
-  ais4 ~
-  \tuplet 3/2 { ais8 b cis } |
-  \tuplet 3/2 { b8( cis d) cis( d e) } |
-  ais,8. b16
-  \onceShowTupletNumber \tuplet 3/2 { cis8( d e) } |
-  \onceShowTupletNumber \tuplet 3/2 { fis8( ais,) b } fis'8. cis16 |
-  \tuplet 3/2 { d8( cis) b ais( b) cis } |
-  fis,2 |
-  gis |
-  ais |
-  b |
-  cis |
-  d8. e16 fis8. g16 |
-  d8 r d\trill r |
-  b4 r |
-  r8 r16 a d8. a16 |
-  \undo \omit TupletNumber
-  \tuplet 3/2 { b8( a) g fis( g) a } |
-  d,8 r cis r |
-  d8 r e r |
-  \tuplet 3/2 { fis8( a) d d( cis) d } |
-  \tuplet 3/2 { b8( e) d cis( fis) e } |
-  d8 r a r |
-  b8 r cis r |
-  \tuplet 3/2 { d8( fis) e d( fis) e } |
-  \omit TupletNumber
-  d4 ~ d8. cis16 |
-  \tuplet 3/2 { d8( e) fis e( fis) g } |
-  \tuplet 3/2 { fis8( g) fis e( fis) d } |
-  \tuplet 3/2 { cis8( e) d cis( d) e } |
-  b8 r cis r |
-  d2 ~ |
-  d ~ |
-  \tuplet 3/2 { d8 e d cis( d) e } |
-  a,8. fis'16 e8. d16 |
-  \tuplet 3/2 { cis8( e) d cis( e) d } |
-  cis2 ~ |
-  \tuplet 3/2 { cis8 e, d cis( e) d } |
-  cis2 |
-  b |
-  fis'' ~ |
-  fis4
-  \onceShowTupletNumber
-  \tuplet 3/2 { e8 fis gis } |
-  a4 ~
-  \tuplet 6/4 { a8 b a } |
-  \tuplet 3/2 { gis8( fis) e } a4 ~ |
-  a gis |
-  a4 ~
-  \tuplet 6/4 { a8 g! fis } |
-  e4 ~
-  \tuplet 6/4 { e8 d cis } |
-  \tuplet 3/2 { d8( cis) b a( e') g } |
-  fis8 r gis r |
-  a8. \noBeam a16 d8. a16 |
-  \tuplet 3/2 { b8( a) g fis( g) a } |
-  d,8 r cis r |
-  b8 r e r |
-  \tuplet 3/2 { d8( fis) a a( g) a } |
-  \tuplet 3/2 { fis8( b) a gis( cis) b } |
-  a4 ~
-  \tuplet 3/2 { a8 b cis } |
-  \tuplet 3/2 { d8( cis) b a( b) g } |
-  fis8 r g r |
-  a8 r c, r |
-  b8 r cis! r |
-  d8 r
-  \tuplet 3/2 { e,( a cis) } |
-  \tuplet 3/2 { fis,8( a d) e,( a cis) } |
-  d8 r g r |
-  fis8 r d r |
-  a8 r a8. g16 |
-  fis8. g16 a4 ~ |
-  \tuplet 3/2 { a8 a g fis( g) a } |
-  d,8. b'16 a8. g16 |
-  \tuplet 3/2 { fis8( a) g fis( a) g } |
-  fis2 ~ |
-  \tuplet 3/2 { fis8 \noBeam fis' e d( fis) e } |
-  d2 ~ |
-  d ~ |
-  d |
-  \tuplet 3/2 { cis8( b) a } a'4 ~ |
-  \tuplet 3/2 { a8 b a } g4 ~ |
-  \tuplet 3/2 { g8 a g } fis4 ~ |
-  \tuplet 3/2 { fis8 b, d e( fis) g } |
-  \tuplet 3/2 { cis,8( e) cis a b cis } |
-  fis,8. g16 e8. d16 |
-  d2 ~ |
-  d ~ |
-  d ~ |
-  d4 ~
-  \tuplet 3/2 { d8 e fis } |
-  e2 ~ |
-  e ~ |
-  e ~ |
-  e4 e' ~ |
-  e fis ~ |
-  fis4 g ~ |
-  g4 a ~ |
-  a8. \noBeam a16 d8. a16 |
-  \tuplet 3/2 { b8( a) g fis( g) a } |
-  d,8. e16 cis8. d16 |
-  d2-\fermata \bar "|."
 }
+

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violinP.ly
@@ -28,7 +28,7 @@ violinP = \relative c'' {
     \tuplet 3/2 { cis8( e) d cis( d) e } |
     b8 r cis r |
     d2 ~ |
-    d ~ |
+    d2 ~ |
 
     % --Bar 17-- %
     \tuplet 3/2 { d8 e d cis( d) e } |
@@ -37,8 +37,8 @@ violinP = \relative c'' {
     cis2 ~ |
     \tuplet 3/2 { cis8 e, d cis( e) d } |
     cis2 |
-    b |
-    fis'' ~ |
+    b2 |
+    fis''2 ~ |
     fis4
     \onceShowTupletNumber
     \tuplet 3/2 { e8 fis gis } |
@@ -82,8 +82,8 @@ violinP = \relative c'' {
     %--Bar 54--%
     \tuplet 3/2 { fis8 \noBeam fis' e d( fis) e } |
     d2 ~ |
-    d ~ |
-    d |
+    d2 ~ |
+    d2 |
     \tuplet 3/2 { cis8( b) a } a'4 ~ |
     \tuplet 3/2 { a8 b a } g4 ~ |
     \tuplet 3/2 { g8 a g } fis4 ~ |
@@ -93,16 +93,16 @@ violinP = \relative c'' {
     \tuplet 3/2 { cis,8( e) cis a( b) cis } |
     fis,8. g16 e8. d16 |
     d2 ~ |
-    d ~ |
-    d ~ |
+    d2 ~ |
+    d2 ~ |
     d4 ~ \tuplet 3/2 { d8 e fis } |
 
     %--Bar 68--%
     e2 ~ |
-    e ~ |
-    e ~ |
+    e2 ~ |
+    e2 ~ |
     e4 e' ~ |
-    e fis ~ |
+    e4 fis ~ |
     fis4 g ~ |
     g4 a ~ |
     a8. \noBeam a16 d8. a16 |
@@ -119,18 +119,18 @@ violinP = \relative c'' {
 
       \tuplet 3/2 {
         b8(-\piano d fis) fis( e fis) |
-        b,( d fis) fis( e fis) |
-        b,( dis e) e( dis e) |
-        ais,( cis e) e( d! e) |
-        b( d fis) fis( e fis) |
-        cis( e g) g( fis g) |
+        b,8( d fis) fis( e fis) |
+        b,8( dis e) e( dis e) |
+        ais,8( cis e) e( d! e) |
+        b8( d fis) fis( e fis) |
+        cis8( e g) g( fis g) |
       }
 
       %--Bar 85--%
-      \tuplet 3/2 { ais,( fis) e' d( e)cis } |
-      b r fis r |
-      b r \tuplet 3/2 { cis d e } |
-      \tuplet 3/2 { fis( e) d cis( b) ais } |
+      \tuplet 3/2 { ais,8( fis) e' d( e)cis } |
+      b8 r fis r |
+      b8 r \tuplet 3/2 { cis d e } |
+      \tuplet 3/2 { fis8( e) d cis( b) ais } |
       b8. fis'16-\forte b8. fis16 |
       g2 ~ |
       g8. g16 \tuplet 3/2 { a8( fis) g } |
@@ -162,8 +162,8 @@ violinP = \relative c'' {
       cis4 r |
       \tuplet 3/2 { r8 e, fis gis b a } |
       b2\trill |
-      a\trill |
-      gis ~ |
+      a2\trill |
+      gis2 ~ |
       \tuplet 3/2 { gis8 eis fis gis( eis) fis } |
       gis4 gis' ~ |
       gis4 fis ~ |
@@ -180,7 +180,7 @@ violinP = \relative c'' {
       \tuplet 3/2 { b8 a gis a( b) cis } |
       \tuplet 3/2 { d8( b) a } gis8. fis16 |
       fis2 ~ |
-      fis |
+      fis2 |
       r8 r16 fis' b8. fis16 |
       \tuplet 3/2 { g!8( fis) e dis( e) fis |}
       \tuplet 3/2 { b,8( e) g b( a) b } |
@@ -196,7 +196,7 @@ violinP = \relative c'' {
       a8. \tuplet 3/2 { g32 fis e } \tuplet 3/2 { d8 fis b } |
       \tuplet 3/2 { e,8( fis ) gis } a4 ~ |
       a2 ~ |
-      a ~ |
+      a2 ~ |
       \tuplet 3/2 { a8 gis fis b( cis) a } |
       \tuplet 3/2 { gis8( fis) e } a8. d,16 |
       cis8 r b\trill r |
@@ -271,10 +271,10 @@ violinP = \relative c'' {
       \onceShowTupletNumber \tuplet 3/2 { fis8( ais,) b } fis'8. cis16 |
       \tuplet 3/2 { d8( cis) b ais( b) cis } |
       fis,2 |
-      gis |
-      ais |
-      b |
-      cis |
+      gis2 |
+      ais2 |
+      b2 |
+      cis2 |
       d8. e16 fis8. g16 |
       d8 r d\trill r |
       b4 r |

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone-score.ly
@@ -1,4 +1,4 @@
-\version "2.4.0"
+\version "2.18.0"
 
 \include "violone.ly"
 

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone-score.ly
@@ -2,17 +2,11 @@
 
 \include "violone.ly"
 
-
-\score
-{
-  %
+\score {
   \violone
   \midi {}
-  \layout
-  {
-  }
-  \header
-  {
+  \layout {}
+  \header {
     instrument = "Double Bass"
   }
 }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone-score.ly
@@ -3,16 +3,16 @@
 \include "violone.ly"
 
 
-\score 
+\score
 {
-	% 
-	\violone
-	\midi {}
- 	\layout 
-	{
-	}
-	\header
-	{
-		instrument = "Double Bass"
-	}
-}	
+  %
+  \violone
+  \midi {}
+  \layout
+  {
+  }
+  \header
+  {
+    instrument = "Double Bass"
+  }
+}

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone-score.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone-score.ly
@@ -1,12 +1,12 @@
 \version "2.18.0"
-
 \include "violone.ly"
+
+\header {
+  instrument = "Violone"
+}
 
 \score {
   \violone
   \midi {}
   \layout {}
-  \header {
-    instrument = "Double Bass"
-  }
 }

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone.ly
@@ -2,7 +2,7 @@
 
 \include "header.ly"
 
- \version "2.4.0"
+ \version "2.18.0"
 violone =  \relative c {
  \clef bass
  \key d \major
@@ -29,7 +29,7 @@ d r r4 |
 R2 |
 r8 r16 a d8. a16 |
 \tripletsShow
- \times 2/3 { b8( a) g  fis ( g) a } |
+ \tuplet 3/2 { b8( a) g  fis ( g) a } |
 \tripletsHide
 % --Bar 41-- %
 d, r e r |
@@ -42,7 +42,7 @@ fis r g r |
 % --Bar 47-- %
 a r b r |
 cis8.\noBeam a16  d8. a16 |
-\times 2/3 { b8( a) g fis( g) a |
+\tuplet 3/2 { b8( a) g fis( g) a |
 d,( fis) e d(e ) fis | }
 g r a r |
 b r g, r |
@@ -59,11 +59,11 @@ R2*2|
 % --Bar 61-- %
 R2 |
 r8 r16 a, d8. a16 |
-\times 2/3 { b8( a) g  }  a8. a16 |
+\tuplet 3/2 { b8( a) g  }  a8. a16 |
 d,8 r fis r |
 R2 |
 r8. g16 d'8. a16 |
-\times 2/3 { b8( a) g  fis( gis) a  } |
+\tuplet 3/2 { b8( a) g  fis( gis) a  } |
 
 % --Bar 68-- %
 gis' r gis, r |
@@ -77,8 +77,8 @@ d8 r fis, r |
 
 % --Bar 76-- %
 g r a r |
-\times 2/3 { b( a) g  } a8. a,16 |
-\times 2/3 { d8( fis) e  d( e fis )}|
+\tuplet 3/2 { b( a) g  } a8. a,16 |
+\tuplet 3/2 { d8( fis) e  d( e fis )}|
 b, r r4 |
 \repeat unfold 6 {R2 |}
 
@@ -117,7 +117,7 @@ d r cis r |
 
 % 143
 d r e r |
-\times 2/3 { fis(e) d cis( dis) e }
+\tuplet 3/2 { fis(e) d cis( dis) e }
 dis4 r8 b |
 e8. d!16 cis8. fis,16 |
 e8. d16 e8. e,16 |
@@ -147,7 +147,7 @@ fis,2~|
 %222
 fis8. \noBeam b16 fis'8. a,16 |
 %should beam down
-\times 2/3 {b8( a) g ais(b) cis }|
+\tuplet 3/2 {b8( a) g ais(b) cis }|
 fis,4 ~ fis8. e16 |
 d8 r r4 |
 
@@ -173,7 +173,7 @@ b r cis r |
 d r r4 |
 R2 |
 r8 r16 a d8. a16 |
-\times 2/3 {b8( a) g fis( a ) b } |
+\tuplet 3/2 {b8( a) g fis( a ) b } |
 d, r e r |
 fis r fis, r |
 
@@ -186,7 +186,7 @@ a r b r |
 
 %280 
 cis8. \noBeam  a16 d8. a16 |
-\times 2/3 {b8(a) g fis (g) a |
+\tuplet 3/2 {b8(a) g fis (g) a |
 d,( fis ) e d(e) fis }|
 g r a r |
 b r b, r |
@@ -202,11 +202,11 @@ R2*3|
 
 %294
 r8 r16 a, d8. a16 |
-\times 2/3 {b8 (a ) fis } a8. a16|
+\tuplet 3/2 {b8 (a ) fis } a8. a16|
 d,8 r r4 |
 r2 |
 r8 r16 g'16 d'8. a16 |
-\times 2/3 {b8(a) g fis( gis) a }|
+\tuplet 3/2 {b8(a) g fis( gis) a }|
 gis r gis, r |
 r4 gis'8 r |
 
@@ -218,7 +218,7 @@ b8 r r r16 g |
 cis8 r r r16 a |
 d8 r fis, r |
 g r a r |
-\times 2/3 {b(a ) g} a8. a,16 |
+\tuplet 3/2 {b(a ) g} a8. a,16 |
 d2-\fermata \bar "|."
 }
 

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone.ly
@@ -25,7 +25,7 @@ violone = \relative c {
     r8 r16 a d8. a16 |
     \tuplet 3/2 { b8( a) g fis( g) a } |
     \hide TupletNumber
-    
+
     % --Bar 41-- %
     d, r e r |
     fis r fis, r |

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone.ly
@@ -1,6 +1,6 @@
+\version "2.18.0"
 \include "header.ly"
 
-\version "2.18.0"
 violone = \relative c {
   \clef bass
   \key d \major

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone.ly
@@ -25,6 +25,7 @@ violone = \relative c {
     r8 r16 a d8. a16 |
     \tuplet 3/2 { b8( a) g fis( g) a } |
     \hide TupletNumber
+    
     % --Bar 41-- %
     d, r e r |
     fis r fis, r |
@@ -74,23 +75,19 @@ violone = \relative c {
   }
   \alternative {
     {
-
       \tuplet 3/2 { d8( fis) e d( e fis) } |
       b, r r4 |
-
-      % --Bar 86 -- %
       R2*19 |
+
       % --Bar 99 -- %
       fis'8_\pianissimoB r r4 |
       fis,8 r r4 |
       \repeat unfold 6 { fis8 r r4 | }
 
       % --Bar 107 -- %
-      %switch staff rests
       R2*21 |
 
       % --Bar 128 -- %
-
       r4 a8_\forteB r |
       b r cis r |
       d r dis r |
@@ -120,17 +117,17 @@ violone = \relative c {
 
       %155
       a8 r r4 |
-      R2 * 22 |
+      R2*22 |
 
       %178
       r4 b |
       e, r |
       r a |
       d r |
-      R2 * 16 |
+      R2*16 |
 
       %198
-      \repeat unfold 5 { cis2 ~ | }
+      \repeat unfold 5 { cis2 ~ } |
       cis8 r r4 |
       %204
       R2*13 |
@@ -140,7 +137,6 @@ violone = \relative c {
 
       %222
       fis8. \noBeam b16 fis'8. a,16 |
-      %should beam down
       \tuplet 3/2 { b8( a) g ais( b) cis } |
       fis,4 ~ fis8. e16 |
       d8 r r4 |
@@ -154,9 +150,7 @@ violone = \relative c {
       R2*27 |
     }
     {
-
       d2-\fermata \bar "|."
     }
   }
 }
-

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone.ly
@@ -2,223 +2,227 @@
 
 \include "header.ly"
 
- \version "2.18.0"
+\version "2.18.0"
 violone =  \relative c {
- \clef bass
- \key d \major
- \time 2/4
+  \clef bass
+  \key d \major
+  \time 2/4
 
   \commonSettings
- 
-  \tripletsHide 
-% --Bar 1-- %
+
+  \tripletsHide
+  % --Bar 1-- %
   \repeat unfold 28 R2|
 
-% --Bar 28-- %
-r4 fis,8 r |
-g r a r |
-b r cis r |
-d r e r |
+  % --Bar 28-- %
+  r4 fis,8 r |
+  g r a r |
+  b r cis r |
+  d r e r |
 
-% --Bar 33-- %
-fis r fis r |
-g r a r |
-b r a r |
-b r cis r |
-d r r4 |
-R2 |
-r8 r16 a d8. a16 |
-\tripletsShow
- \tuplet 3/2 { b8( a) g  fis ( g) a } |
-\tripletsHide
-% --Bar 41-- %
-d, r e r |
-fis r fis, r |
-g r a r |
-b r cis r |
-d r e r |
-fis r g r |
+  % --Bar 33-- %
+  fis r fis r |
+  g r a r |
+  b r a r |
+  b r cis r |
+  d r r4 |
+  R2 |
+  r8 r16 a d8. a16 |
+  \tripletsShow
+  \tuplet 3/2 { b8( a) g  fis ( g) a } |
+  \tripletsHide
+  % --Bar 41-- %
+  d, r e r |
+  fis r fis, r |
+  g r a r |
+  b r cis r |
+  d r e r |
+  fis r g r |
 
-% --Bar 47-- %
-a r b r |
-cis8.\noBeam a16  d8. a16 |
-\tuplet 3/2 { b8( a) g fis( g) a |
-d,( fis) e d(e ) fis | }
-g r a r |
-b r g, r |
-r4 b'8 r |
+  % --Bar 47-- %
+  a r b r |
+  cis8.\noBeam a16  d8. a16 |
+  \tuplet 3/2 {
+    b8( a) g fis( g) a |
+    d,( fis) e d(e ) fis |
+  }
+  g r a r |
+  b r g, r |
+  r4 b'8 r |
 
-% --Bar 54-- %
-fis r fis, r |
-r4 fis'8 r |
-gis r gis, r |
-r4 gis'8 r |
-a r r4 |
-R2*2|
+  % --Bar 54-- %
+  fis r fis, r |
+  r4 fis'8 r |
+  gis r gis, r |
+  r4 gis'8 r |
+  a r r4 |
+  R2*2|
 
-% --Bar 61-- %
-R2 |
-r8 r16 a, d8. a16 |
-\tuplet 3/2 { b8( a) g  }  a8. a16 |
-d,8 r fis r |
-R2 |
-r8. g16 d'8. a16 |
-\tuplet 3/2 { b8( a) g  fis( gis) a  } |
+  % --Bar 61-- %
+  R2 |
+  r8 r16 a, d8. a16 |
+  \tuplet 3/2 { b8( a) g  }  a8. a16 |
+  d,8 r fis r |
+  R2 |
+  r8. g16 d'8. a16 |
+  \tuplet 3/2 { b8( a) g  fis( gis) a  } |
 
-% --Bar 68-- %
-gis' r gis, r |
-r4 gis'8 r |
-gis r gis, r |
-r4 gis'8 r |
-a r r r16 fis | 
-b8 r r r16 g |
-cis 8 r r r16 a |
-d8 r fis, r |
+  % --Bar 68-- %
+  gis' r gis, r |
+  r4 gis'8 r |
+  gis r gis, r |
+  r4 gis'8 r |
+  a r r r16 fis |
+  b8 r r r16 g |
+  cis 8 r r r16 a |
+  d8 r fis, r |
 
-% --Bar 76-- %
-g r a r |
-\tuplet 3/2 { b( a) g  } a8. a,16 |
-\tuplet 3/2 { d8( fis) e  d( e fis )}|
-b, r r4 |
-\repeat unfold 6 {R2 |}
+  % --Bar 76-- %
+  g r a r |
+  \tuplet 3/2 { b( a) g  } a8. a,16 |
+  \tuplet 3/2 { d8( fis) e  d( e fis )}|
+  b, r r4 |
+  \repeat unfold 6 {R2 |}
 
-% --Bar 86 -- %
-R2*8|
-% --Bar 93 -- %
-R2*5|
-% --Bar 99 -- %
-fis'8_\pianoissimoB r r4 |
-fis,8 r r4 |
-\repeat unfold 6{fis8 r r4 |}
+  % --Bar 86 -- %
+  R2*8|
+  % --Bar 93 -- %
+  R2*5|
+  % --Bar 99 -- %
+  fis'8_\pianoissimoB r r4 |
+  fis,8 r r4 |
+  \repeat unfold 6{fis8 r r4 |}
 
-% --Bar 107 -- %
-%switch staff rests
-R2*21 |
+  % --Bar 107 -- %
+  %switch staff rests
+  R2*21 |
 
-% --Bar 128 -- %
+  % --Bar 128 -- %
 
-r4 a8_\forteB r |
-b r cis r |
-d r dis r |
-e r fis r |
-g r gis r |
-a r b r |
-cis r cis, r  |
+  r4 a8_\forteB r |
+  b r cis r |
+  d r dis r |
+  e r fis r |
+  g r gis r |
+  a r b r |
+  cis r cis, r  |
 
-% --Bar 135 -- %
-d r cis r |
-fis r fis, r |
-gis r gis' r |
-a r a, r |
-b r b' r |
-cis r cis, r |
-d r d' r |
-d r cis r |
+  % --Bar 135 -- %
+  d r cis r |
+  fis r fis, r |
+  gis r gis' r |
+  a r a, r |
+  b r b' r |
+  cis r cis, r |
+  d r d' r |
+  d r cis r |
 
-% 143
-d r e r |
-\tuplet 3/2 { fis(e) d cis( dis) e }
-dis4 r8 b |
-e8. d!16 cis8. fis,16 |
-e8. d16 e8. e,16 |
-a8-\pianoB r r4 |
-\repeat unfold 6 { a8 r r4 |}
+  % 143
+  d r e r |
+  \tuplet 3/2 { fis(e) d cis( dis) e }
+  dis4 r8 b |
+  e8. d!16 cis8. fis,16 |
+  e8. d16 e8. e,16 |
+  a8-\pianoB r r4 |
+  \repeat unfold 6 { a8 r r4 |}
 
-%155
-a8 r r4 | 
-R2 * 22|
+  %155
+  a8 r r4 |
+  R2 * 22|
 
-%178
-r4 b |
-e, r |
-r a |
-d r |
-R2 * 16  |
+  %178
+  r4 b |
+  e, r |
+  r a |
+  d r |
+  R2 * 16  |
 
-%198
-\repeat unfold 5 { cis2~|}
-cis8 r r4|
-%204
-R2*13 |
-%217
-fis,2~|
-\repeat unfold 4 { fis~|}
+  %198
+  \repeat unfold 5 { cis2~|}
+  cis8 r r4|
+  %204
+  R2*13 |
+  %217
+  fis,2~|
+  \repeat unfold 4 { fis~|}
 
-%222
-fis8. \noBeam b16 fis'8. a,16 |
-%should beam down
-\tuplet 3/2 {b8( a) g ais(b) cis }|
-fis,4 ~ fis8. e16 |
-d8 r r4 |
+  %222
+  fis8. \noBeam b16 fis'8. a,16 |
+  %should beam down
+  \tuplet 3/2 {b8( a) g ais(b) cis }|
+  fis,4 ~ fis8. e16 |
+  d8 r r4 |
 
-%226
-R2*4 |
-r8 r16 g' d8. e16|
-fis8. e16 fis8. fis,16 |
-b4 r |
-d r |
+  %226
+  R2*4 |
+  r8 r16 g' d8. e16|
+  fis8. e16 fis8. fis,16 |
+  b4 r |
+  d r |
 
-%261
-R2 * 27 |
-r4 fis,8 r |
-g r a r |
-b r cis r |
-d r e r |
-fis r fis r |
-g r a r |
+  %261
+  R2 * 27 |
+  r4 fis,8 r |
+  g r a r |
+  b r cis r |
+  d r e r |
+  fis r fis r |
+  g r a r |
 
-%267
-b r a r |
-b r cis r |
-d r r4 |
-R2 |
-r8 r16 a d8. a16 |
-\tuplet 3/2 {b8( a) g fis( a ) b } |
-d, r e r |
-fis r fis, r |
+  %267
+  b r a r |
+  b r cis r |
+  d r r4 |
+  R2 |
+  r8 r16 a d8. a16 |
+  \tuplet 3/2 {b8( a) g fis( a ) b } |
+  d, r e r |
+  fis r fis, r |
 
-%275
-g r a r |
-b r cis r |
-d r e r |
-fis r g r |
-a r b r |
+  %275
+  g r a r |
+  b r cis r |
+  d r e r |
+  fis r g r |
+  a r b r |
 
-%280 
-cis8. \noBeam  a16 d8. a16 |
-\tuplet 3/2 {b8(a) g fis (g) a |
-d,( fis ) e d(e) fis }|
-g r a r |
-b r b, r |
-r4 b'8 r |
-fis r fis, r |
-r4 fis'8 r |
+  %280
+  cis8. \noBeam  a16 d8. a16 |
+  \tuplet 3/2 {
+    b8(a) g fis (g) a |
+    d,( fis ) e d(e) fis
+  }|
+  g r a r |
+  b r b, r |
+  r4 b'8 r |
+  fis r fis, r |
+  r4 fis'8 r |
 
-%288
-gis r gis, r |
-r4 gis'8 r |
-a r r4 |
-R2*3|
+  %288
+  gis r gis, r |
+  r4 gis'8 r |
+  a r r4 |
+  R2*3|
 
-%294
-r8 r16 a, d8. a16 |
-\tuplet 3/2 {b8 (a ) fis } a8. a16|
-d,8 r r4 |
-r2 |
-r8 r16 g'16 d'8. a16 |
-\tuplet 3/2 {b8(a) g fis( gis) a }|
-gis r gis, r |
-r4 gis'8 r |
+  %294
+  r8 r16 a, d8. a16 |
+  \tuplet 3/2 {b8 (a ) fis } a8. a16|
+  d,8 r r4 |
+  r2 |
+  r8 r16 g'16 d'8. a16 |
+  \tuplet 3/2 {b8(a) g fis( gis) a }|
+  gis r gis, r |
+  r4 gis'8 r |
 
-%302
-gis r gis, r |
-r4 gis'8 r |
-a r r r16 fis |
-b8 r r r16 g |
-cis8 r r r16 a |
-d8 r fis, r |
-g r a r |
-\tuplet 3/2 {b(a ) g} a8. a,16 |
-d2-\fermata \bar "|."
+  %302
+  gis r gis, r |
+  r4 gis'8 r |
+  a r r r16 fis |
+  b8 r r r16 g |
+  cis8 r r r16 a |
+  d8 r fis, r |
+  g r a r |
+  \tuplet 3/2 {b(a ) g} a8. a,16 |
+  d2-\fermata \bar "|."
 }
 

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone.ly
@@ -1,5 +1,3 @@
-#(ly:set-point-and-click 'line-column )
-
 \include "header.ly"
 
 \version "2.18.0"

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone.ly
@@ -6,217 +6,157 @@ violone = \relative c {
   \key d \major
   \time 2/4
 
-  \hide TupletNumber
-  % --Bar 1-- %
   R2*28 |
 
-  % --Bar 28-- %
-  r4 fis,8 r |
-  g r a r |
-  b r cis r |
-  d r e r |
+  \repeat unfold 2 {
+    % --Bar 28-- %
+    r4 fis,8 r |
+    g r a r |
+    b r cis r |
+    d r e r |
 
-  % --Bar 33-- %
-  fis r fis r |
-  g r a r |
-  b r a r |
-  b r cis r |
-  d r r4 |
-  R2 |
-  r8 r16 a d8. a16 |
-  \undo \hide TupletNumber
-  \tuplet 3/2 { b8( a) g fis ( g) a } |
-  \hide TupletNumber
-  % --Bar 41-- %
-  d, r e r |
-  fis r fis, r |
-  g r a r |
-  b r cis r |
-  d r e r |
-  fis r g r |
+    % --Bar 33-- %
+    fis r fis r |
+    g r a r |
+    b r a r |
+    b r cis r |
+    d r r4 |
+    R2 |
+    r8 r16 a d8. a16 |
+    \tuplet 3/2 { b8( a) g fis( g) a } |
+    \hide TupletNumber
+    % --Bar 41-- %
+    d, r e r |
+    fis r fis, r |
+    g r a r |
+    b r cis r |
+    d r e r |
+    fis r g r |
 
-  % --Bar 47-- %
-  a r b r |
-  cis8.\noBeam a16 d8. a16 |
-  \tuplet 3/2 {
-    b8( a) g fis( g) a |
-    d,( fis) e d(e ) fis |
+    % --Bar 47-- %
+    a r b r |
+    cis8.\noBeam a16 d8. a16 |
+    \tuplet 3/2 {
+      b8( a) g fis( g) a |
+      d,( fis) e d( e) fis |
+    }
+    g r a r |
+    b r b, r |
+    r4 b'8 r |
+
+    % --Bar 54-- %
+    fis r fis, r |
+    r4 fis'8 r |
+    gis r gis, r |
+    r4 gis'8 r |
+    a r r4 |
+    R2*3 |
+    r8 r16 a, d8. a16 |
+    \tuplet 3/2 { b8( a) g } a8. a16 |
+    d,8 r r4 |
+    R2 |
+    r8 r16 g'16 d'8. a16 |
+    \tuplet 3/2 { b8( a) g fis( gis) a } |
+
+    % --Bar 68-- %
+    gis r gis, r |
+    r4 gis'8 r |
+    gis r gis, r |
+    r4 gis'8 r |
+    a r r r16 fis |
+    b8 r r r16 g |
+    cis8 r r r16 a |
+    d8 r fis, r |
+
+    % --Bar 76-- %
+    g r a r |
+    \tuplet 3/2 { b( a) g } a8. a,16 |
   }
-  g r a r |
-  b r g, r |
-  r4 b'8 r |
+  \alternative {
+    {
 
-  % --Bar 54-- %
-  fis r fis, r |
-  r4 fis'8 r |
-  gis r gis, r |
-  r4 gis'8 r |
-  a r r4 |
-  R2 |
-  R2 |
+      \tuplet 3/2 { d8( fis) e d( e fis) } |
+      b, r r4 |
 
-  % --Bar 61-- %
-  R2 |
-  r8 r16 a, d8. a16 |
-  \tuplet 3/2 { b8( a) g } a8. a16 |
-  d,8 r fis r |
-  R2 |
-  r8. g16 d'8. a16 |
-  \tuplet 3/2 { b8( a) g fis( gis) a } |
+      % --Bar 86 -- %
+      R2*19 |
+      % --Bar 99 -- %
+      fis'8_\pianissimoB r r4 |
+      fis,8 r r4 |
+      \repeat unfold 6 { fis8 r r4 | }
 
-  % --Bar 68-- %
-  gis' r gis, r |
-  r4 gis'8 r |
-  gis r gis, r |
-  r4 gis'8 r |
-  a r r r16 fis |
-  b8 r r r16 g |
-  cis 8 r r r16 a |
-  d8 r fis, r |
+      % --Bar 107 -- %
+      %switch staff rests
+      R2*21 |
 
-  % --Bar 76-- %
-  g r a r |
-  \tuplet 3/2 { b( a) g } a8. a,16 |
-  \tuplet 3/2 { d8( fis) e d( e fis) } |
-  b, r r4 |
+      % --Bar 128 -- %
 
-  % --Bar 86 -- %
-  R2*19 |
-  % --Bar 99 -- %
-  fis'8_\pianissimoB r r4 |
-  fis,8 r r4 |
-  \repeat unfold 6 { fis8 r r4 | }
+      r4 a8_\forteB r |
+      b r cis r |
+      d r dis r |
+      e r fis r |
+      g r gis r |
+      a r b r |
+      cis r cis, r |
 
-  % --Bar 107 -- %
-  %switch staff rests
-  R2*21 |
+      % --Bar 135 -- %
+      d r cis r |
+      fis r fis, r |
+      gis r gis' r |
+      a r a, r |
+      b r b' r |
+      cis r cis, r |
+      d r d' r |
+      d r cis r |
 
-  % --Bar 128 -- %
+      % 143
+      d r e r |
+      \tuplet 3/2 { fis(e) d cis( dis) e }
+      dis4 r8 b |
+      e8. d!16 cis8. fis,16 |
+      e8. d16 e8. e,16 |
+      a8-\pianoB r r4 |
+      \repeat unfold 6 { a8 r r4 | }
 
-  r4 a8_\forteB r |
-  b r cis r |
-  d r dis r |
-  e r fis r |
-  g r gis r |
-  a r b r |
-  cis r cis, r |
+      %155
+      a8 r r4 |
+      R2 * 22 |
 
-  % --Bar 135 -- %
-  d r cis r |
-  fis r fis, r |
-  gis r gis' r |
-  a r a, r |
-  b r b' r |
-  cis r cis, r |
-  d r d' r |
-  d r cis r |
+      %178
+      r4 b |
+      e, r |
+      r a |
+      d r |
+      R2 * 16 |
 
-  % 143
-  d r e r |
-  \tuplet 3/2 { fis(e) d cis( dis) e }
-  dis4 r8 b |
-  e8. d!16 cis8. fis,16 |
-  e8. d16 e8. e,16 |
-  a8-\pianoB r r4 |
-  \repeat unfold 6 { a8 r r4 | }
+      %198
+      \repeat unfold 5 { cis2 ~ | }
+      cis8 r r4 |
+      %204
+      R2*13 |
+      %217
+      fis,2 ~ |
+      \repeat unfold 4 { fis2 ~ } |
 
-  %155
-  a8 r r4 |
-  R2 * 22 |
+      %222
+      fis8. \noBeam b16 fis'8. a,16 |
+      %should beam down
+      \tuplet 3/2 { b8( a) g ais( b) cis } |
+      fis,4 ~ fis8. e16 |
+      d8 r r4 |
 
-  %178
-  r4 b |
-  e, r |
-  r a |
-  d r |
-  R2 * 16 |
+      %226
+      R2*4 |
+      r8 r16 g' d8. e16 |
+      fis8. e16 fis8. fis,16 |
+      b4 r |
+      d r |
+      R2*27 |
+    }
+    {
 
-  %198
-  \repeat unfold 5 { cis2 ~ | }
-  cis8 r r4 |
-  %204
-  R2*13 |
-  %217
-  fis,2 ~ |
-  \repeat unfold 4 { fis ~ | }
-
-  %222
-  fis8. \noBeam b16 fis'8. a,16 |
-  %should beam down
-  \tuplet 3/2 { b8( a) g ais(b) cis } |
-  fis,4 ~ fis8. e16 |
-  d8 r r4 |
-
-  %226
-  R2*4 |
-  r8 r16 g' d8. e16 |
-  fis8. e16 fis8. fis,16 |
-  b4 r |
-  d r |
-
-  %261
-  R2 * 27 |
-  r4 fis,8 r |
-  g r a r |
-  b r cis r |
-  d r e r |
-  fis r fis r |
-  g r a r |
-
-  %267
-  b r a r |
-  b r cis r |
-  d r r4 |
-  R2 |
-  r8 r16 a d8. a16 |
-  \tuplet 3/2 { b8( a) g fis( a ) b } |
-  d, r e r |
-  fis r fis, r |
-
-  %275
-  g r a r |
-  b r cis r |
-  d r e r |
-  fis r g r |
-  a r b r |
-
-  %280
-  cis8. \noBeam a16 d8. a16 |
-  \tuplet 3/2 {
-    b8(a) g fis (g) a |
-    d,( fis ) e d(e) fis
-  } |
-  g r a r |
-  b r b, r |
-  r4 b'8 r |
-  fis r fis, r |
-  r4 fis'8 r |
-
-  %288
-  gis r gis, r |
-  r4 gis'8 r |
-  a r r4 |
-  R2*3 |
-
-  %294
-  r8 r16 a, d8. a16 |
-  \tuplet 3/2 { b8 (a ) fis } a8. a16 |
-  d,8 r r4 |
-  R2 |
-  r8 r16 g'16 d'8. a16 |
-  \tuplet 3/2 { b8(a) g fis( gis) a } |
-  gis r gis, r |
-  r4 gis'8 r |
-
-  %302
-  gis r gis, r |
-  r4 gis'8 r |
-  a r r r16 fis |
-  b8 r r r16 g |
-  cis8 r r r16 a |
-  d8 r fis, r |
-  g r a r |
-  \tuplet 3/2 { b(a ) g} a8. a,16 |
-  d2-\fermata \bar "|."
+      d2-\fermata \bar "|."
+    }
+  }
 }
 

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone.ly
@@ -12,72 +12,72 @@ violone = \relative c {
   \repeat unfold 2 {
     % --Bar 28-- %
     r4 fis,8 r |
-    g r a r |
-    b r cis r |
-    d r e r |
+    g8 r a r |
+    b8 r cis r |
+    d8 r e r |
 
     % --Bar 33-- %
-    fis r fis r |
-    g r a r |
-    b r a r |
-    b r cis r |
-    d r r4 |
+    fis8 r fis r |
+    g8 r a r |
+    b8 r a r |
+    b8 r cis r |
+    d8 r r4 |
     R2 |
     r8 r16 a d8. a16 |
     \tuplet 3/2 { b8( a) g fis( g) a } |
     \hide TupletNumber
 
     % --Bar 41-- %
-    d, r e r |
-    fis r fis, r |
-    g r a r |
-    b r cis r |
-    d r e r |
-    fis r g r |
+    d,8 r e r |
+    fis8 r fis, r |
+    g8 r a r |
+    b8 r cis r |
+    d8 r e r |
+    fis8 r g r |
 
     % --Bar 47-- %
-    a r b r |
+    a8 r b r |
     cis8.\noBeam a16 d8. a16 |
     \tuplet 3/2 {
       b8( a) g fis( g) a |
-      d,( fis) e d( e) fis |
+      d,8( fis) e d( e) fis |
     }
-    g r a r |
-    b r b, r |
+    g8 r a r |
+    b8 r b, r |
     r4 b'8 r |
 
     % --Bar 54-- %
-    fis r fis, r |
+    fis8 r fis, r |
     r4 fis'8 r |
-    gis r gis, r |
+    gis8 r gis, r |
     r4 gis'8 r |
-    a r r4 |
+    a8 r r4 |
     R2*3 |
     r8 r16 a, d8. a16 |
     \tuplet 3/2 { b8( a) g } a8. a16 |
     d,8 r r4 |
     R2 |
-    r8 r16 g'16 d'8. a16 |
+    r8 r16 g' d'8. a16 |
     \tuplet 3/2 { b8( a) g fis( gis) a } |
 
     % --Bar 68-- %
-    gis r gis, r |
+    gis8 r gis, r |
     r4 gis'8 r |
-    gis r gis, r |
+    gis8 r gis, r |
     r4 gis'8 r |
-    a r r r16 fis |
+    a8 r r r16 fis |
     b8 r r r16 g |
     cis8 r r r16 a |
     d8 r fis, r |
 
     % --Bar 76-- %
-    g r a r |
-    \tuplet 3/2 { b( a) g } a8. a,16 |
+    g8 r a r |
+    \tuplet 3/2 { b8( a) g } a8. a,16 |
   }
   \alternative {
     {
       \tuplet 3/2 { d8( fis) e d( e fis) } |
-      b, r r4 |
+      b,8 r r4 |
       R2*19 |
 
       % --Bar 99 -- %
@@ -90,26 +90,26 @@ violone = \relative c {
 
       % --Bar 128 -- %
       r4 a8_\forteB r |
-      b r cis r |
-      d r dis r |
-      e r fis r |
-      g r gis r |
-      a r b r |
-      cis r cis, r |
+      b8 r cis r |
+      d8 r dis r |
+      e8 r fis r |
+      g8 r gis r |
+      a8 r b r |
+      cis8 r cis, r |
 
       % --Bar 135 -- %
-      d r cis r |
-      fis r fis, r |
-      gis r gis' r |
-      a r a, r |
-      b r b' r |
-      cis r cis, r |
-      d r d' r |
-      d r cis r |
+      d8 r cis r |
+      fis8 r fis, r |
+      gis8 r gis' r |
+      a8 r a, r |
+      b8 r b' r |
+      cis8 r cis, r |
+      d8 r d' r |
+      d8 r cis r |
 
       % 143
-      d r e r |
-      \tuplet 3/2 { fis(e) d cis( dis) e }
+      d8 r e r |
+      \tuplet 3/2 { fis8(e) d cis( dis) e }
       dis4 r8 b |
       e8. d!16 cis8. fis,16 |
       e8. d16 e8. e,16 |
@@ -122,9 +122,9 @@ violone = \relative c {
 
       %178
       r4 b |
-      e, r |
-      r a |
-      d r |
+      e,4 r |
+      r4 a |
+      d4 r |
       R2*16 |
 
       %198
@@ -147,7 +147,7 @@ violone = \relative c {
       r8 r16 g' d8. e16 |
       fis8. e16 fis8. fis,16 |
       b4 r |
-      d r |
+      d4 r |
       R2*27 |
     }
     {

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone.ly
@@ -6,11 +6,9 @@ violone = \relative c {
   \key d \major
   \time 2/4
 
-  \commonSettings
-
-  \tripletsHide
+  \hide TupletNumber
   % --Bar 1-- %
-  \repeat unfold 28 R2 |
+  R2*28 |
 
   % --Bar 28-- %
   r4 fis,8 r |
@@ -26,9 +24,9 @@ violone = \relative c {
   d r r4 |
   R2 |
   r8 r16 a d8. a16 |
-  \tripletsShow
+  \undo \hide TupletNumber
   \tuplet 3/2 { b8( a) g fis ( g) a } |
-  \tripletsHide
+  \hide TupletNumber
   % --Bar 41-- %
   d, r e r |
   fis r fis, r |
@@ -54,7 +52,8 @@ violone = \relative c {
   gis r gis, r |
   r4 gis'8 r |
   a r r4 |
-  R2*2 |
+  R2 |
+  R2 |
 
   % --Bar 61-- %
   R2 |
@@ -78,16 +77,13 @@ violone = \relative c {
   % --Bar 76-- %
   g r a r |
   \tuplet 3/2 { b( a) g } a8. a,16 |
-  \tuplet 3/2 { d8( fis) e d( e fis )} |
+  \tuplet 3/2 { d8( fis) e d( e fis) } |
   b, r r4 |
-  \repeat unfold 6 { R2 | }
 
   % --Bar 86 -- %
-  R2*8 |
-  % --Bar 93 -- %
-  R2*5 |
+  R2*19 |
   % --Bar 99 -- %
-  fis'8_\pianoissimoB r r4 |
+  fis'8_\pianissimoB r r4 |
   fis,8 r r4 |
   \repeat unfold 6 { fis8 r r4 | }
 
@@ -206,7 +202,7 @@ violone = \relative c {
   r8 r16 a, d8. a16 |
   \tuplet 3/2 { b8 (a ) fis } a8. a16 |
   d,8 r r4 |
-  r2 |
+  R2 |
   r8 r16 g'16 d'8. a16 |
   \tuplet 3/2 { b8(a) g fis( gis) a } |
   gis r gis, r |

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone.ly
@@ -2,6 +2,7 @@
 \include "header.ly"
 
 violone = \relative c {
+  \tempo "Allegro."
   \clef bass
   \key d \major
   \time 2/4

--- a/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone.ly
+++ b/ftp/BachJS/BWV1050/brand5-3/brand5-3-lys/violone.ly
@@ -1,7 +1,7 @@
 \include "header.ly"
 
 \version "2.18.0"
-violone =  \relative c {
+violone = \relative c {
   \clef bass
   \key d \major
   \time 2/4
@@ -10,7 +10,7 @@ violone =  \relative c {
 
   \tripletsHide
   % --Bar 1-- %
-  \repeat unfold 28 R2|
+  \repeat unfold 28 R2 |
 
   % --Bar 28-- %
   r4 fis,8 r |
@@ -27,7 +27,7 @@ violone =  \relative c {
   R2 |
   r8 r16 a d8. a16 |
   \tripletsShow
-  \tuplet 3/2 { b8( a) g  fis ( g) a } |
+  \tuplet 3/2 { b8( a) g fis ( g) a } |
   \tripletsHide
   % --Bar 41-- %
   d, r e r |
@@ -39,7 +39,7 @@ violone =  \relative c {
 
   % --Bar 47-- %
   a r b r |
-  cis8.\noBeam a16  d8. a16 |
+  cis8.\noBeam a16 d8. a16 |
   \tuplet 3/2 {
     b8( a) g fis( g) a |
     d,( fis) e d(e ) fis |
@@ -54,16 +54,16 @@ violone =  \relative c {
   gis r gis, r |
   r4 gis'8 r |
   a r r4 |
-  R2*2|
+  R2*2 |
 
   % --Bar 61-- %
   R2 |
   r8 r16 a, d8. a16 |
-  \tuplet 3/2 { b8( a) g  }  a8. a16 |
+  \tuplet 3/2 { b8( a) g } a8. a16 |
   d,8 r fis r |
   R2 |
   r8. g16 d'8. a16 |
-  \tuplet 3/2 { b8( a) g  fis( gis) a  } |
+  \tuplet 3/2 { b8( a) g fis( gis) a } |
 
   % --Bar 68-- %
   gis' r gis, r |
@@ -77,19 +77,19 @@ violone =  \relative c {
 
   % --Bar 76-- %
   g r a r |
-  \tuplet 3/2 { b( a) g  } a8. a,16 |
-  \tuplet 3/2 { d8( fis) e  d( e fis )}|
+  \tuplet 3/2 { b( a) g } a8. a,16 |
+  \tuplet 3/2 { d8( fis) e d( e fis )} |
   b, r r4 |
-  \repeat unfold 6 {R2 |}
+  \repeat unfold 6 { R2 | }
 
   % --Bar 86 -- %
-  R2*8|
+  R2*8 |
   % --Bar 93 -- %
-  R2*5|
+  R2*5 |
   % --Bar 99 -- %
   fis'8_\pianoissimoB r r4 |
   fis,8 r r4 |
-  \repeat unfold 6{fis8 r r4 |}
+  \repeat unfold 6 { fis8 r r4 | }
 
   % --Bar 107 -- %
   %switch staff rests
@@ -103,7 +103,7 @@ violone =  \relative c {
   e r fis r |
   g r gis r |
   a r b r |
-  cis r cis, r  |
+  cis r cis, r |
 
   % --Bar 135 -- %
   d r cis r |
@@ -122,38 +122,38 @@ violone =  \relative c {
   e8. d!16 cis8. fis,16 |
   e8. d16 e8. e,16 |
   a8-\pianoB r r4 |
-  \repeat unfold 6 { a8 r r4 |}
+  \repeat unfold 6 { a8 r r4 | }
 
   %155
   a8 r r4 |
-  R2 * 22|
+  R2 * 22 |
 
   %178
   r4 b |
   e, r |
   r a |
   d r |
-  R2 * 16  |
+  R2 * 16 |
 
   %198
-  \repeat unfold 5 { cis2~|}
-  cis8 r r4|
+  \repeat unfold 5 { cis2 ~ | }
+  cis8 r r4 |
   %204
   R2*13 |
   %217
-  fis,2~|
-  \repeat unfold 4 { fis~|}
+  fis,2 ~ |
+  \repeat unfold 4 { fis ~ | }
 
   %222
   fis8. \noBeam b16 fis'8. a,16 |
   %should beam down
-  \tuplet 3/2 {b8( a) g ais(b) cis }|
+  \tuplet 3/2 { b8( a) g ais(b) cis } |
   fis,4 ~ fis8. e16 |
   d8 r r4 |
 
   %226
   R2*4 |
-  r8 r16 g' d8. e16|
+  r8 r16 g' d8. e16 |
   fis8. e16 fis8. fis,16 |
   b4 r |
   d r |
@@ -173,7 +173,7 @@ violone =  \relative c {
   d r r4 |
   R2 |
   r8 r16 a d8. a16 |
-  \tuplet 3/2 {b8( a) g fis( a ) b } |
+  \tuplet 3/2 { b8( a) g fis( a ) b } |
   d, r e r |
   fis r fis, r |
 
@@ -185,11 +185,11 @@ violone =  \relative c {
   a r b r |
 
   %280
-  cis8. \noBeam  a16 d8. a16 |
+  cis8. \noBeam a16 d8. a16 |
   \tuplet 3/2 {
     b8(a) g fis (g) a |
     d,( fis ) e d(e) fis
-  }|
+  } |
   g r a r |
   b r b, r |
   r4 b'8 r |
@@ -200,15 +200,15 @@ violone =  \relative c {
   gis r gis, r |
   r4 gis'8 r |
   a r r4 |
-  R2*3|
+  R2*3 |
 
   %294
   r8 r16 a, d8. a16 |
-  \tuplet 3/2 {b8 (a ) fis } a8. a16|
+  \tuplet 3/2 { b8 (a ) fis } a8. a16 |
   d,8 r r4 |
   r2 |
   r8 r16 g'16 d'8. a16 |
-  \tuplet 3/2 {b8(a) g fis( gis) a }|
+  \tuplet 3/2 { b8(a) g fis( gis) a } |
   gis r gis, r |
   r4 gis'8 r |
 
@@ -220,7 +220,7 @@ violone =  \relative c {
   cis8 r r r16 a |
   d8 r fis, r |
   g r a r |
-  \tuplet 3/2 {b(a ) g} a8. a,16 |
+  \tuplet 3/2 { b(a ) g} a8. a,16 |
   d2-\fermata \bar "|."
 }
 


### PR DESCRIPTION
This update is now done from my side. It is updated to 2.18.0 (as the [update-wiki](https://github.com/MutopiaProject/MutopiaProject/wiki/Updating-Lilypond-files-for-the-Mutopia-Project#the-goal-of-your-update-session) says). However I tested it with 2.18.2. I would suggest to update the wiki and drop 2.14 as a suggestion and add 2.18.2.

I contacted the maintainer privately and he allowed me to do some more changes to the code than a usual [version update](https://github.com/MutopiaProject/MutopiaProject/wiki/Updating-Lilypond-files-for-the-Mutopia-Project#the-goal-of-your-update-session) would contain. This comprises:
- Adding bass figures
- Using `\repeat unfold` instead of code duplication

I don't know if multiple maintainers are possible. If yes, I would suggest to list myself in addition as I did in the maintainer field. If not, please just leave Joshua and delete my name.