### PR TITLE
Update Haydn, Op.76, No.1 from Lilypond version 2.16.0 to 2.18.0

### DIFF
--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 \header {
   title = "String Quartet in G major"
   subtitle = "Op. 76 No. 1"
@@ -40,8 +40,8 @@ markingsIII =  {
   s4
 
   s2.*33 s2
-  \override Score.RehearsalMark #'break-visibility = #begin-of-line-invisible
-  \override Score.RehearsalMark #'self-alignment-X = #1
+  \override Score.RehearsalMark.break-visibility = #begin-of-line-invisible
+  \override Score.RehearsalMark.self-alignment-X = #1
   \mark \markup { \large { \italic "Menuetto D.C." } }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/i-midi.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/i-midi.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
   \midi {
     \tempo 4 = 160

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/i-viola.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/i-viola.ily
@@ -1,10 +1,10 @@
-\version "2.16.0"
+\version "2.18.0"
 violaFirstMov =  \relative d' {
   \key g \major
   \clef alto
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   <d b'-.>4\f r <d c'-.> r
   | <d b'-.> r r

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/i-violin1.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/i-violin1.ily
@@ -1,10 +1,10 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIFirstMov =  \relative d' {
   \key g \major
   \clef violin
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   <d b' g'-.>4-\f r <d d' a'-.> r
   | <d d' b'-.> r r

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/i-violin2.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/i-violin2.ily
@@ -1,10 +1,10 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIIFirstMov =  \relative d' {
   \key g \major
   \clef violin
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   <d b' g'>4\f-. r <d a' fis'>-. r
   | <d b' g'>-. r r

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/i-violoncello.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/i-violoncello.ily
@@ -1,10 +1,10 @@
-\version "2.16.0"
+\version "2.18.0"
 celloFirstMov =  \relative g {
   \key g \major
   \clef bass
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   g4-.\f r d-. r
   | g,-. r r

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/ii-midi.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/ii-midi.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
   \midi {
     \tempo 4 = 36

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/ii-viola.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/ii-viola.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violaSecondMov =  \relative g {
   \key c \major
   \clef alto

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/ii-violin1.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/ii-violin1.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinISecondMov =  \relative e' {
   \key c \major
   \clef violin
@@ -11,7 +11,7 @@ violinISecondMov =  \relative e' {
   | f-(-[ e d8. dis16-)-]
   | e4-( d!-)
   | c!4-( d8 e-)
-  | f8-( \times 2/3 { a16 f d-) } c8-( \times 2/3 { b16 d g-) }
+  | f8-( \tuplet 3/2 { a16 f d-) } c8-( \tuplet 3/2 { b16 d g-) }
   | f4-( e8-) r
   | e'4-( d-)
 
@@ -97,7 +97,7 @@ violinISecondMov =  \relative e' {
   | f-[-( e d8. dis16-)-]
   | e4-( d!-)
   | c-( d8-[ e-]-)
-  | f-( \times 2/3 { a16 f d-) } c8-( \times 2/3 { b16 d f-) }
+  | f-( \tuplet 3/2 { a16 f d-) } c8-( \tuplet 3/2 { b16 d f-) }
   | e8 r r r32 g-(-[_\markup { \italic { più } \dynamic f } e c-)-]
 
   % 80

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/ii-violin2.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/ii-violin2.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIISecondMov =  \relative c' {
   \key c \major
   \clef violin

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/ii-violoncello.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/ii-violoncello.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 celloSecondMov =  \relative f {
   \key c \major
   \clef bass

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/iii-midi.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/iii-midi.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
   \midi {
     \tempo 4 = 280

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/iii-viola.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/iii-viola.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violaThirdMov =  \relative b {
   \key g \major
   \clef alto

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/iii-violin1.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/iii-violin1.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIThirdMov =  \relative d' {
   \key g \major
   \clef violin

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/iii-violin2.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/iii-violin2.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIIThirdMov =  \relative d' {
   \key g \major
   \clef violin

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/iii-violoncello.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/iii-violoncello.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 celloThirdMov =  \relative g {
   \key g \major
   \clef bass

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/iv-midi.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/iv-midi.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
   \midi {
     \tempo 4 = 160

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/iv-viola.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/iv-viola.ily
@@ -1,20 +1,20 @@
-\version "2.16.0"
+\version "2.18.0"
 violaFourthMov =  \relative g {
   \key g \minor
   \clef alto
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   \repeat volta 2 {
-    \times 2/3 { g8(\f fis g) }
-    | bes!4-. g-. d-. \times 2/3 { c'8( d c) }
-    | es4-. c-. fis,-. \times 2/3 { d'8( es c) }
-    | bes4-. \times 2/3 { bes8( c a) } \noTupletNum g4-. d-.
+    \tuplet 3/2 { g8(\f fis g) }
+    | bes!4-. g-. d-. \tuplet 3/2 { c'8( d c) }
+    | es4-. c-. fis,-. \tuplet 3/2 { d'8( es c) }
+    | bes4-. \tuplet 3/2 { bes8( c a) } \noTupletNum g4-. d-.
     | \repeat unfold 2 { es4(\trill d8) r }
     | \acciaccatura d8 \afterGrace es1(\trill {d16[ es])}
-    | d4-. d'-. r \times 2/3 { g8( fis g) }
-    | bes4-. g-. d-. \times 2/3 { c'8( d c) }
+    | d4-. d'-. r \tuplet 3/2 { g8( fis g) }
+    | bes4-. g-. d-. \tuplet 3/2 { c'8( d c) }
     | es4-. c-. fis,-. d'-.
     | g,( a bes) d,-.
 
@@ -26,17 +26,17 @@ violaFourthMov =  \relative g {
     | r bes-. bes-. r
     | r cis-. cis-. r
     | R1
-    | r2 r4 \times 2/3 { f,8(\f e f) }
-    | bes-. r \times 2/3 { f( e f) } bes-. r \times 2/3 { f-. e-. f-. }
-    | \times 2/3 { bes[-. a-. bes-.] f-.[ e-. f]-. bes[-. a-. bes]-. f[-. e-. f]-. }
+    | r2 r4 \tuplet 3/2 { f,8(\f e f) }
+    | bes-. r \tuplet 3/2 { f( e f) } bes-. r \tuplet 3/2 { f-. e-. f-. }
+    | \tuplet 3/2 { bes[-. a-. bes-.] f-.[ e-. f]-. bes[-. a-. bes]-. f[-. e-. f]-. }
 
     % 20
     | f1
     | d'2 e
-    | \times 2/3 { f8[-. c-. bes]-. a[-. g-. f]-. } e2
-    | \times 2/3 { f'8[-. c-. bes]-. a[-. g-. f]-. } e2
-    | \times 2/3 { f'8[-. d-. c]-. bes[-. a-. g]-. } f4 r
-    | r2 r4 \times 2/3 { f'8-.\p g-. f-. }
+    | \tuplet 3/2 { f8[-. c-. bes]-. a[-. g-. f]-. } e2
+    | \tuplet 3/2 { f'8[-. c-. bes]-. a[-. g-. f]-. } e2
+    | \tuplet 3/2 { f'8[-. d-. c]-. bes[-. a-. g]-. } f4 r
+    | r2 r4 \tuplet 3/2 { f'8-.\p g-. f-. }
     | bes4-. f-. d-. a'-.
     | bes r r es,(
     | d) r r es(
@@ -61,14 +61,14 @@ violaFourthMov =  \relative g {
     | f8 r r4 r f'->\p ~
     | f8 r f4-> ~ f8 r f4-> ~
     | f8 r r4 r2
-    | r4 \times 2/3 { bes8[\cresc a g] f[ es d] c[ bes a!] }
-    | \times 2/3 { g[ bes es] g[-> f es] d[ c bes] as[ g f] }
-    | \times 2/3 { es[ g c] es[ g c] } es4 d
+    | r4 \tuplet 3/2 { bes8[\cresc a g] f[ es d] c[ bes a!] }
+    | \tuplet 3/2 { g[ bes es] g[-> f es] d[ c bes] as[ g f] }
+    | \tuplet 3/2 { es[ g c] es[ g c] } es4 d
     | c\f es d2
 
     % 50
     | c4 es d2
-    | \times 2/3 { c8[\< d es] c[ d es] c[ d es] c[ d es]\! }
+    | \tuplet 3/2 { c8[\< d es] c[ d es] c[ d es] c[ d es]\! }
     | c2\ff des
     | bes( c4) es,-.
     | d bes2\fz( bes4-.)
@@ -114,13 +114,13 @@ violaFourthMov =  \relative g {
   | r c-. c-. r
   | r c-. c-. r
   | r des-. des-. r
-  | r des( es) \times 2/3 { es8( f e) }
+  | r des( es) \tuplet 3/2 { es8( f e) }
 
   % 90
   | as4( es c bes)
   | as4 r r2
   | R1
-  | r4 g'-. as-. \times 2/3 { g8( as bes) }
+  | r4 g'-. as-. \tuplet 3/2 { g8( as bes) }
   | es,1\>
   | << { es,( } { s4 s2.\! } >>
   | fes1\p
@@ -135,36 +135,36 @@ violaFourthMov =  \relative g {
   | e
   | fis(
   | << { gis) } { s2.\< s4\! } >>
-  | a4 r r \times 2/3 { e8( fis e) }
+  | a4 r r \tuplet 3/2 { e8( fis e) }
   | a4-. e-. cis-. gis''-.
-  | a-. \times 2/3 { gis8( a b) } c!4-. b-.
-  | g-.\fz \times 2/3 { gis8( a b) } e,4-. \times 2/3 { e8( f! e) }
+  | a-. \tuplet 3/2 { gis8( a b) } c!4-. b-.
+  | g-.\fz \tuplet 3/2 { gis8( a b) } e,4-. \tuplet 3/2 { e8( f! e) }
 
   % 110
-  | \repeat unfold 4 { a4-.\fz \times 2/3 { e8( f e) } }
-  | \repeat unfold 4 { g4-.\fz \times 2/3 { e8( f e) } }
+  | \repeat unfold 4 { a4-.\fz \tuplet 3/2 { e8( f e) } }
+  | \repeat unfold 4 { g4-.\fz \tuplet 3/2 { e8( f e) } }
   | \tieDown g1( ~
-  | <g bes>2.) \tieNeutral \times 2/3 { a8( bes a) }
-  | \repeat unfold 3 { d4-.\fz \times 2/3 { a8( bes a) } }
-  d4-.\fz \times 2/3 { a,8( bes a) } 
-  | \repeat unfold 3 { c4-.\fz \times 2/3 { a8( bes a) } } 
-  c4-.\fz\times 2/3 { a'8( bes a) }
+  | <g bes>2.) \tieNeutral \tuplet 3/2 { a8( bes a) }
+  | \repeat unfold 3 { d4-.\fz \tuplet 3/2 { a8( bes a) } }
+  d4-.\fz \tuplet 3/2 { a,8( bes a) } 
+  | \repeat unfold 3 { c4-.\fz \tuplet 3/2 { a8( bes a) } } 
+  c4-.\fz\tuplet 3/2 { a'8( bes a) }
 
   % 120
   | c1\ff ~
-  | c2 r4 \times 2/3 { g8\f( fis g) }
-  | bes4-. g-. d-. \times 2/3 { c'8( d c) }
+  | c2 r4 \tuplet 3/2 { g8\f( fis g) }
+  | bes4-. g-. d-. \tuplet 3/2 { c'8( d c) }
   | es4-. c-. fis,-. d'-.
   | g,4( a bes) d,-.
   | es4(\trill d8) r es4(\trill d8) r
   | \acciaccatura d8 \afterGrace es1\trill( {d16[ es])}
   | d4-. d'-. r2
-  | r4 \times 2/3 { bes,8( a bes) } d4-. bes-.
-  | g-. \times 2/3 { g8( fis g) } bes4-. g-.
+  | r4 \tuplet 3/2 { bes,8( a bes) } d4-. bes-.
+  | g-. \tuplet 3/2 { g8( fis g) } bes4-. g-.
 
   % 130
-  | es \times 2/3 { a8( bes a) } c4-. a-.
-  | fis4-. \times 2/3 { fis8( g fis) } a4-. fis-.
+  | es \tuplet 3/2 { a8( bes a) } c4-. a-.
+  | fis4-. \tuplet 3/2 { fis8( g fis) } a4-. fis-.
   | g( fis) g( fis)
   | g1(
   | fis2) r4 fis4-.
@@ -200,7 +200,7 @@ violaFourthMov =  \relative g {
   | b( c b c)
   | b r r2
   | c(\< << { cis) } { s4 s4\! } >>
-  | \times 2/3 { d8[-.\f g-. b-.] d-.[ b-. g-.] } d4-. a-.
+  | \tuplet 3/2 { d8[-.\f g-. b-.] d-.[ b-. g-.] } d4-. a-.
 
   % 160
   | b-. g2\fz( g4)-.
@@ -221,10 +221,10 @@ violaFourthMov =  \relative g {
   | g-. r r2
   | g4( a) g( a)
   | g-. r r2
-  | \times 2/3 { c,,8[-. e-. g]-. c[-.-\markup { \italic cresc. } g-. e-.] 
+  | \tuplet 3/2 { c,,8[-. e-. g]-. c[-.-\markup { \italic cresc. } g-. e-.] 
   c[-. e-. g-.] c-.[ g-. e-.] }
-  | \times 2/3 { cis[ e g] bes[ g e] cis[ e g] bes[ g e] }
-  | \times 2/3 { d[\ff g b!] d[ b g] d[ g b] d[ b g] }
+  | \tuplet 3/2 { cis[ e g] bes[ g e] cis[ e g] bes[ g e] }
+  | \tuplet 3/2 { d[\ff g b!] d[ b g] d[ g b] d[ b g] }
   | d4-. r d' r
 
   % 180
@@ -235,7 +235,7 @@ violaFourthMov =  \relative g {
   | d' r r2 
   | <b d>4-\markup { \italic cresc. } r <b d> r
   | <b d> r r d'4\f^\markup { arco }
-  | \times 2/3 { e8[-. d-. c]-. b[-. a-. g]-. fis[-. e-. d]-. c[-. b-. a]-. }
+  | \tuplet 3/2 { e8[-. d-. c]-. b[-. a-. g]-. fis[-. e-. d]-. c[-. b-. a]-. }
   | g4 r r b\p^\markup { pizz. }
   | d b d b
 
@@ -245,7 +245,7 @@ violaFourthMov =  \relative g {
   | d' r r2 
   | <b d>4-\markup { \italic cresc. } r <b d> r
   | <b d> r r d'4\ff^\markup { arco }
-  | \times 2/3 { e8[-. d-. c]-. b[-. a-. g]-. fis[-. e-. d]-. c[-. b-. a]-. }
+  | \tuplet 3/2 { e8[-. d-. c]-. b[-. a-. g]-. fis[-. e-. d]-. c[-. b-. a]-. }
   | g4 r r2
   | R1
   | g4-. d'-. d-. fis-.

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/iv-violin1.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/iv-violin1.ily
@@ -1,16 +1,16 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIFourthMov =  \relative g' {
   \key g \minor
   \clef violin
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   \repeat volta 2 {
-    \times 2/3 { g8(\f fis g) }
-    | bes!4-. g-. d-. \times 2/3 { c'8( d c) }
-    | es4-. c-. fis,-. \times 2/3 { d'8( es c) }
-    | bes4-. \times 2/3 { bes8( c a) } g4-. d-.
+    \tuplet 3/2 { g8(\f fis g) }
+    | bes!4-. g-. d-. \tuplet 3/2 { c'8( d c) }
+    | es4-. c-. fis,-. \tuplet 3/2 { d'8( es c) }
+    | bes4-. \tuplet 3/2 { bes8( c a) } g4-. d-.
     | \repeat unfold 2 { es4(\trill d8) r }
     | \acciaccatura d8 \afterGrace es1(\trill {d16[ es])}
     | d4-. d'-. r2
@@ -21,44 +21,44 @@ violinIFourthMov =  \relative g' {
     % 10
     | g(\trill fis8) r g4(\trill fis8) r
     | \acciaccatura fis8 \afterGrace g1(\trill {fis16[ g])}
-    | fis4 r r \times 2/3 { g,8( fis g) }
-    | bes4-. g-. d-. \times 2/3 { g8( fis g) }
-    | bes4-. g-. es-. \times 2/3 { g8( fis g) } \noTupletNum
-    | bes4-. g-. e-. \times 2/3 { g8(\p fis g) }
-    | \repeat unfold 3 { bes8-. r \times 2/3 { g( fis g) } }
-    bes-. r \times 2/3 { f(\f e f) }
-    | bes-. r \times 2/3 { f( e f) } bes-. r \times 2/3 { f-. e-. f-. }
-    | \times 2/3 { bes[-. a-. bes-.] f-.[ e-. f]-. bes[-. a-. bes]-. f[-. e-. f]-. }
+    | fis4 r r \tuplet 3/2 { g,8( fis g) }
+    | bes4-. g-. d-. \tuplet 3/2 { g8( fis g) }
+    | bes4-. g-. es-. \tuplet 3/2 { g8( fis g) } \noTupletNum
+    | bes4-. g-. e-. \tuplet 3/2 { g8(\p fis g) }
+    | \repeat unfold 3 { bes8-. r \tuplet 3/2 { g( fis g) } }
+    bes-. r \tuplet 3/2 { f(\f e f) }
+    | bes-. r \tuplet 3/2 { f( e f) } bes-. r \tuplet 3/2 { f-. e-. f-. }
+    | \tuplet 3/2 { bes[-. a-. bes-.] f-.[ e-. f]-. bes[-. a-. bes]-. f[-. e-. f]-. }
 
     % 20
-    | \times 2/3 { bes[-. a-. bes-.] d-.[ c-. d]-. f[-. e-. f]-. bes[-. a-. bes]-. }
-    | \times 2/3 { d-.[ c-. bes-.] a[-. g-. f-.] e[-. d-. c-.] bes-.[ a-. g-.] }
-    | f4 r \times 2/3 { bes'8-.[ g-. e-.] c-.[ bes-. g-.] }
-    | f4 r \times 2/3 { bes'8-.[ g-. e-.] c-.[ bes-. g-.] }
+    | \tuplet 3/2 { bes[-. a-. bes-.] d-.[ c-. d]-. f[-. e-. f]-. bes[-. a-. bes]-. }
+    | \tuplet 3/2 { d-.[ c-. bes-.] a[-. g-. f-.] e[-. d-. c-.] bes-.[ a-. g-.] }
+    | f4 r \tuplet 3/2 { bes'8-.[ g-. e-.] c-.[ bes-. g-.] }
+    | f4 r \tuplet 3/2 { bes'8-.[ g-. e-.] c-.[ bes-. g-.] }
     | f4 r r2
     | r r4 c'-.\p
     | d( es f) es-.
-    | d-. \times 2/3 { f8-. g-. f-. } bes4-. f-.
-    | d-. \times 2/3 { f8-. g-. f-. } bes4-. f-.
-    | d-. \times 2/3 { f8-. g-. f-. } bes4-. \times 2/3 { bes8-.\fz c-. bes-. }
+    | d-. \tuplet 3/2 { f8-. g-. f-. } bes4-. f-.
+    | d-. \tuplet 3/2 { f8-. g-. f-. } bes4-. f-.
+    | d-. \tuplet 3/2 { f8-. g-. f-. } bes4-. \tuplet 3/2 { bes8-.\fz c-. bes-. }
 
     % 30
-    | \times 2/3 { a-.[ bes-. c-.] bes-.[ a-. g-.] } 
-    f4 \times 2/3 { bes8-.\fz c-. bes-. }
-    | \times 2/3 { a-.[ bes-. c-.] bes-.[ a-. g-.] } 
-    f4 \times 2/3 { bes8-. c-. bes-. }
-    | \times 2/3 { es[-.-\mf c-. a-.] c[-. a-. f-.] es-.[ d-. es]-. a,-.[ c-. f-.] }
-    | \times 2/3 { d[ c bes] a[ c f] bes,[ c bes] a[ c f] }
-    | \times 2/3 { bes,[ d f] bes[ a g] f[ es d] c[ bes a] }
-    | \times 2/3 { bes[ c bes] a[ c f] bes,[ c bes] a[ c f] }
-    | \times 2/3 { bes,[ d f] bes[ a g] f[ es d] c[ bes a] }
-    | \times 2/3 { bes[ c bes] a[ c f] bes,[ c bes] a[ c f] }
-    | \times 2/3 { bes,[ d es] f[ d a] as[ d es] f[ d as] }
-    | \times 2/3 { g[\f f' f] f[ f f] g,[ es' es] es[ es es] }
+    | \tuplet 3/2 { a-.[ bes-. c-.] bes-.[ a-. g-.] } 
+    f4 \tuplet 3/2 { bes8-.\fz c-. bes-. }
+    | \tuplet 3/2 { a-.[ bes-. c-.] bes-.[ a-. g-.] } 
+    f4 \tuplet 3/2 { bes8-. c-. bes-. }
+    | \tuplet 3/2 { es[-.-\mf c-. a-.] c[-. a-. f-.] es-.[ d-. es]-. a,-.[ c-. f-.] }
+    | \tuplet 3/2 { d[ c bes] a[ c f] bes,[ c bes] a[ c f] }
+    | \tuplet 3/2 { bes,[ d f] bes[ a g] f[ es d] c[ bes a] }
+    | \tuplet 3/2 { bes[ c bes] a[ c f] bes,[ c bes] a[ c f] }
+    | \tuplet 3/2 { bes,[ d f] bes[ a g] f[ es d] c[ bes a] }
+    | \tuplet 3/2 { bes[ c bes] a[ c f] bes,[ c bes] a[ c f] }
+    | \tuplet 3/2 { bes,[ d es] f[ d a] as[ d es] f[ d as] }
+    | \tuplet 3/2 { g[\f f' f] f[ f f] g,[ es' es] es[ es es] }
 
     % 40
-    | \times 2/3 { f,[ es' es] es[ es es] es,[ d' d] d[ d d] }
-    | \times 2/3 { es,[ c' c] es,[ c' c] d,[ bes' bes] es,[ a a] }
+    | \tuplet 3/2 { f,[ es' es] es[ es es] es,[ d' d] d[ d d] }
+    | \tuplet 3/2 { es,[ c' c] es,[ c' c] d,[ bes' bes] es,[ a a] }
     | bes4 \grace { f'32([ es d] } es4)->( 
     d8) r \grace { f32([ es d] } es4)->( 
     | d8) r r4 r \grace { f32([ es d] } es4)->\p( 
@@ -68,14 +68,14 @@ violinIFourthMov =  \relative g' {
     | g2\cresc r4 d8. d16
     | bes'2 r4 bes8. bes16
     | es2 r4 es8. es16
-    | \times 2/3 { es8[\f d c] bes[ a g] 
+    | \tuplet 3/2 { es8[\f d c] bes[ a g] 
     f[ g a] bes[ c d] }
 
     % 50
-    | \times 2/3 { es[ d c] bes[ a g] f[ g a] bes[ c d] }
-    | \times 2/3 { es[-\< d c] d[ c bes] es[ d c] d[ c bes]-\! }
-    | \times 2/3 { es,\ff g' g g g g e, g' g g g g }
-    | \times 2/3 { f,[ bes d] f[ d bes] } f4 \afterGrace c'4(\trill {bes16[ c)]} 
+    | \tuplet 3/2 { es[ d c] bes[ a g] f[ g a] bes[ c d] }
+    | \tuplet 3/2 { es[-\< d c] d[ c bes] es[ d c] d[ c bes]-\! }
+    | \tuplet 3/2 { es,\ff g' g g g g e, g' g g g g }
+    | \tuplet 3/2 { f,[ bes d] f[ d bes] } f4 \afterGrace c'4(\trill {bes16[ c)]} 
     | bes4-. es,,2(\fz f4)-.
     | \acciaccatura as8 ges4\p( f \slashedGrace as8 ges4 f)
     | ges2( f4 es)
@@ -90,10 +90,10 @@ violinIFourthMov =  \relative g' {
     | ges4-. bes2(\fz c4)-.
     | \acciaccatura es8 des4\p-\( c \acciaccatura es8 des4-\) c
     | des2 a
-    | \times 2/3 { bes'8[(\f c bes]) a-.[ f-. a-.] bes[( c bes]) a-.[ f-. a]-. }
-    | \times 2/3 { bes[ d! c] bes[ a g] f[ g f] es[ d es] }
-    | \times 2/3 { bes'[(\f c bes]) a-.[ f-. a-.] bes[( c bes]) a-.[ f-. a]-. }
-    | \times 2/3 { bes[ d c] bes[ a g] f[ es d] c[ bes a] }
+    | \tuplet 3/2 { bes'8[(\f c bes]) a-.[ f-. a-.] bes[( c bes]) a-.[ f-. a]-. }
+    | \tuplet 3/2 { bes[ d! c] bes[ a g] f[ g f] es[ d es] }
+    | \tuplet 3/2 { bes'[(\f c bes]) a-.[ f-. a-.] bes[( c bes]) a-.[ f-. a]-. }
+    | \tuplet 3/2 { bes[ d c] bes[ a g] f[ es d] c[ bes a] }
 
     % 70
     | g4-. g'-. f-. a,-.
@@ -101,8 +101,8 @@ violinIFourthMov =  \relative g' {
     | <bes-. bes'> r r
   }
 
-  \times 2/3 { bes8(\f a bes) }
-  | des4-. bes-. f-. \times 2/3 { es'8( f es) }
+  \tuplet 3/2 { bes8(\f a bes) }
+  | des4-. bes-. f-. \tuplet 3/2 { es'8( f es) }
   | ges4-. es-. a,-. f' ~
   | f des-. bes-. c-.
   | \acciaccatura es8 des4-\( c \acciaccatura es8 des4-\) c
@@ -115,18 +115,18 @@ violinIFourthMov =  \relative g' {
   | f4( e f c)
   | \acciaccatura es8 des4-\( c \acciaccatura es8 des4-\) c
   | \acciaccatura c8 \afterGrace des1(\trill {c16[ des])}
-  | c2. \times 2/3 { c8( des c) }
-  | as'4-. f-. c-. \times 2/3 { c8( des c) }
-  | bes'4-. g-. c,-. \times 2/3 { c8( des c) }
-  | as'4-. f-. c-. \times 2/3 { des8( es des) }
-  | as'4-. f-. des-. \times 2/3 { des8( c des) }
+  | c2. \tuplet 3/2 { c8( des c) }
+  | as'4-. f-. c-. \tuplet 3/2 { c8( des c) }
+  | bes'4-. g-. c,-. \tuplet 3/2 { c8( des c) }
+  | as'4-. f-. c-. \tuplet 3/2 { des8( es des) }
+  | as'4-. f-. des-. \tuplet 3/2 { des8( c des) }
   | bes'4( g) des( bes)
 
   % 90
-  | c-. des-. es-. \times 2/3 { es8( f es) }
-  | as4-. es-. c-. \times 2/3 { es8( f es) }
-  | as4-. es-. c-. \times 2/3 { es8( f es) }
-  | as4-. es-. ces-. \times 2/3 { es8( fes es) }
+  | c-. des-. es-. \tuplet 3/2 { es8( f es) }
+  | as4-. es-. c-. \tuplet 3/2 { es8( f es) }
+  | as4-. es-. c-. \tuplet 3/2 { es8( f es) }
+  | as4-. es-. ces-. \tuplet 3/2 { es8( fes es) }
   | as4(-\> es ces g!)
   | as( es-\! ces as)
   | as'1\p ~
@@ -142,35 +142,35 @@ violinIFourthMov =  \relative g' {
   | a'( fis d b)
   | gis'(-\< e d b)-\!
   | cis4r r2
-  | r4 \times 2/3 { e'8(\f fis e) } a4-. e-.
-  | cis-. \times 2/3 { e8( f! e) } a4-. e-.
-  | c!-.\fz \times 2/3 { e8( f e) } a4-.\fz \times 2/3 { e,8( f e) }
+  | r4 \tuplet 3/2 { e'8(\f fis e) } a4-. e-.
+  | cis-. \tuplet 3/2 { e8( f! e) } a4-. e-.
+  | c!-.\fz \tuplet 3/2 { e8( f e) } a4-.\fz \tuplet 3/2 { e,8( f e) }
 
   % 110
-  | \repeat unfold 4 { a4-.\fz \times 2/3 { e8( f e) } }
-  | g!4-.\fz \times 2/3 { e8( f e) } 
-  \repeat unfold 3 { g4-.\fz \times 2/3 { e8( f e) } }
-  | cis'4-.\ff \times 2/3 { cis8( d cis) } bes'!4-.\fz \times 2/3 { e,8( f e) }
-  | g4-.\f \times 2/3 { cis,8( d cis) } e4-.\fz \times 2/3 { a,8( bes a) }
-  | \repeat unfold 4 { d4-.\fz \times 2/3 { a8( bes a) } }
-  | c!4-.\fz \times 2/3 { a8( bes a) }
-  \repeat unfold 2 { c4-.\fz \times 2/3 { a8( bes a) } }
-  c4-.\fz \times 2/3 { c8( d c) }
+  | \repeat unfold 4 { a4-.\fz \tuplet 3/2 { e8( f e) } }
+  | g!4-.\fz \tuplet 3/2 { e8( f e) } 
+  \repeat unfold 3 { g4-.\fz \tuplet 3/2 { e8( f e) } }
+  | cis'4-.\ff \tuplet 3/2 { cis8( d cis) } bes'!4-.\fz \tuplet 3/2 { e,8( f e) }
+  | g4-.\f \tuplet 3/2 { cis,8( d cis) } e4-.\fz \tuplet 3/2 { a,8( bes a) }
+  | \repeat unfold 4 { d4-.\fz \tuplet 3/2 { a8( bes a) } }
+  | c!4-.\fz \tuplet 3/2 { a8( bes a) }
+  \repeat unfold 2 { c4-.\fz \tuplet 3/2 { a8( bes a) } }
+  c4-.\fz \tuplet 3/2 { c8( d c) }
 
   % 120
-  | a'4-.\ff \times 2/3 { a8( bes a) } c4-.\fz \times 2/3 { fis,8( g fis) }
-  | a4-. \times 2/3 { c,8( d c) } es4-. es-.\f
+  | a'4-.\ff \tuplet 3/2 { a8( bes a) } c4-.\fz \tuplet 3/2 { fis,8( g fis) }
+  | a4-. \tuplet 3/2 { c,8( d c) } es4-. es-.\f
   | d bes'2(-> a4)
   | r4 es'2(-> d8 c)
   | bes4( a g) fis-.
   | g4(\trill fis8) r g4(\trill fis8) r
   | \acciaccatura fis8 \afterGrace g1(\trill {fis16[ g])}
-  | fis2 r4 \times 2/3 { g,8( fis g) }
-  | bes4-. g-. d-. \times 2/3 { g8( fis g) }
-  | bes4-. g-. es-. \times 2/3 { g8( fis g) }
+  | fis2 r4 \tuplet 3/2 { g,8( fis g) }
+  | bes4-. g-. d-. \tuplet 3/2 { g8( fis g) }
+  | bes4-. g-. es-. \tuplet 3/2 { g8( fis g) }
 
   % 130
-  | es'4-. c-. a-. \times 2/3 { a8( bes a) }
+  | es'4-. c-. a-. \tuplet 3/2 { a8( bes a) }
   | c4-. a-. fis-. d-.
   | es(\trill d) es\trill( d)
   | \acciaccatura d8 \afterGrace es1(\trill {d16[ es])}
@@ -182,34 +182,34 @@ violinIFourthMov =  \relative g' {
 
   \key g \major
 
-  \acciaccatura a''8 \times 2/3 { g8( fis g) }
-  | b4( g d) \acciaccatura e8 \times 2/3 { d8( cis d) }
+  \acciaccatura a''8 \tuplet 3/2 { g8( fis g) }
+  | b4( g d) \acciaccatura e8 \tuplet 3/2 { d8( cis d) }
 
   % 140
   % The cautionary natural before the C is repeated two times as well
   | \repeat unfold 2 { c'!4( a d,) 
-  \acciaccatura e8 \times 2/3 { d( cis d) } }
-  | d'4( b g8.[) d'16] \acciaccatura e8 \times 2/3 { d[( cis d)] }
+  \acciaccatura e8 \tuplet 3/2 { d( cis d) } }
+  | d'4( b g8.[) d'16] \acciaccatura e8 \tuplet 3/2 { d[( cis d)] }
   | g4( d b g)
   | e( c a e)
   | d2(-> \afterGrace c)\(\trill {b16[ c]\)}
-  | b4 \times 2/3 { g'8( fis g) b[( a b)] d[( cis d)] }
-  | \times 2/3 { g[( fis g)] b[( a b)] d[( cis d)] } g4 ~
+  | b4 \tuplet 3/2 { g'8( fis g) b[( a b)] d[( cis d)] }
+  | \tuplet 3/2 { g[( fis g)] b[( a b)] d[( cis d)] } g4 ~
   | g4 e2 c!4 ~
   | c a2 g4
 
   % 150
   | \repeat unfold 3
-  { \times 2/3 { fis8[-. g-. a-.] g[-. fis-. e-.] } 
-  d4 \times 2/3 { g8[-.\fz a-. g-.] } }
-  | \times 2/3 { fis[-. c'-. a]-. g[-. fis-. e]-. d[-. e-. d]-. c[-. b-. a]-. }
+  { \tuplet 3/2 { fis8[-. g-. a-.] g[-. fis-. e-.] } 
+  d4 \tuplet 3/2 { g8[-.\fz a-. g-.] } }
+  | \tuplet 3/2 { fis[-. c'-. a]-. g[-. fis-. e]-. d[-. e-. d]-. c[-. b-. a]-. }
   | \repeat unfold 2
   {
-    \times 2/3 { g[ b d] c[ a fis] g[ b d] c[ a fis] }
-    \times 2/3 { g[ b d] g[ fis e] d[ c b] a[ g fis] }
+    \tuplet 3/2 { g[ b d] c[ a fis] g[ b d] c[ a fis] }
+    \tuplet 3/2 { g[ b d] g[ fis e] d[ c b] a[ g fis] }
   }
-  | \times 2/3 { e[-\< e' e] e[ e e] e,[ g' g] g[ g g]-\! }
-  | \times 2/3 { d,[-.\f g-. b-.] d[-. b-. g-.] } d4-. fis'-.
+  | \tuplet 3/2 { e[-\< e' e] e[ e e] e,[ g' g] g[ g g]-\! }
+  | \tuplet 3/2 { d,[-.\f g-. b-.] d[-. b-. g-.] } d4-. fis'-.
 
   % 160
   | g-. c,,2(\fz d4)-.
@@ -226,36 +226,36 @@ violinIFourthMov =  \relative g' {
   % 170
   | \acciaccatura c'!8 bes4\p-\( a \acciaccatura c8 bes4-\) a
   |  bes2 fis
-  | \times 2/3 { g'8(\f a g) fis[-. d-. fis-.] g[( a g)] fis[-. d-. fis-.] }
-  | \times 2/3 { g[-. b!-. a]-. g[-. fis-. e]-. d[-. e-. d]-. c[-. b-. a]-. }
-  | \repeat unfold 2 { \times 2/3 { g'[( a g)] fis[-. d-. fis]-. } }
-  | \times 2/3 { g[-. b-. a]-. g[-. fis-. e]-. d[-. e-. d]-. c[-. b-. a]-. }
+  | \tuplet 3/2 { g'8(\f a g) fis[-. d-. fis-.] g[( a g)] fis[-. d-. fis-.] }
+  | \tuplet 3/2 { g[-. b!-. a]-. g[-. fis-. e]-. d[-. e-. d]-. c[-. b-. a]-. }
+  | \repeat unfold 2 { \tuplet 3/2 { g'[( a g)] fis[-. d-. fis]-. } }
+  | \tuplet 3/2 { g[-. b-. a]-. g[-. fis-. e]-. d[-. e-. d]-. c[-. b-. a]-. }
   | e4 r r2
   | <bes' g'>4 r r2
-  | \times 2/3 { d,8[-.\ff g-. b-.] d[-. b-. g-.] d[-. g-. b]-. d[-. b-. g]-. }
+  | \tuplet 3/2 { d,8[-.\ff g-. b-.] d[-. b-. g-.] d[-. g-. b]-. d[-. b-. g]-. }
   | d4-. r <d-. a' fis'> r
 
   % 180
-  | r2 r4 \times 2/3 { d'8(\p e d) }
-  | b4-. \times 2/3 { d8( e d) } b4-. \times 2/3 { d8( e d) }
-  | b4-. g'-. b-. \times 2/3 { c,8( d c) }
-  | a4-. \times 2/3 { c8( d c) } a4-. \times 2/3 { c8( d c) }
-  | a4-. fis'-. a-. \times 2/3 { b,8( c b) }
-  | g4-\markup { \italic cresc. } \times 2/3 { d'8( e d) } b4-. \times 2/3 { g'8( a g) }
-  | d4 \times 2/3 { b'8( c b) } g4-. d'-.\f
-  | \times 2/3 { c8[-. b-. a]-. g[-. fis-. e]-. d[-. c-. b]-. a[-. g-. fis]-. }
-  | g4 r r \times 2/3 { d'8(\p e d) }
-  | b4-. \times 2/3 { d8( e d) } b4-. \times 2/3 { d8( e d) }
+  | r2 r4 \tuplet 3/2 { d'8(\p e d) }
+  | b4-. \tuplet 3/2 { d8( e d) } b4-. \tuplet 3/2 { d8( e d) }
+  | b4-. g'-. b-. \tuplet 3/2 { c,8( d c) }
+  | a4-. \tuplet 3/2 { c8( d c) } a4-. \tuplet 3/2 { c8( d c) }
+  | a4-. fis'-. a-. \tuplet 3/2 { b,8( c b) }
+  | g4-\markup { \italic cresc. } \tuplet 3/2 { d'8( e d) } b4-. \tuplet 3/2 { g'8( a g) }
+  | d4 \tuplet 3/2 { b'8( c b) } g4-. d'-.\f
+  | \tuplet 3/2 { c8[-. b-. a]-. g[-. fis-. e]-. d[-. c-. b]-. a[-. g-. fis]-. }
+  | g4 r r \tuplet 3/2 { d'8(\p e d) }
+  | b4-. \tuplet 3/2 { d8( e d) } b4-. \tuplet 3/2 { d8( e d) }
 
   % 190
-  | b4-. g'-. b-. \times 2/3 { c,8( d c) }
-  | a4-. \times 2/3 { c8( d c) } a4-. \times 2/3 { c8( d c) }
-  | a4-. fis'-. a-. \times 2/3 { b,8( c b) }
-  | g4-.-\markup { \italic cresc. } \times 2/3 { d'8( e d) } b4-. \times 2/3 { g'8( a g) }
-  | d4-. \times 2/3 { b'8( c b) } g4-. d'-.\ff
-  | \times 2/3 { c8[-. b-. a]-. g[-. fis-. e]-. d[-. c-. b]-. a[-. g-. fis]-. }
+  | b4-. g'-. b-. \tuplet 3/2 { c,8( d c) }
+  | a4-. \tuplet 3/2 { c8( d c) } a4-. \tuplet 3/2 { c8( d c) }
+  | a4-. fis'-. a-. \tuplet 3/2 { b,8( c b) }
+  | g4-.-\markup { \italic cresc. } \tuplet 3/2 { d'8( e d) } b4-. \tuplet 3/2 { g'8( a g) }
+  | d4-. \tuplet 3/2 { b'8( c b) } g4-. d'-.\ff
+  | \tuplet 3/2 { c8[-. b-. a]-. g[-. fis-. e]-. d[-. c-. b]-. a[-. g-. fis]-. }
   | \repeat unfold 2
-  { \times 2/3 { g[( a b]) a[( b c]) b[( c d]) c[( b a]) } }
+  { \tuplet 3/2 { g[( a b]) a[( b c]) b[( c d]) c[( b a]) } }
   | g4-. fis'-. g-. a-.
   | b-. r <d,,-. a' fis'> r
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/iv-violin2.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/iv-violin2.ily
@@ -1,16 +1,16 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIIFourthMov =  \relative g' {
   \key g \minor
   \clef violin
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   \repeat volta 2 {
-    \times 2/3 { g8(\f fis g) }
-    | bes!4-. g-. d-. \times 2/3 { c'8( d c) }
-    | es4-. c-. fis,-. \times 2/3 { d'8( es c) }
-    | bes4-. \times 2/3 { bes8( c a) } \noTupletNum g4-. d-.
+    \tuplet 3/2 { g8(\f fis g) }
+    | bes!4-. g-. d-. \tuplet 3/2 { c'8( d c) }
+    | es4-. c-. fis,-. \tuplet 3/2 { d'8( es c) }
+    | bes4-. \tuplet 3/2 { bes8( c a) } \noTupletNum g4-. d-.
     | \repeat unfold 2 { es4(-\trill d8) r }
     | \acciaccatura d8 \afterGrace es1(\trill {d16[ es])}
     | d4-. d'-. r2
@@ -26,20 +26,20 @@ violinIIFourthMov =  \relative g' {
     | r es-. es-. r
     | r bes-. bes-. r
     | R1
-    | r2 r4 \times 2/3 { f'8(\f e f) }
-    | bes-. r \times 2/3 { f( e f) } bes-. r \times 2/3 { f-. e-. f-. }
-    | \times 2/3 { bes[-. a-. bes-.] f-.[ e-. f]-. bes[-. a-. bes]-. f[-. e-. f]-. }
+    | r2 r4 \tuplet 3/2 { f'8(\f e f) }
+    | bes-. r \tuplet 3/2 { f( e f) } bes-. r \tuplet 3/2 { f-. e-. f-. }
+    | \tuplet 3/2 { bes[-. a-. bes-.] f-.[ e-. f]-. bes[-. a-. bes]-. f[-. e-. f]-. }
 
     % 20
     | bes1 ~
     | bes2 <g bes>
     | <f a>4 r <g bes>2
     | <f a>4 r <bes, g'>2
-    | <a f'>4-. r r \times 2/3 { f'8-.\p g-. f-. }
+    | <a f'>4-. r r \tuplet 3/2 { f'8-.\p g-. f-. }
     | bes4-. f-. d-. a'-.
     | bes( c d) c-.
-    | bes r r \times 2/3 { a8-. bes-. c-. }
-    | f,4 r r \times 2/3 { a8-. bes-. c-. }
+    | bes r r \tuplet 3/2 { a8-. bes-. c-. }
+    | f,4 r r \tuplet 3/2 { a8-. bes-. c-. }
     | f,4 r r2
 
     % 30
@@ -68,7 +68,7 @@ violinIIFourthMov =  \relative g' {
 
     % 50
     | f
-    | \times 2/3 { f8[-\< f f] f[ f f] f[ f f] f[ f f]-\! }
+    | \tuplet 3/2 { f8[-\< f f] f[ f f] f[ f f] f[ f f]-\! }
     | <bes, g'>1\ff
     | d2( es4) a,-.
     | bes-. des,2(\fz des4)-.
@@ -120,7 +120,7 @@ violinIIFourthMov =  \relative g' {
   % 90
   | as( bes c des)
   | c r r2
-  | r4 \tupletNum \times 2/3 { es,8( f es) } \noTupletNum as4-. es-.
+  | r4 \tupletNum \tuplet 3/2 { es,8( f es) } \noTupletNum as4-. es-.
   | ces-. bes-. ces-. bes'-.
   | as1-\> ~
   | << { as } { s4 s2.-\! } >>
@@ -136,21 +136,21 @@ violinIIFourthMov =  \relative g' {
   | a
   | d! ~
   | << { d1 } { s2.-\< s4-\! } >>
-  | cis4 \times 2/3 { e8(\f fis e) } a!4-. e-.
-  | cis-. r r \times 2/3 { e8( fis e) }
+  | cis4 \tuplet 3/2 { e8(\f fis e) } a!4-. e-.
+  | cis-. r r \tuplet 3/2 { e8( fis e) }
   | a4-. e-. c!-. gis'-.
-  | a-.\fz b-. c!-.\fz \times 2/3 { e,8( f! e) }
+  | a-.\fz b-. c!-.\fz \tuplet 3/2 { e,8( f! e) }
 
   % 110
-  | \repeat unfold 4 { a4-.\fz \times 2/3 { e8( f e) } }
-  | g!4-.\fz \times 2/3 { e8( f e) } 
-  \repeat unfold 3 { g4-.\fz \times 2/3 { e8( f e) } }
+  | \repeat unfold 4 { a4-.\fz \tuplet 3/2 { e8( f e) } }
+  | g!4-.\fz \tuplet 3/2 { e8( f e) } 
+  \repeat unfold 3 { g4-.\fz \tuplet 3/2 { e8( f e) } }
   | <e cis'>1\ff ~
-  | <e cis'>2. \times 2/3 { a8( bes a) }
-  | \repeat unfold 4 { d4-.\fz \times 2/3 { a8( bes a) } }
-  | c!4-.\fz \times 2/3 { a8( bes a) }
-  \repeat unfold 2 { c4-.\fz \times 2/3 { a8( bes a) } }
-  c4-.\fz \times 2/3 { c8( d c) }
+  | <e cis'>2. \tuplet 3/2 { a8( bes a) }
+  | \repeat unfold 4 { d4-.\fz \tuplet 3/2 { a8( bes a) } }
+  | c!4-.\fz \tuplet 3/2 { a8( bes a) }
+  \repeat unfold 2 { c4-.\fz \tuplet 3/2 { a8( bes a) } }
+  c4-.\fz \tuplet 3/2 { c8( d c) }
 
   % 120
   | <a fis'>1\ff ~
@@ -164,8 +164,8 @@ violinIIFourthMov =  \relative g' {
   | R1*2
 
   % 130
-  | r4 \times 2/3 { c8( d c) } es4-. c-.
-  | a \times 2/3 { a8( bes a) } c4-. a,-.
+  | r4 \tuplet 3/2 { c8( d c) } es4-. c-.
+  | a \tuplet 3/2 { a8( bes a) } c4-. a,-.
   | bes( a) bes( a)
   | bes1(
   | a2) r
@@ -200,7 +200,7 @@ violinIIFourthMov =  \relative g' {
   | d d2 d4
   | d4 r r2
   | << { c2( cis) } { s2-\< s4 s4-\! } >>
-  | \times 2/3 { d8[-.\f g-. b-.] d[-. b-. g-.] } d4-. c'!-.
+  | \tuplet 3/2 { d8[-.\f g-. b-.] d[-. b-. g-.] } d4-. c'!-.
 
   % 160
   | b-. bes,2(\fz bes4)-.
@@ -221,10 +221,10 @@ violinIIFourthMov =  \relative g' {
   | <d b'>4-. r r2
   | << { b'!4( c) b( c) } \\ { d,1 } >>
   | <d b'>4-. r r2
-  | \times 2/3 { c8[-. e-. g]-. c[-.-\markup { \italic cresc. } g-. e]-. 
+  | \tuplet 3/2 { c8[-. e-. g]-. c[-.-\markup { \italic cresc. } g-. e]-. 
   c[-. e-. g]-. c[-. g-. e]-. }
-  | \times 2/3 { cis[-. e-. g]-. bes[-. g-. e]-. cis[-. e-. g]-. bes[-. g-. e]-. }
-  | \times 2/3 { d[-.\ff g-. b!]-. d[-. b-. g]-. d[-. g-. b]-. d[-. b-. g]-. }
+  | \tuplet 3/2 { cis[-. e-. g]-. bes[-. g-. e]-. cis[-. e-. g]-. bes[-. g-. e]-. }
+  | \tuplet 3/2 { d[-.\ff g-. b!]-. d[-. b-. g]-. d[-. g-. b]-. d[-. b-. g]-. }
   | d4-. r <d c'!-.> r
 
   % 180
@@ -235,7 +235,7 @@ violinIIFourthMov =  \relative g' {
   | fis a c g
   | d-\markup { \italic cresc. } b' g d'
   | b g' r g\f^\markup { arco }
-  | \times 2/3 { g8[-. fis-. e]-. d[-. c-. b]-. a[-. g-. fis]-. e[-. d-. c]-. }
+  | \tuplet 3/2 { g8[-. fis-. e]-. d[-. c-. b]-. a[-. g-. fis]-. e[-. d-. c]-. }
   | b4 r r b'\p^\markup { pizz. }
   | g b g b
 
@@ -245,10 +245,10 @@ violinIIFourthMov =  \relative g' {
   | fis a c g
   | d-\markup { \italic cresc. } b' g d'
   | b g' r g\ff^\markup { arco }
-  | \times 2/3 { g8[-. fis-. e]-. d[-. c-. b]-. a[-. g-. fis]-. e[-. d-. c]-. }
+  | \tuplet 3/2 { g8[-. fis-. e]-. d[-. c-. b]-. a[-. g-. fis]-. e[-. d-. c]-. }
   | b4-. d-. g-. d-.
   | b-. d-. g-. d-.
-  | \times 2/3 { g8[( a b]) a[( b c]) b[( c d]) c[( b a]) }
+  | \tuplet 3/2 { g8[( a b]) a[( b c]) b[( c d]) c[( b a]) }
   | g4-. r <d-. a' fis'> r
 
   % 200

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/iv-violoncello.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/iv-violoncello.ily
@@ -1,16 +1,16 @@
-\version "2.16.0"
+\version "2.18.0"
 celloFourthMov =  \relative e, {
   \key g \minor
   \clef bass
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   \repeat volta 2 {
-    \times 2/3 { g8(\f fis g) }
-    | bes!4-. g-. d-. \times 2/3 { c'8( d c) }
-    | es4-. c-. fis,-. \times 2/3 { d'8( es c) }
-    | bes4-. \times 2/3 { bes8( c a) } \noTupletNum g4-. d-.
+    \tuplet 3/2 { g8(\f fis g) }
+    | bes!4-. g-. d-. \tuplet 3/2 { c'8( d c) }
+    | es4-. c-. fis,-. \tuplet 3/2 { d'8( es c) }
+    | bes4-. \tuplet 3/2 { bes8( c a) } \noTupletNum g4-. d-.
     | \repeat unfold 2 { es4(-\trill d8) r }
     | \acciaccatura d8 \afterGrace es1-\trill( {d16[ es])}
     | d4-. d'-. r2
@@ -21,20 +21,20 @@ celloFourthMov =  \relative e, {
     | r g-. g-. r
     | r g-. g-. r
     | R1
-    | r2 r4 \times 2/3 { f!8(\f e f) }
-    | bes-. r \times 2/3 { f!8( e f) } bes-. r \times 2/3 { f!8-. e-. f-. }
-    | \repeat unfold 2 { \times 2/3 { bes[-. a-. bes-.] f-.[ e-. f-.] } }
+    | r2 r4 \tuplet 3/2 { f!8(\f e f) }
+    | bes-. r \tuplet 3/2 { f!8( e f) } bes-. r \tuplet 3/2 { f!8-. e-. f-. }
+    | \repeat unfold 2 { \tuplet 3/2 { bes[-. a-. bes-.] f-.[ e-. f-.] } }
 
     % 20
     | d1
     | g,2 c
     | f, r
     | f r
-    | f \times 2/3 { f'8[-. e-. f-.] es-.[ d-. c-.] }
+    | f \tuplet 3/2 { f'8[-. e-. f-.] es-.[ d-. c-.] }
     | bes4 r r2
-    | r r4 \times 2/3 { f'8-.\p g-. f-. }
-    | bes4-. f-. d-.\times 2/3 { f8-. g-. f-. }
-    | bes4-. f-. d-. \times 2/3 { f8-. g-. f-. }
+    | r r4 \tuplet 3/2 { f'8-.\p g-. f-. }
+    | bes4-. f-. d-.\tuplet 3/2 { f8-. g-. f-. }
+    | bes4-. f-. d-. \tuplet 3/2 { f8-. g-. f-. }
     | bes4-. f-. d-. d'-.
 
     % 30
@@ -46,24 +46,24 @@ celloFourthMov =  \relative e, {
     | bes,1 ~
     | bes4 r r f'
     | bes,1 ~
-    | bes2 r4 \times 2/3 { d,8-. c-. d-. }
+    | bes2 r4 \tuplet 3/2 { d,8-. c-. d-. }
     | es4-.\f g-. c-. es-.
 
     % 40
     | a,-. a'-. bes-. d-.
     | es,-. c-. f-. f,-.
-    | \times 2/3 { bes8[ c bes] a[ c f] bes,[ c bes] a[ c f] }
-    | \times 2/3 { bes,[ d f] bes[-> a g] f[ es d] c[\p bes a] }
-    | \times 2/3 { bes[ c bes] a[ c f] bes,[ c bes] a[ c f] }
-    | \times 2/3 { bes,[ d f] bes[-> a g] f[ es d] c[ bes a] }
-    | \deprecatedcresc \times 2/3 { g[ bes d] g[ f es] d[ c bes] a![ g f] }
-    | \times 2/3 { es[ g bes] es[ d c] bes[ as g] f[ es d] }
-    | \times 2/3 { c[ es g] c[ es g] c[ d c] bes[ c bes] }
+    | \tuplet 3/2 { bes8[ c bes] a[ c f] bes,[ c bes] a[ c f] }
+    | \tuplet 3/2 { bes,[ d f] bes[-> a g] f[ es d] c[\p bes a] }
+    | \tuplet 3/2 { bes[ c bes] a[ c f] bes,[ c bes] a[ c f] }
+    | \tuplet 3/2 { bes,[ d f] bes[-> a g] f[ es d] c[ bes a] }
+    | \deprecatedcresc \tuplet 3/2 { g[ bes d] g[ f es] d[ c bes] a![ g f] }
+    | \tuplet 3/2 { es[ g bes] es[ d c] bes[ as g] f[ es d] }
+    | \tuplet 3/2 { c[ es g] c[ es g] c[ d c] bes[ c bes] }
     | a2\f bes
 
     % 50
     | a bes
-    | \times 2/3 { a8[\< a a] bes[ bes bes] a[ a a] bes[ bes bes] }
+    | \tuplet 3/2 { a8[\< a a] bes[ bes bes] a[ a a] bes[ bes bes] }
     | es,2\!\ff e
     | f2. f4-.
     | bes,-. ges'2\fz( f4-.)
@@ -93,25 +93,25 @@ celloFourthMov =  \relative e, {
 
   r4
   | R1*5
-  | r2 r4 \times 2/3 { f'8(\f e f) }
-  | bes4-. f-. c-. \times 2/3 { bes'8( c bes) }
+  | r2 r4 \tuplet 3/2 { f'8(\f e f) }
+  | bes4-. f-. c-. \tuplet 3/2 { bes'8( c bes) }
 
   % 80
   | des4-. bes-. e,-. c'-.
   | f,( bes as) r
   | R1*2
-  | r4 \times 2/3 { e,8( f g) } c,4 r
+  | r4 \tuplet 3/2 { e,8( f g) } c,4 r
   | r4 f'-. f-. r
   | r e-. e-. r
   | r f-. f-. r
   | r f-. f-. r
-  | r \times 2/3 { es,8( d! es) } g4 r
+  | r \tuplet 3/2 { es,8( d! es) } g4 r
 
   % 90
   | R1
-  | r4 \times 2/3 { es8( f es) } as4-. es-.
+  | r4 \tuplet 3/2 { es8( f es) } as4-. es-.
   | c-. r r2
-  | r4 \times 2/3 { es'8( fes es) } as4-. es-.
+  | r4 \tuplet 3/2 { es'8( fes es) } as4-. es-.
   | ces1\> ~
   | << { ces } { s4 s2.\! } >>
   | des1\p(
@@ -125,35 +125,35 @@ celloFourthMov =  \relative e, {
   | cis,(
   | cis')
   | b
-  | e,2.\< \times 2/3 { e8\!(\f fis e) }
+  | e,2.\< \tuplet 3/2 { e8\!(\f fis e) }
   | a4-. e-. cis-. r
   | R1
-  | r2 r4 \times 2/3 { e'8( f! e) }
-  | a4-.\fz e-. c!-.\fz \times 2/3 { e8( f e) }
+  | r2 r4 \tuplet 3/2 { e'8( f! e) }
+  | a4-.\fz e-. c!-.\fz \tuplet 3/2 { e8( f e) }
 
   % 110
-  | a4-.\fz \times 2/3 { e8( f e) } a4-.\fz \times 2/3 { e8( f e) }
-  | a4-.\fz \times 2/3 { e8( f e) } a4-.\fz \times 2/3 { e8( f e) }
-  | g!4-.\fz \times 2/3 { e8( f e) } g4-.\fz \times 2/3 { e8( f e) }
-  | g4-.\fz \times 2/3 { e8( f e) } g4-.\fz \times 2/3 { e8( f e) }
+  | a4-.\fz \tuplet 3/2 { e8( f e) } a4-.\fz \tuplet 3/2 { e8( f e) }
+  | a4-.\fz \tuplet 3/2 { e8( f e) } a4-.\fz \tuplet 3/2 { e8( f e) }
+  | g!4-.\fz \tuplet 3/2 { e8( f e) } g4-.\fz \tuplet 3/2 { e8( f e) }
+  | g4-.\fz \tuplet 3/2 { e8( f e) } g4-.\fz \tuplet 3/2 { e8( f e) }
   | a,1\ff ~
-  | a2. \times 2/3 { a'8( bes! a) }
-  | d4-.\fz \times 2/3 { a8( bes a) } d4-.\fz \times 2/3 { a8( bes a) }
-  | d4-.\fz \times 2/3 { a8( bes a) } d4-.\fz \times 2/3 { a,8( bes a) }
-  | c!4-.\fz \times 2/3 { a8( bes a) } c4-.\fz \times 2/3 { a8( bes a) }
-  | c4-.\fz \times 2/3 { a8( bes a) } c4-.\fz \times 2/3 { a8( bes a) }
+  | a2. \tuplet 3/2 { a'8( bes! a) }
+  | d4-.\fz \tuplet 3/2 { a8( bes a) } d4-.\fz \tuplet 3/2 { a8( bes a) }
+  | d4-.\fz \tuplet 3/2 { a8( bes a) } d4-.\fz \tuplet 3/2 { a,8( bes a) }
+  | c!4-.\fz \tuplet 3/2 { a8( bes a) } c4-.\fz \tuplet 3/2 { a8( bes a) }
+  | c4-.\fz \tuplet 3/2 { a8( bes a) } c4-.\fz \tuplet 3/2 { a8( bes a) }
 
   % 120
   | d,1\ff ~
   | d2 r
   | R1*6
-  | r4 \times 2/3 { g'8(\f fis g) } bes4-. g-.
-  | es-. \times 2/3 { es8( d es) } g4-. es-.
+  | r4 \tuplet 3/2 { g'8(\f fis g) } bes4-. g-.
+  | es-. \tuplet 3/2 { es8( d es) } g4-. es-.
 
   % 130
   | c-. r r2
   | R1*3
-  | r4 \times 2/3 { fis,8( g a) } d,4 d
+  | r4 \tuplet 3/2 { fis,8( g a) } d,4 d
   | c( d c d)
   | es1 ~
   | es\fz->\fermata
@@ -186,7 +186,7 @@ celloFourthMov =  \relative e, {
   | g,1
   | g4 r r2
   | c2(\< << { cis) } { s4 s4\! } >>
-  | \times 2/3 { d8[-. g-. b]-. d[-. b-. g-.] } d4-. d-.
+  | \tuplet 3/2 { d8[-. g-. b]-. d[-. b-. g-.] } d4-. d-.
 
   % 160
   | g,-. es'2(\fz d4)-.
@@ -206,10 +206,10 @@ celloFourthMov =  \relative e, {
   | g,4-. r r2
   | g'1
   | g,4-. r r2
-  | \times 2/3 { c,8[-. e-. g]-. c[-.-\markup { \italic cresc. } g-. e]-. 
+  | \tuplet 3/2 { c,8[-. e-. g]-. c[-.-\markup { \italic cresc. } g-. e]-. 
   c[-. e-. g]-. c[-. g-. e]-. }
-  | \times 2/3 { cis[ e g] bes[ g e] cis[ e g] bes[ g e] }
-  | \times 2/3 { d[\ff g b!] d[ b g] d[ g b] d[ b g] }
+  | \tuplet 3/2 { cis[ e g] bes[ g e] cis[ e g] bes[ g e] }
+  | \tuplet 3/2 { d[\ff g b!] d[ b g] d[ g b] d[ b g] }
   | d4-. r d-. r
 
   % 180

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/score.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/score.ly
@@ -1,7 +1,7 @@
 % -*- LilyPond -*-
 % vim: ft=lilypond :
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -21,8 +21,8 @@ markingsIV = {}
 \layout {
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/viola.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/viola.ly
@@ -1,6 +1,6 @@
 % -*- LilyPond -*-
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -27,8 +27,8 @@ violaOverridesIV = {}
   \compressFullBarRests
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/viola_defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/viola_defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
 violaBreakBeforeII = ##t
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/violin1.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/violin1.ly
@@ -1,6 +1,6 @@
 % -*- LilyPond -*-
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -27,8 +27,8 @@ violinIOverridesIV = {}
   \compressFullBarRests
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/violin1_defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/violin1_defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
 violinIBreakI = {
   s1*87

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/violin2.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/violin2.ly
@@ -1,6 +1,6 @@
 % -*- LilyPond -*-
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -27,8 +27,8 @@ violinIIOverridesIV = {}
   \compressFullBarRests
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/violin2_defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/violin2_defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
 violinIIBreakBeforeII = ##t
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/violoncello.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/violoncello.ly
@@ -1,6 +1,6 @@
 % -*- LilyPond -*-
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -27,8 +27,8 @@ celloOverridesIV = {}
   \compressFullBarRests
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/violoncello_defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/1/violoncello_defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
 celloBreakBeforeII = ##t
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 \header {
   title = "String Quartet in D minor (“Fifths”)"
   subtitle = "Op. 76 No. 2"
@@ -47,8 +47,8 @@ markingsIII =  {
   s4
 
   s2.*42 s2
-  \override Score.RehearsalMark #'break-visibility = #begin-of-line-invisible
-  \override Score.RehearsalMark #'self-alignment-X = #1
+  \override Score.RehearsalMark.break-visibility = #begin-of-line-invisible
+  \override Score.RehearsalMark.self-alignment-X = #1
   \mark \markup { \large { \italic "Menuetto D.C." } }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/i-midi.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/i-midi.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
   \midi {
     \tempo 4 = 120

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/i-viola.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/i-viola.ily
@@ -1,10 +1,10 @@
-\version "2.16.0"
+\version "2.18.0"
 violaFirstMov =  \relative f {
   \key d \minor
   \clef alto
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   \repeat volta 2 {
     f8-.\f f-. f-. f-. r f-. f-. f-.

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/i-violin1.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/i-violin1.ily
@@ -1,10 +1,10 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIFirstMov =  \relative a' {
   \key d \minor
   \clef violin
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   \repeat volta 2 {
     a2\f d,

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/i-violin2.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/i-violin2.ily
@@ -1,10 +1,10 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIIFirstMov =  \relative a {
   \key d \minor
   \clef violin
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   \repeat volta 2 {
     r8 a\f-. a-. a-. r a-. a-. a-.

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/i-violoncello.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/i-violoncello.ily
@@ -1,10 +1,10 @@
-\version "2.16.0"
+\version "2.18.0"
 celloFirstMov =  \relative d, {
   \key d \minor
   \clef bass
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   \repeat volta 2 {
     d8\f d'-. d-. d-. r d-. d-. d-.

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/ii-midi.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/ii-midi.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
   \midi {
     \tempo 4 = 48

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/ii-viola.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/ii-viola.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violaSecondMov =  \relative d' {
   \key d \major
   \clef alto

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/ii-violin1.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/ii-violin1.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinISecondMov =  \relative a' {
   \key d \major
   \clef violin
@@ -97,8 +97,8 @@ violinISecondMov =  \relative a' {
   | d4 cis cis8 cis
 
 
-  \cadenzaOn c8[\fz\fermata ~ \times 2/3 { c16 a fis] } 
-  \times 2/3 { dis[ fis a] } 
+  \cadenzaOn c8[\fz\fermata ~ \tuplet 3/2 { c16 a fis] } 
+  \tuplet 3/2 { dis[ fis a] } 
   \small c16[ a fis dis fis a c8 a fis dis fis a] 
   \normalsize c4\p\fermata r8 \cadenzaOff
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/ii-violin2.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/ii-violin2.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIISecondMov =  \relative a {
   \key d \major
   \clef violin

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/ii-violoncello.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/ii-violoncello.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 celloSecondMov =  \relative f {
   \key d \major
   \clef bass

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/iii-midi.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/iii-midi.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
   \midi {
     \tempo 4 = 180

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/iii-viola.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/iii-viola.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violaThirdMov =  \relative d {
   \key d \minor
   \clef alto

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/iii-violin1.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/iii-violin1.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIThirdMov =  \relative d'' {
   \key d \minor
   \clef violin

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/iii-violin2.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/iii-violin2.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIIThirdMov =  \relative d' {
   \key d \minor
   \clef violin

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/iii-violoncello.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/iii-violoncello.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 celloThirdMov =  \relative d, {
   \key d \minor
   \clef bass

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/iv-midi.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/iv-midi.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
   \midi {
     \tempo 4 = 160

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/iv-viola.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/iv-viola.ily
@@ -1,10 +1,10 @@
-\version "2.16.0"
+\version "2.18.0"
 violaFourthMov =  \relative f' {
   \key d \minor
   \clef alto
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   \repeat volta 2 {
     r8
@@ -325,7 +325,7 @@ violaFourthMov =  \relative f' {
   | a,( g')
   | fis( d)
   | a( cis)
-  | \repeat unfold 2 { \times 2/3 { d,8-. fis-. a-. d-. a-. fis-. } }
+  | \repeat unfold 2 { \tuplet 3/2 { d,8-. fis-. a-. d-. a-. fis-. } }
   | d4 r <d a' d> r
   | <d a' d> r8
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/iv-violin1.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/iv-violin1.ily
@@ -1,10 +1,10 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIFourthMov =  \relative a' {
   \key d \minor
   \clef violin
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   \repeat volta 2 {
     a8\p
@@ -323,24 +323,24 @@ violinIFourthMov =  \relative a' {
   | \acciaccatura fis8 e d e cis
 
   % 250
-  | \times 2/3 { d-. e-. fis-. d-. e-. fis-. }
-  | \times 2/3 { e-. fis-. g-. a,-. b-. cis-. } \noTupletNum
-  | \times 2/3 { d-. cis-. d e fis g }
-  | \times 2/3 { gis a b g e cis }
-  | \times 2/3 { a cis d e fis g }
-  | \times 2/3 { gis a b g e cis }
-  | \times 2/3 { d e fis g a b }
-  | \times 2/3 { cis a cis e a, cis }
-  | \times 2/3 { d a g fis e d }
-  | \times 2/3 { e fis g a, b cis }
+  | \tuplet 3/2 { d-. e-. fis-. d-. e-. fis-. }
+  | \tuplet 3/2 { e-. fis-. g-. a,-. b-. cis-. } \noTupletNum
+  | \tuplet 3/2 { d-. cis-. d e fis g }
+  | \tuplet 3/2 { gis a b g e cis }
+  | \tuplet 3/2 { a cis d e fis g }
+  | \tuplet 3/2 { gis a b g e cis }
+  | \tuplet 3/2 { d e fis g a b }
+  | \tuplet 3/2 { cis a cis e a, cis }
+  | \tuplet 3/2 { d a g fis e d }
+  | \tuplet 3/2 { e fis g a, b cis }
 
   % 260
-  | \times 2/3 { d cis d e fis g }
-  | \times 2/3 { gis a b g e cis }
-  | \times 2/3 { a cis d e fis g }
-  | \times 2/3 { gis a b g e cis }
-  | \times 2/3 { d-. fis-. a-. d-. a-. fis-. }
-  | \times 2/3 { d-. fis-. a-. d-. a-. fis-. }
+  | \tuplet 3/2 { d cis d e fis g }
+  | \tuplet 3/2 { gis a b g e cis }
+  | \tuplet 3/2 { a cis d e fis g }
+  | \tuplet 3/2 { gis a b g e cis }
+  | \tuplet 3/2 { d-. fis-. a-. d-. a-. fis-. }
+  | \tuplet 3/2 { d-. fis-. a-. d-. a-. fis-. }
   | d4 r <d, fis' d'> r
   | d4 r8
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/iv-violin2.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/iv-violin2.ily
@@ -1,10 +1,10 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIIFourthMov =  \relative a' {
   \key d \minor
   \clef violin
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   \repeat volta 2 {
     r8
@@ -337,7 +337,7 @@ violinIIFourthMov =  \relative a' {
   | <e cis'>
   | <fis d'>
   | <e cis'>)
-  | \repeat unfold 2 { \times 2/3 { d8-. fis-. a-. d-. a-. fis-. } }
+  | \repeat unfold 2 { \tuplet 3/2 { d8-. fis-. a-. d-. a-. fis-. } }
   | d4 r
   | <d a' fis'> r
   | <d a' fis'> r8

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/iv-violoncello.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/iv-violoncello.ily
@@ -1,10 +1,10 @@
-\version "2.16.0"
+\version "2.18.0"
 celloFourthMov =  \relative d' {
   \key d \minor
   \clef bass
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   \repeat volta 2 {
     r8 
@@ -234,7 +234,7 @@ celloFourthMov =  \relative d' {
   | d-. r
   | r a
   | \repeat unfold 3 { \grace { d,16[( a'] } d2) ~ d }
-  | \repeat unfold 2 { \times 2/3 { d,8-. fis-. a-. d-. a-. fis-. } }
+  | \repeat unfold 2 { \tuplet 3/2 { d,8-. fis-. a-. d-. a-. fis-. } }
   | d4 r
   | <d a' d> r
   | <d a' d> r8

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/score.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/score.ly
@@ -1,7 +1,7 @@
 % -*- LilyPond -*-
 % vim: ft=lilypond :
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -21,8 +21,8 @@ markingsIV = {}
 \layout {
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/viola.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/viola.ly
@@ -1,6 +1,6 @@
 % -*- LilyPond -*-
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -27,8 +27,8 @@ violaOverridesIV = {}
   \compressFullBarRests
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/viola_defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/viola_defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
 violaBreakII = {
   s8

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/violin1.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/violin1.ly
@@ -1,6 +1,6 @@
 % -*- LilyPond -*-
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -27,8 +27,8 @@ violinIOverridesIV = {}
   \compressFullBarRests
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/violin1_defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/violin1_defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
 violinIBreakI = {
   s1*98 \pageBreak

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/violin2.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/violin2.ly
@@ -1,6 +1,6 @@
 % -*- LilyPond -*-
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -27,8 +27,8 @@ violinIIOverridesIV = {}
   \compressFullBarRests
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/violin2_defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/violin2_defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
 violinIIBreakBeforeII = ##t
 violinIIBreakIV = {

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/violoncello.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/violoncello.ly
@@ -1,6 +1,6 @@
 % -*- LilyPond -*-
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -27,8 +27,8 @@ celloOverridesIV = {}
   \compressFullBarRests
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/violoncello_defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/2/violoncello_defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
 celloBreakBeforeII = ##t
 celloBreakIV = {

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 \header {
   title = "String Quartet in C major (“Emperor”)"
   subtitle = "Op. 76 No. 3"
@@ -76,7 +76,7 @@ markingsIII =  {
   s4
 
   s2.*43 s2
-  \override Score.RehearsalMark #'break-visibility = #begin-of-line-invisible
-  \override Score.RehearsalMark #'self-alignment-X = #1
+  \override Score.RehearsalMark.break-visibility = #begin-of-line-invisible
+  \override Score.RehearsalMark.self-alignment-X = #1
   \mark \markup { \large { \italic "Menuetto D.C." } }
 }

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/i-midi.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/i-midi.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
   \midi {
     \tempo 4 = 100

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/i-viola.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/i-viola.ily
@@ -1,10 +1,10 @@
-\version "2.16.0"
+\version "2.18.0"
 violaFirstMov =  \relative g' {
   \key c \major
   \clef alto
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   \repeat volta 2 {
     g8-.\f

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/i-violin1.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/i-violin1.ily
@@ -1,10 +1,10 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIFirstMov =  \relative g'' {
   \key c \major
   \clef violin
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   \repeat volta 2 {
     g8-.\f
@@ -41,7 +41,7 @@ violinIFirstMov =  \relative g'' {
     fis8.(\trill\fz e32 fis) g8-. g-.
     | fis8.(\trill\fz e32 fis) g8-. g-. 
     fis8.(\trill\fz e32 fis) g8-. b-.
-    | \times 4/6 { c16[\ff a fis d c a] } \times 4/6 { fis[ a c d fis a] } c8 r r
+    | \tuplet 6/4 { c16[\ff a fis d c a] } \tuplet 6/4 { fis[ a c d fis a] } c8 r r
     << { b,8( a4. b8) } \\ { g8\p ~ g fis16 e fis8 gis } >> <c a>4 r8 e-.\fz
     | cis4( d8) c-.\fz ais4( b8) a-.\fz
     | fis4( g8) e'-.\fz g,4( a8) fis-.
@@ -150,7 +150,7 @@ violinIFirstMov =  \relative g'' {
     | cis8.(\trill b32 cis) d8 \grace { c16( } b16)( a32 b) 
     c8 \grace { g16( } fis16)( e32 fis) g8 g'
     | a4\trill b\trill c\trill d8-. e-.
-    | \repeat unfold 2 { \times 4/6 { f16[ d b g b d] } } f8 r r\fermata e,-.\p
+    | \repeat unfold 2 { \tuplet 6/4 { f16[ d b g b d] } } f8 r r\fermata e,-.\p
     | d4.( e8) f4 r8 a-.\fz
     | fis4( g8) f-.\fz dis4( e8) d-.\fz
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/i-violin2.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/i-violin2.ily
@@ -1,10 +1,10 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIIFirstMov =  \relative d'' {
   \key c \major
   \clef violin
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   \repeat volta 2 {
     d8-.\f

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/i-violoncello.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/i-violoncello.ily
@@ -1,10 +1,10 @@
-\version "2.16.0"
+\version "2.18.0"
 celloFirstMov =  \relative b {
   \key c \major
   \clef bass
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   \repeat volta 2 {
     b8-.\f

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/ii-midi.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/ii-midi.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
   \midi {
     \tempo 4 = 48

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/ii-viola.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/ii-viola.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violaSecondMov =  \relative g {
   \key g \major
   \clef alto

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/ii-violin1.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/ii-violin1.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinISecondMov =  \relative g' {
   \key g \major
   \clef violin
@@ -52,7 +52,7 @@ violinISecondMov =  \relative g' {
   | c, g' e' g, b, g' d' g, c, e g c e g b,, g'
   | a, c d fis g b d g c,,\p d fis a c fis g a
   | b, g' c, g' e, g' cis,, e' d, g b d d, c'! fis c
-  | b g' d b g d b d \times 4/6 { g, b d g b d } g b, b, g'
+  | b g' d b g d b d \tuplet 6/4 { g, b d g b d } g b, b, g'
   | c, g' e' g, b, g' d' g, c, e g c e g b,, g'
   | a, c d fis g b d g c,,\p d fis a c fis g a
   | b, g' c, g' e, g' cis,, e' d, g b d d, c'! fis c

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/ii-violin2.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/ii-violin2.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIISecondMov =  \relative b {
   \key g \major
   \clef violin

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/ii-violoncello.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/ii-violoncello.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 celloSecondMov =  \relative g {
   \key g \major
   \clef bass

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/iii-midi.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/iii-midi.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
   \midi {
     \tempo 4 = 180

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/iii-viola.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/iii-viola.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violaThirdMov =  \relative c' {
   \key c \major
   \clef alto

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/iii-violin1.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/iii-violin1.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIThirdMov =  \relative c'' {
   \key c \major
   \clef violin

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/iii-violin2.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/iii-violin2.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIIThirdMov =  \relative e' {
   \key c \major
   \clef violin

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/iii-violoncello.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/iii-violoncello.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 celloThirdMov =  \relative c' {
   \key c \major
   \clef bass

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/iv-midi.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/iv-midi.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
   \midi {
     \tempo 4 = 192

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/iv-viola.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/iv-viola.ily
@@ -1,10 +1,10 @@
-\version "2.16.0"
+\version "2.18.0"
 violaFourthMov =  \relative es' {
   \key c \minor
   \clef alto
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   \repeat volta 2 {
     <es c'>4-.\f r <d b'>-. r
@@ -26,7 +26,7 @@ violaFourthMov =  \relative es' {
     | f( es4) e(
     | f g as g)
     | f2( fis)
-    | \repeat unfold 2 { \times 2/3 { g,8 b d g fis g g, c es g fis g } }
+    | \repeat unfold 2 { \tuplet 3/2 { g,8 b d g fis g g, c es g fis g } }
 
     % 20
     | g,4 r r2
@@ -70,7 +70,7 @@ violaFourthMov =  \relative es' {
     | es4-. r f-. r
     | g-. r r2
     | R1*2
-    | \repeat unfold 4 { \times 2/3 { bes,8 bes bes } }
+    | \repeat unfold 4 { \tuplet 3/2 { bes,8 bes bes } }
     | as4 r bes r
     | es, r r es'
     | d2( es4 f)
@@ -110,7 +110,7 @@ violaFourthMov =  \relative es' {
   | r2 r4 d-.
   | es2( d4) r
   | R1*3
-  | r4 \times 2/3 { es8\f f es des c bes as g f }
+  | r4 \tuplet 3/2 { es8\f f es des c bes as g f }
   | es4( as g des')
   | c2( des4 es)
 
@@ -123,7 +123,7 @@ violaFourthMov =  \relative es' {
   | as2( g)
   | f( g4 as)
   | bes r r bes, ~
-  | bes \times 2/3 { g'8 f g as g as bes as bes }
+  | bes \tuplet 3/2 { g'8 f g as g as bes as bes }
   | c4 es,2 es4
 
   % 100
@@ -131,23 +131,23 @@ violaFourthMov =  \relative es' {
   | <bes g'>2( as'4 bes)
   | c <c, es>2 <as as'>4
   | <bes g'>2( as'4 bes)
-  | <es, c'> g as \times 2/3 { des,8 c bes }
-  | c4 g' as \noTupletNum \times 2/3 { des,8 c bes }
-  | \times 2/3 { c des es des c bes as bes c bes as g }
-  | \times 2/3 { f g as g f es d! es f g as a }
+  | <es, c'> g as \tuplet 3/2 { des,8 c bes }
+  | c4 g' as \noTupletNum \tuplet 3/2 { des,8 c bes }
+  | \tuplet 3/2 { c des es des c bes as bes c bes as g }
+  | \tuplet 3/2 { f g as g f es d! es f g as a }
   | bes4 as'!2\fz d,4
   | es es'2\fz bes,4
 
   % 110
   | g f'2\fz g4 ~
-  | g b c \times 2/3 { <f, b>8 <f b> <f b> }
-  | <es c'>4 b' c \times 2/3 { <f, b>8 <f b> <f b> }
-  | <es c'>4 b' c \times 2/3 { c,8( b c) }
-  | d4-. \times 2/3 { e8( d e) } f4-. e-.
-  | f-. \times 2/3 { g8( f e) } f4-. \times 2/3 { bes,8( a bes) }
-  | c4-. \times 2/3 { d8( c d) } es!4-. d-.
-  | es-. \times 2/3 { f8( es d) } es4-. r
-  | r2 r4 \times 2/3 { es8( f es) } \tupletNum
+  | g b c \tuplet 3/2 { <f, b>8 <f b> <f b> }
+  | <es c'>4 b' c \tuplet 3/2 { <f, b>8 <f b> <f b> }
+  | <es c'>4 b' c \tuplet 3/2 { c,8( b c) }
+  | d4-. \tuplet 3/2 { e8( d e) } f4-. e-.
+  | f-. \tuplet 3/2 { g8( f e) } f4-. \tuplet 3/2 { bes,8( a bes) }
+  | c4-. \tuplet 3/2 { d8( c d) } es!4-. d-.
+  | es-. \tuplet 3/2 { f8( es d) } es4-. r
+  | r2 r4 \tuplet 3/2 { es8( f es) } \tupletNum
   | d4-. g,-. g'-. g-.
 
   % 120
@@ -176,18 +176,18 @@ violaFourthMov =  \relative es' {
 
   % 140
   | f2( es)
-  | f4 \times 2/3 { d'!8 es-. f-. f ges as as ges f } \noTupletNum
+  | f4 \tuplet 3/2 { d'!8 es-. f-. f ges as as ges f } \noTupletNum
   | es4 bes2 bes4
   | as ces2\fz f,4
   | ges2( f)
-  | g!4 \times 2/3 { e'8-. f-. g-. g as bes bes as g }
+  | g!4 \tuplet 3/2 { e'8-. f-. g-. g as bes bes as g }
   | <c, as'>1
   | <c g'> ~
   | <c g'>
   | b4 r c r
 
   % 150
-  | \repeat unfold 2 { \times 2/3 { g8 b d g fis g g, c es g fis g } }
+  | \repeat unfold 2 { \tuplet 3/2 { g8 b d g fis g g, c es g fis g } }
   | g,4 r r\fermata \key c \major e'-.\p
   | f2( e4 f)
   | e( c' b) r
@@ -219,7 +219,7 @@ violaFourthMov =  \relative es' {
   | e r r c
   | b2( c4 d)
   | e-. r c-. r
-  | \times 2/3 { f,8 f f f f f es es es c c c }
+  | \tuplet 3/2 { f,8 f f f f f es es es c c c }
   | c4-. r g-. r
   | c r r g'
   | as2( g4 f)

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/iv-violin1.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/iv-violin1.ily
@@ -1,10 +1,10 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIFourthMov =  \relative es' {
   \key c \minor
   \clef violin
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   \repeat volta 2 {
     <es c' g'>4-.\f r <d b' as'>-. r
@@ -22,8 +22,8 @@ violinIFourthMov =  \relative es' {
     | c,2( b)
     | <es, c' g'>4-.\f r <d b' as'>-. r
     | <es c' g'>-. r r8 g'[ es c]
-    | \times 2/3 { b as' g f es d c g' f es d c }
-    | \times 2/3 { b as' g f es d } c8( g' c bes!)
+    | \tuplet 3/2 { b as' g f es d c g' f es d c }
+    | \tuplet 3/2 { b as' g f es d } c8( g' c bes!)
     | bes( as) as( g) g( f) f( es) 
     | es( d) d2 es8 c
     | \repeat unfold 2 { <d, b' g'>4-. r <es c' g'>-. r }
@@ -59,37 +59,37 @@ violinIFourthMov =  \relative es' {
     | bes1 ~
     | bes2. as4 ~
     | as g2( f4)
-    | \times 2/3 { bes'8\f g f es d c bes as g f es d } \noTupletNum
-    | \times 2/3 { es( d es) g( fis g) bes( a bes) es( d es) }
-    | \times 2/3 { f b d c bes as g f e f g es } \tupletNum
-    | d4-. \times 2/3 { bes8( a bes) c( bes c) d( c d) } \noTupletNum
+    | \tuplet 3/2 { bes'8\f g f es d c bes as g f es d } \noTupletNum
+    | \tuplet 3/2 { es( d es) g( fis g) bes( a bes) es( d es) }
+    | \tuplet 3/2 { f b d c bes as g f e f g es } \tupletNum
+    | d4-. \tuplet 3/2 { bes8( a bes) c( bes c) d( c d) } \noTupletNum
 
     % 50
-    | \times 2/3 { es-. c( b c) a-. f-. es-. f-. a-. c-. d-. es-. }
-    | \times 2/3 { f-. d( cis d) bes-. a-. bes-. c-. d-. es-. e-. f-. }
-    | \times 2/3 { g-. es( d es) f-. g-. as-. f( e f) g-. as-. }
-    | \times 2/3 { g( as g) c( d c) f, g a bes bes, d }
-    | \times 2/3 { es f g as f es d es f g fis g }
-    | \times 2/3 { c, d e f! g as bes, c d es f g }
-    | \times 2/3 { as as as g g g as as as g g g }
+    | \tuplet 3/2 { es-. c( b c) a-. f-. es-. f-. a-. c-. d-. es-. }
+    | \tuplet 3/2 { f-. d( cis d) bes-. a-. bes-. c-. d-. es-. e-. f-. }
+    | \tuplet 3/2 { g-. es( d es) f-. g-. as-. f( e f) g-. as-. }
+    | \tuplet 3/2 { g( as g) c( d c) f, g a bes bes, d }
+    | \tuplet 3/2 { es f g as f es d es f g fis g }
+    | \tuplet 3/2 { c, d e f! g as bes, c d es f g }
+    | \tuplet 3/2 { as as as g g g as as as g g g }
     | c4 r <f,, d'> r
     | <es es'> r r2
-    | \times 2/3 { f'8 g as g f es d c bes as g f }
+    | \tuplet 3/2 { f'8 g as g f es d c bes as g f }
 
     % 60
     | es4 r r2
-    | \times 2/3 { f'8 g as g f es d c bes as g f }
+    | \tuplet 3/2 { f'8 g as g f es d c bes as g f }
     | es4 r <bes' g'> r
     | <c as'> r <d, bes' as'> r
     | <es bes' g'> r <as c f> r
     | <bes, g' es'> r <bes f' d'> r
-    | \times 2/3 { es8 d es g fis g bes a bes g fis g }
-    | \times 2/3 { as! c bes as g f! es d f as f d }
-    | \times 2/3 { es d es g fis g bes a bes g fis g }
-    | \times 2/3 { as! ces bes as ges f es d f as f d }
+    | \tuplet 3/2 { es8 d es g fis g bes a bes g fis g }
+    | \tuplet 3/2 { as! c bes as g f! es d f as f d }
+    | \tuplet 3/2 { es d es g fis g bes a bes g fis g }
+    | \tuplet 3/2 { as! ces bes as ges f es d f as f d }
 
     % 70
-    | \times 2/3 { es d es as f d es d es as f d }
+    | \tuplet 3/2 { es d es as f d es d es as f d }
     | es4-. r g-. r
   }
 
@@ -112,42 +112,42 @@ violinIFourthMov =  \relative es' {
   | a2( bes4) f'-.
   | ges2( f4) r
   | R1*4
-  | r4 \tupletNum \times 2/3 { as8\f bes as ges f es des c bes }
+  | r4 \tupletNum \tuplet 3/2 { as8\f bes as ges f es des c bes }
 
   % 90
   | as4( des c ges')
   | r bes,( a es')
   | f,( des' f,) f'-.
   | as2( g4) f8 d
-  | g,4 \times 2/3 { g'8 f g as g as bes as bes } \noTupletNum
+  | g,4 \tuplet 3/2 { g'8 f g as g as bes as bes } \noTupletNum
   | c4 c,8 c' bes4 bes,8 bes'
-  | as4 \times 2/3 { as8 g as bes as bes c bes c }
+  | as4 \tuplet 3/2 { as8 g as bes as bes c bes c }
   | f,4 bes2 as4
-  | g \times 2/3 { es8 d es f es f g f g }
+  | g \tuplet 3/2 { es8 d es f es f g f g }
   | as2 des
 
   % 100
   | c4 r r2
-  | \times 2/3 { des8 es f es des c bes as g f es des }
+  | \tuplet 3/2 { des8 es f es des c bes as g f es des }
   | c4 r r2
-  | \times 2/3 { des'8 es f es des c bes as g f es des }
+  | \tuplet 3/2 { des'8 es f es des c bes as g f es des }
   | c4 r r2
-  | \times 2/3 { c8 des es des c bes as g as bes c des }
-  | \times 2/3 { c des es des c bes as bes c bes as g }
-  | \times 2/3 { f g as g f es d! es f es d c }
-  | \times 2/3 { bes( a bes) d( cis d) f e f as! g as }
-  | \times 2/3 { g fis g bes a bes es d es g fis g }
+  | \tuplet 3/2 { c8 des es des c bes as g as bes c des }
+  | \tuplet 3/2 { c des es des c bes as bes c bes as g }
+  | \tuplet 3/2 { f g as g f es d! es f es d c }
+  | \tuplet 3/2 { bes( a bes) d( cis d) f e f as! g as }
+  | \tuplet 3/2 { g fis g bes a bes es d es g fis g }
 
   % 110
-  | \times 2/3 { g, fis g b a b d cis d f! e f }
+  | \tuplet 3/2 { g, fis g b a b d cis d f! e f }
   | es!4 r r2
-  | \times 2/3 { es8 f g f es d c b c d c d }
-  | \times 2/3 { es f g f es d } c4 \times 2/3 { c'8( d c) }
-  | b4-. \times 2/3 { bes8( c bes) } as!4-. \times 2/3 { g8( as g) }
-  | \times 2/3 { f( g f) e( f g) } f4-. \times 2/3 { bes8( c bes) }
-  | a4-. \times 2/3 { as8( bes as) } g4-. \times 2/3 { f8( g f) }
-  | \times 2/3 { es( f es) d( es f) } es4-. \times 2/3 { g8( as g) }
-  | f4-. \times 2/3 { es8( f es) } d4-. \times 2/3 { c8( d c) }
+  | \tuplet 3/2 { es8 f g f es d c b c d c d }
+  | \tuplet 3/2 { es f g f es d } c4 \tuplet 3/2 { c'8( d c) }
+  | b4-. \tuplet 3/2 { bes8( c bes) } as!4-. \tuplet 3/2 { g8( as g) }
+  | \tuplet 3/2 { f( g f) e( f g) } f4-. \tuplet 3/2 { bes8( c bes) }
+  | a4-. \tuplet 3/2 { as8( bes as) } g4-. \tuplet 3/2 { f8( g f) }
+  | \tuplet 3/2 { es( f es) d( es f) } es4-. \tuplet 3/2 { g8( as g) }
+  | f4-. \tuplet 3/2 { es8( f es) } d4-. \tuplet 3/2 { c8( d c) }
   | b4-. d-. es-. f-.
 
   % 120
@@ -171,19 +171,19 @@ violinIFourthMov =  \relative es' {
   | des2( f4 as)
   | bes,2( es4 ges)
   | as,4( des8 f) ges,4( c8 es)
-  | \times 2/3 { des8(\f c des) f( e f) as g as f( e f) }
-  | \times 2/3 { ges-. bes-. as-. ges f es! des c es ges es c }
+  | \tuplet 3/2 { des8(\f c des) f( e f) as g as f( e f) }
+  | \tuplet 3/2 { ges-. bes-. as-. ges f es! des c es ges es c }
 
   % 140
   | des4 r r as'
   | \grace { g32[( as bes] } as2) d,!
-  | \times 2/3 { es8( d es) ges( f ges) bes( a bes) ges( f ges) }
-  | \times 2/3 { as!-. ces-. bes-. as ges f es d f as f d }
+  | \tuplet 3/2 { es8( d es) ges( f ges) bes( a bes) ges( f ges) }
+  | \tuplet 3/2 { as!-. ces-. bes-. as ges f es d f as f d }
   | es4 r r bes'
   | \grace { a32[( bes c] } bes2) e,
-  | \times 2/3 { f8( e f) as( g as) } c4 r
-  | \times 2/3 { c,8( b c) g'( fis g) } c4 r
-  | \times 2/3 { c,8( b c) g'( fis g) } c4 r
+  | \tuplet 3/2 { f8( e f) as( g as) } c4 r
+  | \tuplet 3/2 { c,8( b c) g'( fis g) } c4 r
+  | \tuplet 3/2 { c,8( b c) g'( fis g) } c4 r
   | <f,! d'>4 r <es c'> r
 
   % 150
@@ -218,13 +218,13 @@ violinIFourthMov =  \relative es' {
   | g2. f4 ~
   | f e2( d4)
   | c r r2
-  | \times 2/3 { d8 e f e d c b a g f e d }
+  | \tuplet 3/2 { d8 e f e d c b a g f e d }
   | c4 r r2
-  | \times 2/3 { d''8 e f e d c b a g f e d }
+  | \tuplet 3/2 { d''8 e f e d c b a g f e d }
 
   % 180
   | c4-. r <bes e>-. r
-  | \times 2/3 { f'8 f f f f f fis fis fis fis fis fis }
+  | \tuplet 3/2 { f'8 f f f f f fis fis fis fis fis fis }
   | g4-. r <d, b'>-. r
   | <e c'> r r c''
   | b2( c4 d)

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/iv-violin2.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/iv-violin2.ily
@@ -1,10 +1,10 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIIFourthMov =  \relative es' {
   \key c \minor
   \clef violin
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   \repeat volta 2 {
     <es c'>4-.\f r f'-. r
@@ -69,13 +69,13 @@ violinIIFourthMov =  \relative es' {
     | r4 es'2 d4 ~
     | d c2 bes4 ~
     | bes as2 g4
-    | \times 2/3 { f8 f f g g g f f f g g g }
+    | \tuplet 3/2 { f8 f f g g g f f f g g g }
     | as4 r as r
-    | \times 2/3 { g'8 as bes as g f es d c bes as g } \noTupletNum
+    | \tuplet 3/2 { g'8 as bes as g f es d c bes as g } \noTupletNum
     | f4 r r2
 
     % 60
-    | \times 2/3 { g'8 as bes as g f es d c bes as g } \tupletNum
+    | \tuplet 3/2 { g'8 as bes as g f es d c bes as g } \tupletNum
     | f2( g4 as)
     | bes r <es, es'> r
     | <es es'> r <bes' f'> r
@@ -109,7 +109,7 @@ violinIIFourthMov =  \relative es' {
   | a2( bes4) f-.
   | ges2( f4) bes-.
   | a2( bes4) r
-  | r \times 2/3 { bes8\f c bes as! g! f es d c }
+  | r \tuplet 3/2 { bes8\f c bes as! g! f es d c }
   | bes4( es d as')
   | g2( as4 bes)
   | c2( bes4 g)
@@ -123,32 +123,32 @@ violinIIFourthMov =  \relative es' {
   | es2( d)
   | c( d4 e)
   | f2( es) ~
-  | es4 \times 2/3 { d8 c d es d es f es f }
+  | es4 \tuplet 3/2 { d8 c d es d es f es f }
   | bes,4 r r es ~
   | es as bes es,8. bes'16
 
   % 100
-  | \times 2/3 { c8 des es des c bes as g f es des c } \noTupletNum
+  | \tuplet 3/2 { c8 des es des c bes as g f es des c } \noTupletNum
   | bes4 r r2
-  | \times 2/3 { c'8 des es des c bes as g f es des c }
+  | \tuplet 3/2 { c'8 des es des c bes as g f es des c }
   | bes4 r r es,
-  | \times 2/3 { c'8 des es des c bes as g as bes c des }
+  | \tuplet 3/2 { c'8 des es des c bes as g as bes c des }
   | c4 r r2
-  | \times 2/3 { c8 des es des c bes as bes c bes as g }
-  | \times 2/3 { f g as g f es d! es f es d c }
+  | \tuplet 3/2 { c8 des es des c bes as bes c bes as g }
+  | \tuplet 3/2 { f g as g f es d! es f es d c }
   | bes4 f''2\fz f,4
   | g g'2\fz es,4
 
   % 110
   | d d''2\fz d,4
-  | \times 2/3 { es8 f g f es d c b c d c d }
+  | \tuplet 3/2 { es8 f g f es d c b c d c d }
   | es4 r r2
-  | r2 r4 \times 2/3 { es,8( d es) }
-  | f4-. \times 2/3 { g8( f g) } as4-. bes-.
-  | as-. bes-. as-. \times 2/3 { d,8( c d) }
-  | es4-. \times 2/3 { f8( es f) } g4-. as-.
-  | g-. as-. g-. \times 2/3 { es'8( f es) }
-  | d4-. \times 2/3 { c8( d c) } \tupletNum b4-. fis-.
+  | r2 r4 \tuplet 3/2 { es,8( d es) }
+  | f4-. \tuplet 3/2 { g8( f g) } as4-. bes-.
+  | as-. bes-. as-. \tuplet 3/2 { d,8( c d) }
+  | es4-. \tuplet 3/2 { f8( es f) } g4-. as-.
+  | g-. as-. g-. \tuplet 3/2 { es'8( f es) }
+  | d4-. \tuplet 3/2 { c8( d c) } \tupletNum b4-. fis-.
   | g-. b-. c-. d-.
 
   % 120
@@ -176,16 +176,16 @@ violinIIFourthMov =  \relative es' {
   | <c es>2.\fz as4
 
   % 140
-  | \times 2/3 { des8( c des) f( e f) 
+  | \tuplet 3/2 { des8( c des) f( e f) 
   as( g as) es( f es) } \noTupletNum
-  | \times 2/3 { d!-. es-. f-. f ges as as bes ces ces bes as }
+  | \tuplet 3/2 { d!-. es-. f-. f ges as as bes ces ces bes as }
   | ges4 ges2 ges4
   | <d! f>2.\fz bes4
-  | \times 2/3 { es8( d es) ges( f ges) bes( a bes) f( g f) }
-  | \times 2/3 { e-. f-. g-. g as! bes bes c des des c bes }
-  | as4 r \times 2/3 { f8( e f) as( g a) }
-  | c4 r \times 2/3 { c,8( b c) g'( fis g) }
-  | c4 r \times 2/3 { c,8( b c) g'( fis g) } \tupletNum
+  | \tuplet 3/2 { es8( d es) ges( f ges) bes( a bes) f( g f) }
+  | \tuplet 3/2 { e-. f-. g-. g as! bes bes c des des c bes }
+  | as4 r \tuplet 3/2 { f8( e f) as( g a) }
+  | c4 r \tuplet 3/2 { c,8( b c) g'( fis g) }
+  | c4 r \tuplet 3/2 { c,8( b c) g'( fis g) } \tupletNum
   | g,4 r fis'' r
 
   % 150
@@ -219,14 +219,14 @@ violinIIFourthMov =  \relative es' {
   | f2 e4( d)
   | c( bes a) d ~
   | d c2( b4)
-  | \times 2/3 { e8 f g f e d c b a g f e }
+  | \tuplet 3/2 { e8 f g f e d c b a g f e }
   | d4 r r2
-  | \times 2/3 {e'8 f g f e d c b a g f e }
+  | \tuplet 3/2 {e'8 f g f e d c b a g f e }
   | d2( e4 f)
 
   % 180
   | g-. r c-. r
-  | \repeat unfold 4 { \times 2/3 { c8 c c } }
+  | \repeat unfold 4 { \tuplet 3/2 { c8 c c } }
   | e4-. r <f, d'>-. r
   | <e c'> r r e'
   | f2( e4 b')

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/iv-violoncello.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/iv-violoncello.ily
@@ -1,10 +1,10 @@
-\version "2.16.0"
+\version "2.18.0"
 celloFourthMov =  \relative c, {
   \key c \minor
   \clef bass
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   \repeat volta 2 {
     <c c'>4-.\f r <c c'>-. r
@@ -19,12 +19,12 @@ celloFourthMov =  \relative c, {
 
     % 10
     | g
-    | \repeat unfold 2 { \times 2/3 { c,,8\f es g c b c } } \noTupletNum
-    | \times 2/3 { c,8 es f g a b } c4 r
+    | \repeat unfold 2 { \tuplet 3/2 { c,,8\f es g c b c } } \noTupletNum
+    | \tuplet 3/2 { c,8 es f g a b } c4 r
     | c'1 ~
     | c2. r4
     | R1*3
-    | \times 2/3 { g,8 b d g fis g g, c es g fis g }
+    | \tuplet 3/2 { g,8 b d g fis g g, c es g fis g }
 
     % 20
     | g,4 r r2
@@ -68,7 +68,7 @@ celloFourthMov =  \relative c, {
     | es4-. r es-. r 
     | es-. r r2
     | R1*2
-    | \times 2/3 { d8 d d es es es d d d es es es }
+    | \tuplet 3/2 { d8 d d es es es d d d es es es }
     | as,4 r bes r
     | es,1 ~
     | <es as> ~
@@ -76,10 +76,10 @@ celloFourthMov =  \relative c, {
     % 60
     | <es g> ~
     | <es as>
-    | \times 2/3 { des'8 es f es des c bes as g f es des } \noTupletNum
-    | \times 2/3 { c es as c b c d, f bes d! d d }
-    | \times 2/3 { es, g bes es es es as, c f as as as }
-    | \times 2/3 { bes, es g bes bes bes bes, d f bes bes bes } \tupletNum
+    | \tuplet 3/2 { des'8 es f es des c bes as g f es des } \noTupletNum
+    | \tuplet 3/2 { c es as c b c d, f bes d! d d }
+    | \tuplet 3/2 { es, g bes es es es as, c f as as as }
+    | \tuplet 3/2 { bes, es g bes bes bes bes, d f bes bes bes } \tupletNum
     | es,1 ~
     | es
     | es, ~
@@ -115,28 +115,28 @@ celloFourthMov =  \relative c, {
   | g2( a4 b)
   | c2 r
   | R1*2
-  | r4 \times 2/3 { bes!8 a bes c bes c d c d }
+  | r4 \tuplet 3/2 { bes!8 a bes c bes c d c d }
   | es4 es,8 es' des4 des,8 des'
   | c4 c,8 c' g4 g'8 g,
   | as1 ~
   | as ~
   | as ~
   | as ~
-  | as4 r r \times 2/3 { <g es'>8 <g es'> <g es'> } \noTupletNum
-  | <as es'>4 r r \times 2/3 { <g es'>8 <g es'> <g es'> }
-  | <as es'>4 r \times 2/3 { as8 bes c bes as g }
-  | \times 2/3 { f g as g f es d! es f g as a }
-  | \repeat unfold 8 { \times 2/3 { bes8 bes bes } }
-  | \repeat unfold 4 { \times 2/3 { b8 b b } }
-  | c4 r r \times 2/3 { g'8 g g }
-  | c,4 r r \times 2/3 { g'8 g g }
+  | as4 r r \tuplet 3/2 { <g es'>8 <g es'> <g es'> } \noTupletNum
+  | <as es'>4 r r \tuplet 3/2 { <g es'>8 <g es'> <g es'> }
+  | <as es'>4 r \tuplet 3/2 { as8 bes c bes as g }
+  | \tuplet 3/2 { f g as g f es d! es f g as a }
+  | \repeat unfold 8 { \tuplet 3/2 { bes8 bes bes } }
+  | \repeat unfold 4 { \tuplet 3/2 { b8 b b } }
+  | c4 r r \tuplet 3/2 { g'8 g g }
+  | c,4 r r \tuplet 3/2 { g'8 g g }
   | c,4 r r2
   | r r4 c-.
   | f-. c-. f-. r
   | r2 r4 bes,-.
   | es-. bes-. es-. g,(
   | g') g,( g') g,(
-  | g') \times 2/3 { f,8( g f es f es d es d) }
+  | g') \tuplet 3/2 { f,8( g f es f es d es d) }
   | <c c'>4-. r <c c'>-. r
   | <c c'>-. r r es''-.
   | f2( es4) r
@@ -162,12 +162,12 @@ celloFourthMov =  \relative c, {
   | es\fz
   | es'2( des)
   | c1
-  | f,4 \times 2/3 { f'8( e f) } f,4-. f'-.
-  | e,4 \times 2/3 { e'8( d! e) } e,4-. e'-.
-  | es,!4 \times 2/3 { es'!8( d! es) } es,4-. es'-.
-  | \times 2/3 { b8 d g g fis g c, es g g fis g }
+  | f,4 \tuplet 3/2 { f'8( e f) } f,4-. f'-.
+  | e,4 \tuplet 3/2 { e'8( d! e) } e,4-. e'-.
+  | es,!4 \tuplet 3/2 { es'!8( d! es) } es,4-. es'-.
+  | \tuplet 3/2 { b8 d g g fis g c, es g g fis g }
   | g,4 r r2
-  | \times 2/3 { g8 b d g fis g g, c es g fis g }
+  | \tuplet 3/2 { g8 b d g fis g g, c es g fis g }
   | g,4 r r\fermata \key c \major c'-.\p
   | d2( c4 b)
   | c2( g4) r
@@ -196,13 +196,13 @@ celloFourthMov =  \relative c, {
   | <c f>
   | <c e>
   | <c f>)
-  | \times 2/3 { bes'8 c d c bes a g f e d c bes }
-  | \times 2/3 { a a a a a a as as as as as as }
+  | \tuplet 3/2 { bes'8 c d c bes a g f e d c bes }
+  | \tuplet 3/2 { a a a a a a as as as as as as }
   | g4-. r g-. r
-  | \times 2/3 { c,8 e g c b c c, e g c b c }
-  | \times 2/3 { c, f as c b c c, c' c c, c' c }
-  | \times 2/3 { c, e g c b c c, e g c b c }
-  | \times 2/3 { c, f as c b c c, c' c c, c' c }
+  | \tuplet 3/2 { c,8 e g c b c c, e g c b c }
+  | \tuplet 3/2 { c, f as c b c c, c' c c, c' c }
+  | \tuplet 3/2 { c, e g c b c c, e g c b c }
+  | \tuplet 3/2 { c, f as c b c c, c' c c, c' c }
   | c,4 r <c c'>-. r
   | <c c'>-. r <c c'>4. <c c'>8
   | <c c'>4 r r2

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/score.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/score.ly
@@ -1,7 +1,7 @@
 % -*- LilyPond -*-
 % vim: ft=lilypond :
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -21,8 +21,8 @@ markingsIV = {}
 \layout {
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/viola.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/viola.ly
@@ -1,6 +1,6 @@
 % -*- LilyPond -*-
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -27,8 +27,8 @@ violaOverridesIV = {}
   \compressFullBarRests
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/viola_defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/viola_defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
 violaBreakII = {
   s2

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/violin1.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/violin1.ly
@@ -1,6 +1,6 @@
 % -*- LilyPond -*-
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -27,8 +27,8 @@ violinIOverridesIV = {}
   \compressFullBarRests
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/violin1_defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/violin1_defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
 violinIBreakBeforeII = ##t
 violinIBreakBeforeIV = ##t

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/violin2.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/violin2.ly
@@ -1,6 +1,6 @@
 % -*- LilyPond -*-
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -27,8 +27,8 @@ violinIIOverridesIV = {}
   \compressFullBarRests
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/violin2_defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/violin2_defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
 violinIIBreakBeforeII = ##t
 violinIIBreakIV = {

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/violoncello.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/violoncello.ly
@@ -1,6 +1,6 @@
 % -*- LilyPond -*-
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -27,8 +27,8 @@ celloOverridesIV = {}
   \compressFullBarRests
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/violoncello_defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/3/violoncello_defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
 celloBreakI = {
   s8

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 \header {
   title = "String Quartet in B-flat major (“Sunrise”)"
   subtitle = "Op. 76 No. 4"
@@ -42,8 +42,8 @@ markingsIII =  {
 
   s2.*53
   s2
-  \override Score.RehearsalMark #'break-visibility = #begin-of-line-invisible
-  \override Score.RehearsalMark #'self-alignment-X = #1
+  \override Score.RehearsalMark.break-visibility = #begin-of-line-invisible
+  \override Score.RehearsalMark.self-alignment-X = #1
   \mark \markup { \large { \italic "Menuetto D.C." } }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/i-midi.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/i-midi.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
   \midi {
     \tempo 4 = 120

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/i-viola.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/i-viola.ily
@@ -1,26 +1,26 @@
-\version "2.16.0"
+\version "2.18.0"
 violaFirstMov =  \relative f {
   \key bes \major
   \clef alto
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   \repeat volta 2 {
     f1\p ~
     | f ~
     | f ~
     | f
-    | c'4-| r <g f'>-| r
-    | <g es'>-| r r2
+    | c'4-! r <g f'>-! r
+    | <g es'>-! r r2
     | a1
     | a ~
     | a ~
 
     % 10
     | a
-    | bes4-| r es-| r
-    | d-| r r2
+    | bes4-! r es-! r
+    | d-! r r2
     | r4 r8 e(\p f bes g bes)
     | f4.( e8) f8( bes g bes)
     | f4.( e8) f8( bes as bes)
@@ -32,11 +32,11 @@ violaFirstMov =  \relative f {
     % 20
     | g1)
     | bes2( a!4. c8)
-    | bes8-|\f r bes-| c-| d-| r bes-| c-|
-    | d-| r d-. r d-. r d-. r
-    | c-. r a8-| bes-| c-| r a-| bes-|
-    | c-| r c-. r c-. r c-. r
-    | bes-. r bes-| c-| d-| r bes-| c-|
+    | bes8-!\f r bes-! c-! d-! r bes-! c-!
+    | d-! r d-. r d-. r d-. r
+    | c-. r a8-! bes-! c-! r a-! bes-!
+    | c-! r c-. r c-. r c-. r
+    | bes-. r bes-! c-! d-! r bes-! c-!
     | d1
     | d2 fis4 ~ fis16 g fis a
     | bes d c bes a c bes a bes d c bes a c bes a
@@ -66,10 +66,10 @@ violaFirstMov =  \relative f {
     % 50
     | g4\!\f r <c, c'> r
     | <c c'> r e'2
-    | f16-| f( e f) c-. f-. bes,-. f'-. a,-| f'( e f) c-. f-. bes,-. f'-.
-    | a,-| f'( e f) c-. f-. bes,-. f'-. a,8 a'-| a-| a-|
+    | f16-! f( e f) c-. f-. bes,-. f'-. a,-! f'( e f) c-. f-. bes,-. f'-.
+    | a,-! f'( e f) c-. f-. bes,-. f'-. a,8 a'-! a-! a-!
     | g16( a g a) f( g f g) e( f e f) d( e d e)
-    | c( d c d) bes( c bes c) a8 c-| c-| c-|
+    | c( d c d) bes( c bes c) a8 c-! c-! c-!
     | d4 bes2( b4)
     | c1 ~
     | c ~
@@ -93,8 +93,8 @@ violaFirstMov =  \relative f {
   | f ~
   | f ~
   | f
-  | e4-| r f-| r
-  | g-| r r2
+  | e4-! r f-! r
+  | g-! r r2
   | es!1 ~
   | es ~
   | es ~
@@ -102,15 +102,15 @@ violaFirstMov =  \relative f {
   | d
 
   % 80
-  | d4\f r g d'8-| c-|
+  | d4\f r g d'8-! c-!
   | bes1
   | \repeat unfold 2 { d16-. d'( cis d) fis,-. d'-. e,-. d'-. }
   | d,1 ~
   | d8 r d16( es! d c) bes8 r d16( es d c)
   | bes4 <as f'>2 f'4
-  | g8-. r es-| f-| g-| r es-| f-|
+  | g8-. r es-! f-! g-! r es-! f-!
   | g1(
-  | as8) r f-| g-| as-| r f-| g-|
+  | as8) r f-! g-! as-! r f-! g-!
   | a!1(
 
   % 90
@@ -122,7 +122,7 @@ violaFirstMov =  \relative f {
   | es4 r d r
   | d r r8 d'-. r bes-.
   | r es-. r c-. r  a-. r a-.
-  | bes-| bes-. 
+  | bes-! bes-. 
   bes-.-\markup { \italic "(poco a poco decresc.)" } bes-.
   bes-. r a-. r
   | g,-. g'-. g-. g-. g-. r f-. r
@@ -142,14 +142,14 @@ violaFirstMov =  \relative f {
   % 110
   | f ~
   | f
-  | c'4-|\f r <g f'>-| r
-  | <g es'>-| r r2
+  | c'4-!\f r <g f'>-! r
+  | <g es'>-! r r2
   | a1\p ~
   | a-\markup { \italic "cresc" } ~
   | a ~
   | a
-  | bes4-|\f r <c es>-| r
-  | <bes d>-| r r2
+  | bes4-!\f r <c es>-! r
+  | <bes d>-! r r2
 
   % 120
   | r4 r8 e(\p f bes g bes)
@@ -169,9 +169,9 @@ violaFirstMov =  \relative f {
   | bes( a! bes c) des4.\fz c8\p
   | bes( a bes as) ges\fz bes4 as8\p
   | ges( f ges as) bes2
-  | a!8-|\f r a-| bes-| c-| r c-| r
-  | bes-| r bes-| c-| d-| r bes'-| r
-  | g-| r e-| f-| g-| r g-| r
+  | a!8-!\f r a-! bes-! c-! r c-! r
+  | bes-! r bes-! c-! d-! r bes'-! r
+  | g-! r e-! f-! g-! r g-! r
   | f4( a,) bes8( c) des-. des-.
   | c4( a) bes8( c) des-. des-.
 
@@ -190,18 +190,18 @@ violaFirstMov =  \relative f {
   % 150
   | f
   | es2 bes8(\< a bes des)
-  | f16-|\!\f f( e f) c-. f-. bes,-. f'-. 
+  | f16-!\!\f f( e f) c-. f-. bes,-. f'-. 
   a,-. f'( e f) c-. f-. bes,-. f'-.
   | a,-. f'( e f) c-. f-. bes,-. f'-. a,2
-  | bes8-. r d,-| es-| f-| r d[-. \grace { f16[( es d] } es8)]
-  | f-. r d[-. \grace { f16[( es d] } es8)] f8 d''-| d-| d-|
+  | bes8-. r d,-! es-! f-! r d[-. \grace { f16[( es d] } es8)]
+  | f-. r d[-. \grace { f16[( es d] } es8)] f8 d''-! d-! d-!
   | c16( d c d) bes( c bes c) a( bes a bes) g( a g a)
   | f( g f g) es( f es f) d8 f-. f-. f-.
   | g4( es2 e4)
   | f1
 
   % 160
-  | f,16-| bes( a bes) f-. d'( cis d) bes-| f'( e f) d-| bes'( a bes)
+  | f,16-! bes( a bes) f-. d'( cis d) bes-! f'( e f) d-! bes'( a bes)
   | f2 es!\trill
   | d4 r r8 f-.\p r d-.
   | r g-. r es-. r c-. r a-.
@@ -215,7 +215,7 @@ violaFirstMov =  \relative f {
   % 170
   | bes-. r es-. r d-. r c-. r
   | r f-. r ges-. r f-. r ges-.
-  | f-|\ff d-| ges-| ges-| f-| d-| ges-| ges-|
+  | f-!\ff d-! ges-! ges-! f-! d-! ges-! ges-!
   | f2 bes4 bes
   | bes1\fermata
   | r2 r4 c,,4\p

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/i-violin1.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/i-violin1.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIFirstMov =  \relative e' {
   \key bes \major
   \clef violin
@@ -8,16 +8,16 @@ violinIFirstMov =  \relative e' {
     | f4. a8 \acciaccatura c bes a bes d\)
     | f4.(  a,8 bes d f a)
     | bes4.( a8 g f es d)
-    | c4-| r d-| r
-    | es-| r r2
+    | c4-! r d-! r
+    | es-! r r2
     | r r4 b,(
     | c4. d8 es f a c)
     | es4.( b8 c d es fis)
 
     % 10
     | \acciaccatura a g4.( f!8 es d es c)
-    | bes4-| r c-| r
-    | d-| r r2
+    | bes4-! r c-! r
+    | d-! r r2
     | f2.(\p e4)
     | f2.( e4)
     | f2.( fis4)
@@ -33,7 +33,7 @@ violinIFirstMov =  \relative e' {
     | d bes' a bes f d' cis d bes f' g f es d c bes
     | a es' d es c d bes c a es d es c es bes es
     | a, g' f g es c' bes c a es' d es a, g' f es
-    | d8-. r d-| es-| f-| r d-| es-|
+    | d8-. r d-! es-! f-! r d-! es-!
     | f2( fis)\fz
     | g4 g8. g16 a4 a8. a16
     | <d, bes'>8 r <d d'> r <d bes'> r <d d'> r
@@ -62,11 +62,11 @@ violinIFirstMov =  \relative e' {
     | bes2(\< b)
 
     % 50
-    | c8-.\!\f r e-| f-| g-| r e-| f-|
-    | g-| r g-| a-| bes16 a g f e d c bes
-    | a8-. r a'-| bes-| 
-    \repeat unfold 2 { c-| r a[-. \grace { c32[( bes a)] } bes8]-. }
-    c f-| f-| f-|
+    | c8-.\!\f r e-! f-! g-! r e-! f-!
+    | g-! r g-! a-! bes16 a g f e d c bes
+    | a8-. r a'-! bes-! 
+    \repeat unfold 2 { c-! r a[-. \grace { c32[( bes a)] } bes8]-. }
+    c f-! f-! f-!
     | e16( f e f) d( e d e) c( d c d) bes( c bes c)
     | a( bes a bes) g( a g a) f4 es'
     | d2( e4 f)
@@ -92,8 +92,8 @@ violinIFirstMov =  \relative e' {
   | d4. e8 \acciaccatura g8 f8 e f gis\)
   | a4.\( cis8 \acciaccatura e d cis d f\)
   | gis4.( a8 g f e d)
-  | cis4-. r d-| r
-  | e-| r r2
+  | cis4-. r d-! r
+  | e-! r r2
   | r r4 b,(
   | c4. b8 c es! fis a)
   | c4.( b8 c es! fis a)
@@ -101,20 +101,20 @@ violinIFirstMov =  \relative e' {
   | c,4.( b8 c es a, c)
 
   % 80
-  | bes!4-.\f g'8-| a-| bes-| r g-| a-| % There is an additional r8 in the Kalmus edition
+  | bes!4-.\f g'8-! a-! bes-! r g-! a-! % There is an additional r8 in the Kalmus edition
   | bes16 c d c bes a g fis g f es d c bes a g
-  | fis8 r a'-| bes-| c-| r a-| bes-| 
+  | fis8 r a'-! bes-! c-! r a-! bes-! 
   | c16 d es d c bes a g fis a a, bes c es d c
   | bes8 r bes'16( a bes c) d8 r bes16( a bes c)
-  | d8-| d16( es) f8-| f16 g as4 <as,,, d>
-  | <g es'>16-| es'( d es) bes-. es-. as,-. es'-. 
-  g,-| es'( d es) bes-. es-. as,-. es'-.
-  | g,-| des'( c des c des c des) g,( c b c g bes a! bes)
-  | a-| f'( e f) c-. f-. bes,-. f'-. a,-| f'( e f) c-. f-. bes,-. f'-.
-  | a,!-| es'!( d es d es d es) a,( d cis d a c b c)
+  | d8-! d16( es) f8-! f16 g as4 <as,,, d>
+  | <g es'>16-! es'( d es) bes-. es-. as,-. es'-. 
+  g,-! es'( d es) bes-. es-. as,-. es'-.
+  | g,-! des'( c des c des c des) g,( c b c g bes a! bes)
+  | a-! f'( e f) c-. f-. bes,-. f'-. a,-! f'( e f) c-. f-. bes,-. f'-.
+  | a,!-! es'!( d es d es d es) a,( d cis d a c b c)
 
   % 90
-  | bes!-| g'( fis g) d-| bes'( a bes) g-| d'( cis d) bes-| g'( fis g)
+  | bes!-! g'( fis g) d-! bes'( a bes) g-! d'( cis d) bes-! g'( fis g)
   | fis8-. r a-. r c-. r fis,-. r
   | g-. r bes-. r d-. r d-. r
   | d4.(\fz es16 d) c4-. c-.
@@ -141,14 +141,14 @@ violinIFirstMov =  \relative e' {
   % 110
   | f4.(-\markup { \italic cresc. } a,8 bes d f a)
   | bes4.( a8 g f es d)
-  | c4-.\f r <f, d'>-| r
-  | <g, es' es'>-| r r2
+  | c4-.\f r <f, d'>-! r
+  | <g, es' es'>-! r r2
   | r r4 b(\p
   | c4. d8 es f a c)
   | es4.(-\markup { \italic cresc. } b8 c d es fis)
   | \acciaccatura a g4.( f!8 es d es c)
-  | <d, bes'>4\f r <a f' c'>-| r
-  | <bes f' d'>-| r r2
+  | <d, bes'>4\f r <a f' c'>-! r
+  | <bes f' d'>-! r r2
 
   % 120
   | f''2.(\p e4)
@@ -175,7 +175,7 @@ violinIFirstMov =  \relative e' {
   | f( c' des e,)
 
   % 140
-  | f8-| f16( e f e f e) f8-| f,16( e f e f e)
+  | f8-! f16( e f e f e) f8-! f,16( e f e f e)
   | f4 r8 f'-.\p g-. a-. bes-. c-.
   | d1 ~
   | d ~
@@ -189,10 +189,10 @@ violinIFirstMov =  \relative e' {
   % 150
   | d
   | es2(-\< e)
-  | f8-\!\f r c-| d-| es!-| r c-| d-| 
-  | es-| r c-| d-| es16 d es c bes a c es,
-  | d8-. r d-| es-| f-| r d[-. \grace { f32[( es d)] } es8]-.
-  | f-. r d[-. \grace { f32[( es d)] } es8]-. f8 bes-| bes-| bes-|
+  | f8-\!\f r c-! d-! es!-! r c-! d-! 
+  | es-! r c-! d-! es16 d es c bes a c es,
+  | d8-. r d-! es-! f-! r d[-. \grace { f32[( es d)] } es8]-.
+  | f-. r d[-. \grace { f32[( es d)] } es8]-. f8 bes-! bes-! bes-!
   | a16( bes a bes) g( a g a) f( g f g) es( f es f)
   | d( es d es) c( d c d) bes4 as'
   | g2( a!4 bes)
@@ -213,7 +213,7 @@ violinIFirstMov =  \relative e' {
   % 170
   | d-. r c-. r bes-. r a-. r
   | bes'-. r a-. r bes-. r a-. r
-  | bes\ff-| bes-| a-| a-| bes-| bes-| a-| a-| 
+  | bes\ff-! bes-! a-! a-! bes-! bes-! a-! a-! 
   | bes,16 bes' bes, bes' c, c' c, c' d, d' d, d' es, es' es, es'
   | \slashedGrace f,8 f'1\fermata
   | g,,1\p ~

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/i-violin2.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/i-violin2.ily
@@ -1,26 +1,26 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIIFirstMov =  \relative d' {
   \key bes \major
   \clef violin
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 4)
+  \tupletSpan 4
 
   \repeat volta 2 {
     d1\p ~
     | d ~
     | d ~
     | d
-    | g4-| r b-| r
-    | c-| r r2
+    | g4-! r b-! r
+    | c-! r r2
     | es,1 ~
     | es ~
     | es ~
 
     % 10
     | es
-    | d4-| r a'-| r
-    | bes-| r r2
+    | d4-! r a'-! r
+    | bes-! r r2
     | bes1\p ~
     | bes ~
     | bes ~
@@ -32,10 +32,10 @@ violinIIFirstMov =  \relative d' {
     % 20
     | des1
     | d!2 c8( b c es)
-    | d-|\f r d-| es-| f-| r d-| es-| % The last D has not a staccato stroke
-    | f-| r f-. r f-. r f-. r
-    | <es a>-. r c-| d-| es-| r c-| d-|
-    | es-| r <es a>-. r <es a>-. r <es a>-. r
+    | d-!\f r d-! es-! f-! r d-! es-! % The last D has not a staccato stroke
+    | f-! r f-. r f-. r f-. r
+    | <es a>-. r c-! d-! es-! r c-! d-!
+    | es-! r <es a>-. r <es a>-. r <es a>-. r
     | bes'16 a bes d f, g es f d bes' a bes f g es f
     | d d' c d es d c d d, c' b c d c b c
     | bes! a bes d bes a bes g' fis g a fis d es d c
@@ -47,7 +47,7 @@ violinIIFirstMov =  \relative d' {
     | c16 e g f! e g f e d e f d b c d b
     | c e g f e g f e d e f d b c d b
     | c e g f e g f e f( e f e) f8 f,
-    | e-| c16( b c b c b) c8-. c16( b c b c b)
+    | e-! c16( b c b c b) c8-. c16( b c b c b)
     | c4 r r2
     | c'1\p ~
     | c ~
@@ -66,12 +66,12 @@ violinIIFirstMov =  \relative d' {
     | f4.(\< g!8) as( g as f)
 
     % 50
-    | e-|\!\f r c'-| d-| e-| r c-| d-|
-    | e-| r e-| f-| g16 f e d c bes a g
-    | f8-. r f'-| g-| a-| r f[-. \grace { a32[( g f)] } g8]-.
-    | a-. r f[-. \grace { a32[( g f)] } g8]-. a c,-| c-| c-|
+    | e-!\!\f r c'-! d-! e-! r c-! d-!
+    | e-! r e-! f-! g16 f e d c bes a g
+    | f8-. r f'-! g-! a-! r f[-. \grace { a32[( g f)] } g8]-.
+    | a-. r f[-. \grace { a32[( g f)] } g8]-. a c,-! c-! c-!
     | bes16( c bes c) a( bes a bes) g( a g a) f( g f g)
-    | e( f e f) d( e d e) c8 f-| f-| f-|
+    | e( f e f) d( e d e) c8 f-! f-! f-!
     | f2( g4 gis)
     | a8( gis a gis) a( gis a gis)
     | a4 <f a>2 f'4
@@ -97,8 +97,8 @@ violinIIFirstMov =  \relative d' {
   | a ~
   | a ~
   | a
-  | g'4-| r f-| r
-  | e-| r r2
+  | g'4-! r f-! r
+  | e-! r r2
   | a,1 ~
   | a ~
   | a ~
@@ -106,28 +106,28 @@ violinIIFirstMov =  \relative d' {
   | a
 
   % 80
-  | bes8\f r bes'-| c-| % The first bes is a quarter note
-  d-| r bes-| c-|
+  | bes8\f r bes'-! c-! % The first bes is a quarter note
+  d-! r bes-! c-!
   | d1
-  | <d, a'>8-. r fis'-| g-| a-| r fis,-| g-|
+  | <d, a'>8-. r fis'-! g-! a-! r fis,-! g-!
   | a1
   | bes16 g fis g bes,( c bes a) g g' fis g bes,( c bes a)
   | g4 <as d>2\fz <as f'>4
-  | <g es'>8-. r g'-| as-| bes-| r g-| as-|
+  | <g es'>8-. r g'-! as-! bes-! r g-! as-!
   | bes2.( c8 des)
-  | c r as-| bes-| c-| r as-| bes-|
+  | c r as-! bes-! c-! r as-! bes-!
   | c2.( d8 es)
 
   % 90
   | d4 d2 d4
   | c16 es d es c bes a g fis g a bes c es d c
-  | bes8-| d16( cis d cis d cis) d8-| g16( fis g fis g fis)
+  | bes8-! d16( cis d cis d cis) d8-! g16( fis g fis g fis)
   | g4-. g-. g4.(\fz a16 g
   | fis4) fis-. g-. d
   | es r c r
   | bes8 bes'-. bes-. bes-. bes-. r g-. r
   | c-. r a-. r fis-. r fis-. r
-  | g-| d-.-\markup { \italic "(poco a poco decresc.)" } d-. d-.  d-. r c-. r
+  | g-! d-.-\markup { \italic "(poco a poco decresc.)" } d-. d-.  d-. r c-. r
   | bes,-. bes'-. bes-. bes-. bes-. r a-. r
 
   % 100
@@ -145,14 +145,14 @@ violinIIFirstMov =  \relative d' {
   % 110
   | d ~
   | d
-  | g4-|\f r <d b'>-| r
-  | <g, es' c'>-| r r2
+  | g4-!\f r <d b'>-! r
+  | <g, es' c'>-! r r2
   | es'1\p ~
   | es-\markup { \italic "cresc." } ~
   | es ~
   | es
-  | d4-|\f r <es a>-| r
-  | <d bes'>-| r r2
+  | d4-!\f r <es a>-! r
+  | <d bes'>-! r r2
 
   % 120
   | bes'1\p ~
@@ -172,14 +172,14 @@ violinIIFirstMov =  \relative d' {
   | des( c des es) f4.\fz es8\p
   | des( c des c) bes4 bes
   | bes r r2
-  | <a f'>8-.\f r c-| d-| es-| r <es a>-| r
-  | <d bes'>-| r d-| es-| f-| r d'-| r
-  | <bes e>-| r g-| a-| bes-| r <bes e>-| r
+  | <a f'>8-.\f r c-! d-! es-! r <es a>-! r
+  | <d bes'>-! r d-! es-! f-! r d'-! r
+  | <bes e>-! r g-! a-! bes-! r <bes e>-! r
   | <a f'>16 f' e f es f es f des f c f bes, des c bes
   | a f' e f es f es f des f c f bes, des c bes
 
   % 140
-  | a8-| f16( e f e f e) f8-| f16( e f e f e)
+  | a8-! f16( e f e f e) f8-! f16( e f e f e)
   | f4 r r2
   | f'1\p ~
   | f ~
@@ -193,11 +193,11 @@ violinIIFirstMov =  \relative d' {
   % 150
   | a( bes ces bes ces bes ces bes)
   | bes(-\< a bes c! des c des bes)-\!
-  | a-|\f r a-| bes-| c-| r a-| bes-|
-  | c-| r a-| bes-| c2
-  | d16-| bes( a bes) f-. g-. es-. f-.
-  d-| bes'( a bes) f-. g-. es-. f-. 
-  | d-| bes'( a bes) f-. g-. es-. f-. d8 f'-| f-| f-|
+  | a-!\f r a-! bes-! c-! r a-! bes-!
+  | c-! r a-! bes-! c2
+  | d16-! bes( a bes) f-. g-. es-. f-.
+  d-! bes'( a bes) f-. g-. es-. f-. 
+  | d-! bes'( a bes) f-. g-. es-. f-. d8 f'-! f-! f-!
   | es16( f es f) d( es d es) c( d c d) bes( c bes c)
   | a( bes a bes) g( a g a) f8 bes-. bes-. bes-.
   | bes2( c4 cis)
@@ -218,7 +218,7 @@ violinIIFirstMov =  \relative d' {
   % 170
   | bes-. r g-. r f-. r es-. r
   | bes'-. r a-. r bes-. r a-. r
-  | bes\ff-| bes-| c-| c-| bes-| bes-| c-| c-|
+  | bes\ff-! bes-! c-! c-! bes-! bes-! c-! c-!
   | d d, es' es, f' f, g' g,
   | as'1\fermata
   | bes,,1\p ~

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/i-violoncello.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/i-violoncello.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 celloFirstMov =  \relative bes, {
   \key bes \major
   \clef bass
@@ -8,16 +8,16 @@ celloFirstMov =  \relative bes, {
     | bes ~
     | bes ~
     | bes
-    | es4-| r d-| r
-    | c-| r r2
+    | es4-! r d-! r
+    | c-! r r2
     | f,1 ~
     | f ~
     | f ~
 
     % 10
     | f
-    | g4-| r f-| r
-    | bes-| r r2
+    | g4-! r f-! r
+    | bes-! r r2
     | d'2.(\p cis4)
     | d2.( cis4)
     | d2. d,4
@@ -30,9 +30,9 @@ celloFirstMov =  \relative bes, {
     | es2( e)
     | f1
     | bes,4\f r bes r
-    | bes8-| r bes-. r bes-. r bes-. r
+    | bes8-! r bes-. r bes-. r bes-. r
     | bes4 r bes r
-    | bes8-| r bes-. r bes-. r bes-. r
+    | bes8-! r bes-. r bes-. r bes-. r
     | bes4 r bes r
     | bes8 bes' bes bes a,\fz a' a a
     | g, g' g g d, d' d d
@@ -61,16 +61,16 @@ celloFirstMov =  \relative bes, {
     | << { des2 des, } { s2-\< s4. s8-\! } >>
 
     % 50
-    | c16-|\f c'( b c) e,-. c'-. d,-. c'-. 
-    \repeat unfold 2 { c,-| c'( b c) e,-. c'-. d,-. c'-. }
+    | c16-!\f c'( b c) e,-. c'-. d,-. c'-. 
+    \repeat unfold 2 { c,-! c'( b c) e,-. c'-. d,-. c'-. }
     c, c' c, c' c, c' c, c'
     | f,4 r f r
     | f r f r
     | R1
-    | r2 a8-| a-| a-| a-|
+    | r2 a8-! a-! a-! a-!
     | bes bes bes bes bes bes b b
     | c4 r r2
-    | c,16-| f( e f) c-| a'( g a) c,-| c'( b c) c,-| f'( e f)
+    | c,16-! f( e f) c-! a'( g a) c,-! c'( b c) c,-! f'( e f)
     | c,4-. r c2
 
     % 60
@@ -91,15 +91,15 @@ celloFirstMov =  \relative bes, {
   | d ~
   | d ~
   | d2. f'4
-  | e-| r d-| r
-  | cis-| r r2
+  | e-! r d-! r
+  | cis-! r r2
   | fis,1 ~
   | fis ~
   | fis ~
   | fis ~
   | fis
-  | g16\f-| g'( fis g) bes,-. g'-. a,-. g'-. 
-  g,-| g'( fis g) bes,-. g'-. a,-. g'-.
+  | g16\f-! g'( fis g) bes,-. g'-. a,-. g'-. 
+  g,-! g'( fis g) bes,-. g'-. a,-. g'-.
   | g,1
   | d'4 r fis, r
   | fis'1
@@ -114,8 +114,8 @@ celloFirstMov =  \relative bes, {
   | g8) g' g g g g g g
   | a, a' a a a a a a
   | bes, bes' bes bes bes bes bes bes
-  | es,16-| es'( d es d es d es) a,4 r
-  | d,16-| d'( cis d cis d cis d) g,4 r
+  | es,16-! es'( d es d es d es) a,4 r
+  | d,16-! d'( cis d cis d cis d) g,4 r
   | c r d r
   | \clef violin g4 r r8 bes-. r g-.
   | r c-. r a-. r fis-. r d-.
@@ -136,14 +136,14 @@ celloFirstMov =  \relative bes, {
   % 110
   | bes ~
   | bes
-  | es4-|\f r <g, d'>-| r
-  | <c, c'>-| r r2
+  | es4-!\f r <g, d'>-! r
+  | <c, c'>-! r r2
   | f1\p ~
   | f-\markup { \italic "cresc" } ~
   | f ~
   | f
-  | g4-|\f r f-| r
-  | bes-| r r2
+  | g4-!\f r f-! r
+  | bes-! r r2
 
   % 120
   | d'2.(\p cis4)
@@ -188,7 +188,7 @@ celloFirstMov =  \relative bes, {
   | bes4 r bes r
   | bes r bes r
   | R1
-  | r2 d8-| d-| d-| d-|
+  | r2 d8-! d-! d-! d-!
   | es es es es e e e e
   | f4 r r2
 
@@ -207,7 +207,7 @@ celloFirstMov =  \relative bes, {
   % 170
   | g-. g-. r es-. r f-. r f'-.
   | r d'-. r es-. r d-. r es-.
-  | d-|\ff bes,-| es-| bes-| d-| bes-| es-| bes-|
+  | d-!\ff bes,-! es-! bes-! d-! bes-! es-! bes-!
   | d bes a a' as, as' g, g'
   | d,1\fermata
   | es1\p ~

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/ii-midi.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/ii-midi.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
   \midi {
     \tempo 4 = 48

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/ii-viola.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/ii-viola.ily
@@ -1,9 +1,9 @@
-\version "2.16.0"
+\version "2.18.0"
 violaSecondMov =  \relative g {
   \key es \major
   \clef alto
 
-  \override Staff.Hairpin   #'minimum-length = #3
+  \override Staff.Hairpin.minimum-length = #3
 
   g4( as g)
   | << { bes2.\fermata } { s4-\< s4-\!-\> s4-\! } >>

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/ii-violin1.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/ii-violin1.ily
@@ -1,10 +1,10 @@
-\version "2.16.0"
+\version "2.18.0"
 violinISecondMov =  \relative es' {
   \key es \major
   \clef violin
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 8)
+  \tupletSpan 8
 
   es4( d es)
   | f << { g2\fermata } { s4-\< s8-\!-\> s8-\! } >>
@@ -32,13 +32,13 @@ violinISecondMov =  \relative es' {
   | d4) r r
   | f(\p e f)
   | fis g4.( f8)
-  | \times 2/3 { e16[( g bes) des-. bes-. g-.] e[( f a) c-. a-. f-.] } r4
-  | \times 2/3 { d16[( es! g) bes-. g-. es-.] cis[( d f) a!-. f-. d-.] } r4
-  | \times 2/3 { b16[( c! es) g-. es-. c-.] a![( bes d) f-. d-. bes-.] } bes'4 ~
-  | \times 2/3 { bes16[ fis( g) d( es) b(] 
+  | \tuplet 3/2 { e16[( g bes) des-. bes-. g-.] e[( f a) c-. a-. f-.] } r4
+  | \tuplet 3/2 { d16[( es! g) bes-. g-. es-.] cis[( d f) a!-. f-. d-.] } r4
+  | \tuplet 3/2 { b16[( c! es) g-. es-. c-.] a![( bes d) f-. d-. bes-.] } bes'4 ~
+  | \tuplet 3/2 { bes16[ fis( g) d( es) b(] 
     c[) fis,( g) d( es) b(] 
   c[) es g b c g'] }
-  | \times 2/3 { e,[( f! fis g as a)] 
+  | \tuplet 3/2 { e,[( f! fis g as a)] 
     bes![( f fis g as a)] 
   bes[( d f! a! bes d)] }
   | f4. f8[ f f]
@@ -48,10 +48,10 @@ violinISecondMov =  \relative es' {
   | bes,,4)-\! r r
   | r r bes(
   | a bes c)
-  | \times 2/3 { d16[( f as c bes as)] 
+  | \tuplet 3/2 { d16[( f as c bes as)] 
     g[( f es d c bes)] 
   as[( g as c as f)] }
-  | es4( d8)-. r \times 2/3 { a16[( bes b c des d)] }
+  | es4( d8)-. r \tuplet 3/2 { a16[( bes b c des d)] }
   | es4( d es)
   | f-\< << { ges2\fermata } { s4-\!-\> s4-\! } >>
   | as4( g! as)
@@ -63,17 +63,17 @@ violinISecondMov =  \relative es' {
   | d!8.( f16) as4 ges8.(\trill f32 ges)
   | f4 r r
   | R2.
-  | \times 2/3 { c'16[( des c) bes'-. g!-. e-.]
+  | \tuplet 3/2 { c'16[( des c) bes'-. g!-. e-.]
     c[( as') e( f) b,( c)]
     g[( as) e( f) as-. c-.] }
-  | \times 2/3 { bes![( c bes) as'-. f-. d]-. 
+  | \tuplet 3/2 { bes![( c bes) as'-. f-. d]-. 
     bes[( g') d( es) a,( bes)]
     fis[( g) d( es) g-. bes-.] }
   | as2( g4)
-  | \times 2/3 { f16[( g) e( f) g( as)]
+  | \tuplet 3/2 { f16[( g) e( f) g( as)]
     b[( c) e( f) g( as)]
     b[( c bes as g f)] }
-  | es4( \times 2/3 { d16[) es(-. f-. g-. as-. bes)]-.
+  | es4( \tuplet 3/2 { d16[) es(-. f-. g-. as-. bes)]-.
     c[(-. d-. es-. f-. g-. as)]-. }
   | bes2( b4)
 
@@ -91,10 +91,10 @@ violinISecondMov =  \relative es' {
 
   % 60
   | as2( g4)
-  | \times 2/3 { f16[-. b( c) g( as) e(]
+  | \tuplet 3/2 { f16[-. b( c) g( as) e(]
     f[) b,( c) g( as) e(]
   f[) c'-. bes-. as-. g-. f-.] }
-  | \times 2/3 { es![ bes' a as g f]
+  | \tuplet 3/2 { es![ bes' a as g f]
     es[ es' d c bes as]
   g[ bes d es g bes] }
   | bes4. bes8[ bes bes]

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/ii-violin2.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/ii-violin2.ily
@@ -1,10 +1,10 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIISecondMov =  \relative bes {
   \key es \major
   \clef violin
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 8)
+  \tupletSpan 8
 
   bes2.
   | d4 << { es2\fermata } { s4-\< s8-\!-\> s8-\! } >>
@@ -73,15 +73,15 @@ violinIISecondMov =  \relative bes {
   | r ges,(\fz f)
   | r as(\fz g!)
   | r4 bes8.( as16 g8 c)
-  | \times 2/3 { c16[( es f) a-. f-. es]-.
+  | \tuplet 3/2 { c16[( es f) a-. f-. es]-.
     c[( es f) a-. f-. es]-.
   bes[( d f) bes-. f-. d]-. } \noTupletNum
-  | \times 2/3 { bes[( des es) g-. es-. des]-.
+  | \tuplet 3/2 { bes[( des es) g-. es-. des]-.
     bes[( des es) g-. es-. des]-.
   as[( c es) as-. es-. c]-. }
 
   % 60
-  | \times 2/3 { as'[-. f-. d!-. bes-. as-. f]-.
+  | \tuplet 3/2 { as'[-. f-. d!-. bes-. as-. f]-.
     d[ f as c as f] 
   es[ g b c d es] } \tupletNum
   | c4 r r
@@ -97,7 +97,7 @@ violinIISecondMov =  \relative bes {
   % 70
   | ces2.
   | bes4( ces bes)
-  | \times 2/3 { ces16[( as bes ces as bes)] \noTupletNum
+  | \tuplet 3/2 { ces16[( as bes ces as bes)] \noTupletNum
     ces16[( as bes ces as bes)]
     ces16[( as bes ces as bes)] }
   | bes4 bes bes

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/ii-violoncello.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/ii-violoncello.ily
@@ -1,10 +1,10 @@
-\version "2.16.0"
+\version "2.18.0"
 celloSecondMov =  \relative es {
   \key es \major
   \clef bass
 
   \noTupletBracket
-  \set tupletSpannerDuration = #(ly:make-moment 1 8)
+  \tupletSpan 8
 
   es4( f es)
   | bes << { es,2\fermata } { s4-\< s8-\!-\> s8-\! } >>
@@ -29,9 +29,9 @@ celloSecondMov =  \relative es {
   % 20
   | bes4 r r
   | R2.*2
-  | r4 r \times 2/3 { e,16(\p f a) c-. a-. f-. }
-  | r4 r \times 2/3 { cis16( d f) a-. f-. d-. }
-  | r4 r \times 2/3 { d,16( f a) bes-. f-. d-. }
+  | r4 r \tuplet 3/2 { e,16(\p f a) c-. a-. f-. }
+  | r4 r \tuplet 3/2 { cis16( d f) a-. f-. d-. }
+  | r4 r \tuplet 3/2 { d,16( f a) bes-. f-. d-. }
   | es4 r r
   | f'2. ~
   | f4. f8[ f f]
@@ -53,9 +53,9 @@ celloSecondMov =  \relative es {
   | bes2.\trill ~
   | bes4 r r
   | es,( d es)
-  | e f ~ \times 2/3 { f16( as c) as-. f-. es-. }
-  | d4 es ~ \times 2/3 { es16( g bes) g-. es-. d-. } \noTupletNum
-  | \times 2/3 { c[ es g as bes c]
+  | e f ~ \tuplet 3/2 { f16( as c) as-. f-. es-. }
+  | d4 es ~ \tuplet 3/2 { es16( g bes) g-. es-. d-. } \noTupletNum
+  | \tuplet 3/2 { c[ es g as bes c]
     d,[ f as bes c d] 
   es,[ g bes es f g] }
   | as2. ~
@@ -91,7 +91,7 @@ celloSecondMov =  \relative es {
   | es2.
   | d4( cis d)
   | \tupletNum 
-  \repeat unfold 3 { \times 2/3 { es16[( d es g bes g)] } 
+  \repeat unfold 3 { \tuplet 3/2 { es16[( d es g bes g)] } 
   \noTupletNum }
   | es2.\fermata   
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/iii-midi.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/iii-midi.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
   \midi {
     \tempo 4 = 180

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/iii-viola.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/iii-viola.ily
@@ -1,14 +1,14 @@
-\version "2.16.0"
+\version "2.18.0"
 violaThirdMov =  \relative d' {
   \key bes \major
   \clef alto
 
   \repeat volta 2 {
     r4
-    | d-|\f f-| r
-    | c-| es-| r
-    | bes-| d-| r
-    | a-| c-| r
+    | d-!\f f-! r
+    | c-! es-! r
+    | bes-! d-! r
+    | a-! c-! r
     | bes bes bes
     | bes2.
     | g'4\fz g, c
@@ -22,13 +22,13 @@ violaThirdMov =  \relative d' {
     % 10
     | r r cis8( d)
     | cis( d bes d) r4
-    | r r b-|
-    | c-| es-| a,-|
-    | bes-| d-| g,-|
-    | a-| c-| fis,-|
-    | g-| bes-| g-|
-    | bes'-| bes-| g,-|
-    | a-| r r
+    | r r b-!
+    | c-! es-! a,-!
+    | bes-! d-! g,-!
+    | a-! c-! fis,-!
+    | g-! bes-! g-!
+    | bes'-! bes-! g,-!
+    | a-! r r
     | bes-. bes-. r
 
     % 20
@@ -44,19 +44,19 @@ violaThirdMov =  \relative d' {
     | cis( d) cis( d) f( d)
 
     % 30
-    | c!4-| c-| r
-    | d-| d-| d-|
-    | es-| es-| r
-    | <a, f'>-| <a f'>-| <a f'>-|
+    | c!4-! c-! r
+    | d-! d-! d-!
+    | es-! es-! r
+    | <a, f'>-! <a f'>-! <a f'>-!
     | <bes f'>2.
     | es4 g f8( es)
     | d4 r r
-    | r r <bes es>-|
-    | <bes d>-| <bes d>-| cis,8( d)
+    | r r <bes es>-!
+    | <bes d>-! <bes d>-! cis,8( d)
     | cis( d) cis( d) es( g)
 
     % 40
-    | bes4-| bes-| r
+    | bes4-! bes-! r
     | f'\p r r
     | g r r
     | es r r

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/iii-violin1.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/iii-violin1.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIThirdMov =  \relative a' {
   \key bes \major
   \clef violin
@@ -6,9 +6,9 @@ violinIThirdMov =  \relative a' {
   \repeat volta 2 {
     a8(\f bes)
     | \stemDown a( bes) a( bes) d( bes) \stemNeutral
-    | f'4-| f-| a,8( bes)
+    | f'4-! f-! a,8( bes)
     | \stemDown a( bes) a( bes) d( bes) \stemNeutral
-    | f'4-| f-| a,8( bes)
+    | f'4-! f-! a,8( bes)
     | \stemDown a( bes) a( bes) g'( bes,) \stemNeutral
     | bes'( bes,) bes'( bes,) bes'( bes,)
     | bes'(\fz g) e( c) bes( g)
@@ -26,9 +26,9 @@ violinIThirdMov =  \relative a' {
     | g( es) c( es) g( f)
     | f( d) bes( d) f( es)
     | es( c) a( c) es( d)
-    | d( bes) g( bes) g'4-|
-    | g-| g-| g-|
-    | fis-| r fis,8( g)
+    | d( bes) g( bes) g'4-!
+    | g-! g-! g-!
+    | fis-! r fis,8( g)
     | fis( g) fis( g) bes( g)
 
     % 20
@@ -44,19 +44,19 @@ violinIThirdMov =  \relative a' {
     | \stemDown a( bes) a( bes) d( bes) \stemNeutral
 
     % 30
-    | f'4-| f-| a,8( bes)
+    | f'4-! f-! a,8( bes)
     | \stemDown a( bes) a( bes) d( bes) \stemNeutral
-    | g'4-| g-| b,8( c)
+    | g'4-! g-! b,8( c)
     | b( c) b( c) a'( c,)
     | bes'!( bes,) bes'( bes,) bes'( bes,)
     | bes'( g) es( c) a( f)
     | bes4 r r
-    | r r <bes g'>-|
-    | <bes f'>-| <bes f'>-| r
-    | r r <bes g'>-|
+    | r r <bes g'>-!
+    | <bes f'>-! <bes f'>-! r
+    | r r <bes g'>-!
 
     % 40
-    | <bes f'>-| <bes f'>-| a'8(\p bes)
+    | <bes f'>-! <bes f'>-! a'8(\p bes)
     | a( bes) a( bes) f( d)
     | fis( g) fis( g) es( c)
     | b( c) b( c) es( a,)
@@ -130,7 +130,7 @@ violinIThirdMov =  \relative a' {
     | a4( bes) c8( bes)
     | a4( bes) c8( d)
     | es4( c a)
-    | f4( es) \times 2/3 { c8( a f) }
+    | f4( es) \tuplet 3/2 { c8( a f) }
     | <c es>2\f\fermata r4
     | R2.
     | r4 r f'\p ~

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/iii-violin2.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/iii-violin2.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIIThirdMov =  \relative bes {
   \key bes \major
   \clef violin
@@ -6,9 +6,9 @@ violinIIThirdMov =  \relative bes {
   \repeat volta 2 {
     r4
     | r r bes8(\f d)
-    | f4-| f-| r
+    | f4-! f-! r
     | r r bes,8( d)
-    | f4-| f-| r
+    | f4-! f-! r
     | g'2.(
     | f)
     | <bes, e>4\fz <bes e> <bes e>
@@ -20,13 +20,13 @@ violinIIThirdMov =  \relative bes {
     | b( c es c) r4
     | r r e8( f)
     | e( f bes f) r4
-    | r r f-|
-    | es-| g-| es-|
-    | d-| f-| bes,-|
-    | c-| es a,-|
-    | bes-| d-| cis ~
-    | cis cis-| cis'-|
-    | d-| r r
+    | r r f-!
+    | es-! g-! es-!
+    | d-! f-! bes,-!
+    | c-! es a,-!
+    | bes-! d-! cis ~
+    | cis cis-! cis'-!
+    | d-! r r
     | d,-. d-. r
 
     % 20
@@ -42,19 +42,19 @@ violinIIThirdMov =  \relative bes {
     | e( f) e( f) bes,( d)
 
     % 30
-    | f4-| f-| r
-    | <bes, f'>-| <bes f'>-| <bes f'>-|
-    | <bes es>-| <bes es>-| r
-    | f'-| a-| c8( a)
+    | f4-! f-! r
+    | <bes, f'>-! <bes f'>-! <bes f'>-!
+    | <bes es>-! <bes es>-! r
+    | f'-! a-! c8( a)
     | f'2.
     | g4 g8( es) c( a)
     | bes4 r r
-    | r r <bes g'>-|
-    | <bes f'>-| <bes f'>-| r
+    | r r <bes g'>-!
+    | <bes f'>-! <bes f'>-! r
     | r r g8( es)
 
     % 40
-    | d4-| bes'-| r
+    | d4-! bes'-! r
     | bes\p r r
     | bes r r
     | a r r

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/iii-violoncello.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/iii-violoncello.ily
@@ -1,14 +1,14 @@
-\version "2.16.0"
+\version "2.18.0"
 celloThirdMov =  \relative bes, {
   \key bes \major
   \clef bass
 
   \repeat volta 2 {
     r4
-    | bes\f-| d'-| r
-    | a,-| c'-| r
-    | g,-| bes'-| r
-    | f,-| a'-| r
+    | bes\f-! d'-! r
+    | a,-! c'-! r
+    | g,-! bes'-! r
+    | f,-! a'-! r
     | es es es
     | d2.
     | <c, c'>4\fz c' c
@@ -26,20 +26,20 @@ celloThirdMov =  \relative bes, {
     | R2.*3
     | r4 r d8( es)
     | d( es) d( es) g( es)
-    | d4-| d'-| r
+    | d4-! d'-! r
     | R2.*5
     | f2. ~
     | f ~
     | f
     | a,8( bes) a( bes) r4
     | R2.
-    | bes4-| bes-| bes-|
+    | bes4-! bes-! bes-!
 
     % 30
-    | a-| a-| r
-    | as-| as-| as-|
-    | g-| g-| r
-    | es'-| es-| es-|
+    | a-! a-! r
+    | as-! as-! as-!
+    | g-! g-! r
+    | es'-! es-! es-!
     | d2.
     | es4 es f
     | bes8( f) d( bes) a( bes)

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/iv-midi.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/iv-midi.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
   \midi {
     \tempo 4 = 160

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/iv-viola.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/iv-viola.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violaFourthMov =  \relative c' {
   \key bes \major
   \clef alto
@@ -7,7 +7,7 @@ violaFourthMov =  \relative c' {
     r4
     | r c8(-\markup { \italic "mezza voce" } d es4) d8( es)
     | f4( g c,) d8( es)
-    | f4-| es-| d-| c-|\fz
+    | f4-! es-! d-! c-!\fz
     | c4 r r2
     | r4 c8( d es4) d8( es)
     | f4( g c,) d8( es)
@@ -17,18 +17,18 @@ violaFourthMov =  \relative c' {
 
   \repeat volta 2 {
     r4
-    | f4( es8 d) c4-| r
+    | f4( es8 d) c4-! r
 
     % 10
-    | g'4( f8 es) d4-| d'8( c)
-    | bes4-| g-| c4( bes8 a)
-    | g4( f8 es) d4-| r
+    | g'4( f8 es) d4-! d'8( c)
+    | bes4-! g-! c4( bes8 a)
+    | g4( f8 es) d4-! r
     | r g\p \acciaccatura bes8 as4( g8 f)
     | es4 f \acciaccatura as8 g4( f8 es)
-    | d4( es f) f-|\f
-    | g8( a! bes c) d4-| bes8( g)
-    | f4-| bes-| c-| bes8( g)
-    | f4-| c8( bes) a( f) r4
+    | d4( es f) f-!\f
+    | g8( a! bes c) d4-! bes8( g)
+    | f4-! bes-! c-! bes8( g)
+    | f4-! c8( bes) a( f) r4
     | f r r2
 
     % 20
@@ -38,15 +38,15 @@ violaFourthMov =  \relative c' {
     | R1*2
     | r4 c'8(\f d) es4 d8( es)
     | f4( g c,) d8( es)
-    | f4-| es-| d-| c-|\fz
+    | f4-! es-! d-! c-!\fz
     | c2 r4 d'8( c)
-    | b4-| c-| a-| bes8( a)
+    | b4-! c-! a-! bes8( a)
 
     % 30
-    | g4-| a-| f-| d-|
-    | es8( d) c4-| d-| f-| 
-    | bes,-| r r f'-|
-    | bes,-| des\fz f f
+    | g4-! a-! f-! d-!
+    | es8( d) c4-! d-! f-! 
+    | bes,-! r r f'-!
+    | bes,-! des\fz f f
     | f r r
   }
 
@@ -54,44 +54,44 @@ violaFourthMov =  \relative c' {
 
   \repeat volta 2 {
     r4
-    | f,-|\f c'8( a) bes4-| c-|
-    | des-| es8( f) bes,4-| f'-|
-    | es-| d'-| es-| as,,-|
-    | as'-| c-| des!-| c,(
-    | des) es-| c-| des-|
+    | f,-!\f c'8( a) bes4-! c-!
+    | des-! es8( f) bes,4-! f'-!
+    | es-! d'-! es-! as,,-!
+    | as'-! c-! des!-! c,(
+    | des) es-! c-! des-!
     | es(\fz c as) des ~
-    | des-| des2 es8( ges)
-    | f4-| des,-| r
+    | des-! des2 es8( ges)
+    | f4-! des,-! r
   }
 
   as'-.\p
   | as-. as-. as-. ces(\f
-  | bes)-| ces( bes)-| des-.\p
+  | bes)-! ces( bes)-! des-.\p
   | c!-. des-. c-. bes(\f
-  | a)-| bes( a)-| c\p ~
-  | c-| c2 c4 ~
-  | c-| c-| c-| r
-  | f,-|\f c'8( a) bes4-| c-|
+  | a)-! bes( a)-! c\p ~
+  | c-! c2 c4 ~
+  | c-! c-! c-! r
+  | f,-!\f c'8( a) bes4-! c-!
 
   % 50
-  | des-| es8( f) bes,4-| f'-|
-  | es( as bes) bes,-|
-  | c2.\fz f4-|
-  | f-| r f-| r
-  | bes,-| r r2
+  | des-! es8( f) bes,4-! f'-!
+  | es( as bes) bes,-!
+  | c2.\fz f4-!
+  | f-! r f-! r
+  | bes,-! r r2
   | es,4\p r f r
-  | bes r r as'-|\f
-  | as-| as-| as-| ces(\p
-  | bes)-| ces( bes)-| des-|\f
-  | c!-| des-| c-| bes(\p
+  | bes r r as'-!\f
+  | as-! as-! as-! ces(\p
+  | bes)-! ces( bes)-! des-!\f
+  | c!-! des-! c-! bes(\p
 
   % 60
-  | a)-| bes( a)-| c\f ~
-  | c-| c2 c4 ~
-  | c-| c-| c-| r
-  | f,,-| c'8( a) bes4-| c-|
-  | des-| es8( f) bes,4-| f'-|
-  | es( as bes) bes,-|
+  | a)-! bes( a)-! c\f ~
+  | c-! c2 c4 ~
+  | c-! c-! c-! r
+  | f,,-! c'8( a) bes4-! c-!
+  | des-! es8( f) bes,4-! f'-!
+  | es( as bes) bes,-!
   | c1\fz
   | R
   | c\fz
@@ -102,25 +102,25 @@ violaFourthMov =  \relative c' {
 
   | r4 c8(\f d es4) d8( es)
   | f4( g c,) d8( es)
-  | f4-| es-| d-| c-|\fz
+  | f4-! es-! d-! c-!\fz
   | c r r2
   | r4 d r a
 
   % 80
   | r bes r bes
-  | bes-| g'(\fz f es)
+  | bes-! g'(\fz f es)
   | d r r2
   | f4( es8 d c4) r
   | g'4( f8 es d4) d'8( c)
-  | bes4-| g-| c4( bes8 a)
-  | g4( f8 es) d4-| r
+  | bes4-! g-! c4( bes8 a)
+  | g4( f8 es) d4-! r
   | r g\p \acciaccatura bes8 as4( g8 f)
   | es4 f \acciaccatura as8 g4( f8 es)
-  | d4( es f) f-|\fz
+  | d4( es f) f-!\fz
 
   % 90
-  | g8( a! bes c) d4-| bes8( g)
-  | f4-| bes-| c-| bes8( g)
+  | g8( a! bes c) d4-! bes8( g)
+  | f4-! bes-! c-! bes8( g)
   | f4 c8( bes) a( f) r4
   | f4 r r2
   | r4 a8( bes) c( a) r4
@@ -130,12 +130,12 @@ violaFourthMov =  \relative c' {
 
   % 100
   | f4( g c,) d8( es)
-  | f4-| es-| d-| c-|\fz
+  | f4-! es-! d-! c-!\fz
   | c2 r8 es'-. d-. c-.
   | b-. d-. c-. bes-. a-. c-. bes-. a-.
   | g-. bes-. a-. g-. f-. fis-. g-. f-.
-  | es-. g-. f-. es-. d4-. f-|
-  | bes,-| r r f'-|
+  | es-. g-. f-. es-. d4-. f-!
+  | bes,-! r r f'-!
   | bes,2 f'\fz
   | r4 r8 e, e4.(\trill d16 e)
   | f1 ~
@@ -146,26 +146,26 @@ violaFourthMov =  \relative c' {
   | r2 c'8(\p es d c)
   | bes r r4 r2
   | r2 r8 f'( es d)
-  | c4-| r r2
+  | c4-! r r2
   | r2 r8 f,( g a)
-  | bes!4-| r r f'(
+  | bes!4-! r r f'(
   | es) r r es(
 
   % 120
   | d) r r c'(
   | bes) r r bes(
   | as) r r2
-  | bes,8(\f c bes as) g4-| r
-  | g8( as g f) es4-| c'-|
+  | bes,8(\f c bes as) g4-! r
+  | g8( as g f) es4-! c'-!
   | d r r8 a!( bes c
-  | d4)-| r r8 a( bes c
+  | d4)-! r r8 a( bes c
   | d) a( bes c d) a( bes c
   | d) a( bes c d) a( bes c
   | d4) r es r
 
   % 130
   | d( e f8) c-. d-. es-.
-  | f4-| es-| d-| c-|
+  | f4-! es-! d-! c-!
   | c r r2
   | d4 r a r
   | bes r bes r
@@ -176,7 +176,7 @@ violaFourthMov =  \relative c' {
   % 143
   | f4 r es r
   | d( e f8) c-. d-. es-.
-  | f4-| es-| d-| c-|
+  | f4-! es-! d-! c-!
   | c r r2
   | r4 d\p r a
   | r bes r bes
@@ -185,11 +185,11 @@ violaFourthMov =  \relative c' {
   % 150
   | d-.\f es-. d-. c-. bes-. g'-. f-. es-.
   | d-. es-. d-. c-. bes-. g'-. f-. es-.
-  | d es d c bes4-| c-|
-  | c-| r r bes'-|
+  | d es d c bes4-! c-!
+  | c-! r r bes'-!
   | c8-. d-. c-. bes-. a-. bes-. a-. g-.
   | f-. g-. f-. es-. d-. es-. d-. c-. 
-  | bes c bes as g4-| r
+  | bes c bes as g4-! r
   | R1
   | b'4\p r b r
   | c r r2
@@ -203,7 +203,7 @@ violaFourthMov =  \relative c' {
   | c1
   | des4( d es e)
   | f1
-  | \repeat unfold 4 { <c' es>4-| }
+  | \repeat unfold 4 { <c' es>4-! }
   | <bes d> r <c f> r
   | <bes f'> r c r
   | d r r2

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/iv-violin1.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/iv-violin1.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIFourthMov =  \relative f'' {
   \key bes \major
   \clef violin
@@ -7,11 +7,11 @@ violinIFourthMov =  \relative f'' {
     f8(-\markup { \italic "mezza voce" } es)
     | d4( es) c-. d8( c)
     | bes4( c) \grace { g16[( f e] } f4) g8( a)
-    | bes4-| c-| d-| \grace { es16[( f] } g4)-|\fz
-    | \acciaccatura d8 c( bes c d) c4-| f8( es)
+    | bes4-! c-! d-! \grace { es16[( f] } g4)-!\fz
+    | \acciaccatura d8 c( bes c d) c4-! f8( es)
     | d4( es) c-. d8( c)
     | bes4( c) \grace { g16[( f e] } f4) g8( a)
-    | bes4-| \grace { g'16[( a] } bes4)-|\fz c,2\trill
+    | bes4-! \grace { g'16[( a] } bes4)-!\fz c,2\trill
     | bes4-. f-. d-.
   }
 
@@ -21,12 +21,12 @@ violinIFourthMov =  \relative f'' {
 
     % 10
     | d4( es f) g8( a)
-    | bes4-| \grace { bes16[( c] } d4)-|\fz fis,2\trill
+    | bes4-! \grace { bes16[( c] } d4)-!\fz fis,2\trill
     | g2. f!8(\p g)
     | \acciaccatura bes8 as4( g8 f) es4 f
     | \acciaccatura as8 g4( f8 es) d4 es
-    | \acciaccatura g8 f4( es8 d c4) d-|\f
-    | e8( f g a) bes4-| e,-|
+    | \acciaccatura g8 f4( es8 d c4) d-!\f
+    | e8( f g a) bes4-! e,-!
     | f\trill e f\trill e
     | f\trill e f a,8( bes)
     | c( a) c-. d-. es!( c) es-. f-.
@@ -39,15 +39,15 @@ violinIFourthMov =  \relative f'' {
     | f( es) g( f) es( g) f(\f es)
     | d4( es) c-. d8( c)
     | bes4( c) \grace { g16[( f e] } f4) g8( a)
-    | bes4-| c-| d-| \grace { es16[( f] } g4)-|\fz
-    | \acciaccatura d8 c( bes c d) c4-| r
-    | g'8( f) es4-| f-| d-|
+    | bes4-! c-! d-! \grace { es16[( f] } g4)-!\fz
+    | \acciaccatura d8 c( bes c d) c4-! r
+    | g'8( f) es4-! f-! d-!
 
     % 30
-    | es8( d) c4-| d-| bes-|
-    | c8( bes) a4 bes-. <f es'>-|
-    | <f d'>-| <bes g'>-| <bes f'>-| <bes as'>-|
-    | <bes g'>-| \grace { g'16[( a!] } bes4)-|\fz c,2\trill
+    | es8( d) c4-! d-! bes-!
+    | c8( bes) a4 bes-. <f es'>-!
+    | <f d'>-! <bes g'>-! <bes f'>-! <bes as'>-!
+    | <bes g'>-! \grace { g'16[( a!] } bes4)-!\fz c,2\trill
     | bes4 r r
   }
 
@@ -57,46 +57,46 @@ violinIFourthMov =  \relative f'' {
 
   \repeat volta 2 {
     f'8(\f bes)
-    | des!( bes a c) bes4-| bes,8( ges')
-    | f( bes, a es') des4-| d-|
-    | es-| f-| ges-| c,-|
-    | des!-| es\turn f-| <as,, as'>
+    | des!( bes a c) bes4-! bes,8( ges')
+    | f( bes, a es') des4-! d-!
+    | es-! f-! ges-! c,-!
+    | des!-! es\turn f-! <as,, as'>
     | <as as'> <as as'> <as as'> <as as'>
 
     % 40
-    | <as as'>4.(^\fz ges'8) f4-| bes(
-    | as)-| bes( as) ges'8( es)
-    | des4-| des'-| r
+    | <as as'>4.(^\fz ges'8) f4-! bes(
+    | as)-! bes( as) ges'8( es)
+    | des4-! des'-! r
   }
 
   ges,4-.\p
   | f-. ges-. f-. as(\f
-  | ges)-| as( ges)-| bes-.\p
+  | ges)-! as( ges)-! bes-.\p
   | a-. bes-. a-. des(\f
-  | c)-| des( c)-| bes8(\p e,)
+  | c)-! des( c)-! bes8(\p e,)
   | f c bes'( e,) f c bes'( e,)
   | f c f c f4 f8(\f bes)
-  | des( bes a c) bes4-| bes,8( ges')
+  | des( bes a c) bes4-! bes,8( ges')
 
   % 50
   | f( bes, a es') des4( d)
-  | es( f ges) ges-|
+  | es( f ges) ges-!
   | a,,2\fz ~ a8 ges''-. f-. es-.
   | des des' c bes a ges' f es
   | des4( bes') bes bes
   | es,,,\p r f r
-  | bes, r r ges''\f-|
-  | f-| ges-| f-| as(\p
-  | ges)-| as( ges)-| bes\f-|
-  | a-| bes-| a-| des(\p
+  | bes, r r ges''\f-!
+  | f-! ges-! f-! as(\p
+  | ges)-! as( ges)-! bes\f-!
+  | a-! bes-! a-! des(\p
 
   % 60
-  | c)-| des( c)-| bes8(\f e,)
+  | c)-! des( c)-! bes8(\f e,)
   | f c bes'( e,) f c bes'( e,)
   | f c f c f4 f8( bes)
-  | des( bes a c) bes4-| bes,8( ges')
-  | f( bes, a es') des4-| d-|
-  | es( f ges) ges-| 
+  | des( bes a c) bes4-! bes,8( ges')
+  | f( bes, a es') des4-! d-!
+  | es( f ges) ges-! 
   | a,,2.\fz a'8( bes)
   | c4-. c8( des) es4-. es8( f)
   | ges2.\fz es8(\p f)
@@ -111,7 +111,7 @@ violinIFourthMov =  \relative f'' {
 
   | d4( es) c-. d8( c)
   | bes4( c) \grace { g16[( f e] } f4) g8( a)
-  | bes4-| c-| d-| \grace { es16[( f] } g4)-|\fz
+  | bes4-! c-! d-! \grace { es16[( f] } g4)-!\fz
   | \acciaccatura d8 c( bes c d) c-. g'-. f-. es-.
   | d-. f-. es-. d-. c-. es-. d-. c-.
 
@@ -121,14 +121,14 @@ violinIFourthMov =  \relative f'' {
   | bes4-. f-. d-. a'8( bes)
   | c4( d es) bes8( c)
   | d4( es f) g8( a)
-  | bes4-| \grace { bes16[( c] } d4)\fz fis,2\trill
+  | bes4-! \grace { bes16[( c] } d4)\fz fis,2\trill
   | g2. f!8(\p g)
   | \acciaccatura bes8 as4( g8 f) es4 f
   | \acciaccatura as!8 g4( f8 es) d4 es
-  | \acciaccatura g8 f4( es8 d) c4 d\fz-|
+  | \acciaccatura g8 f4( es8 d) c4 d\fz-!
 
   % 90
-  | e8( f g a!) bes4-| e,-|
+  | e8( f g a!) bes4-! e,-!
   | f\trill e f\trill e
   | f\trill e f a,8-. bes-.
   | c( a) c-. d-. es!( c) es-. f-.
@@ -141,12 +141,12 @@ violinIFourthMov =  \relative f'' {
 
   % 100
   | bes4( c) \grace { g16[( f e] } f4) g8( a)
-  | bes4-| c-| d-| \grace { es16[( f] } g4)-|\fz
+  | bes4-! c-! d-! \grace { es16[( f] } g4)-!\fz
   | \acciaccatura d8 c( bes c d) c4 r8 as'
   | g-. f-. es-. g-. f es d f
   | es-. d-. c-. es-. d-. c-. bes-. b-.
-  | c-. bes!-. a-. c-. bes4-| <f es'>-|
-  | <f d'>-| <bes g'>-| <bes f'>-| <bes as'>-|
+  | c-. bes!-. a-. c-. bes4-! <f es'>-!
+  | <f d'>-! <bes g'>-! <bes f'>-! <bes as'>-!
   | <bes g'>2 <e, des' bes'>
   | r4 r8 e e4.(\trill d16 e)
   | f1 ~
@@ -155,20 +155,20 @@ violinIFourthMov =  \relative f'' {
   | f2 ~ f8 g(\p f es!)
   | d( f es d) c( es d c)
   | bes( d c bes) a( g' f es)
-  | d4-| r r2
+  | d4-! r r2
   | r r8 as'( g f)
-  | es4-| r r2
+  | es4-! r r2
   | r r8 g,( a! b)
-  | c4-| r r2
+  | c4-! r r2
   | r r8 g'( a b)
-  | c4-| r r8 f,( g a)
+  | c4-! r r8 f,( g a)
 
   % 120
-  | bes!4-| r r8 d( e fis)
+  | bes!4-! r r8 d( e fis)
   | g( fis g a) bes( c, d e)
-  | f!( e f g) as4 d,-|\f
-  | es!-| f-| g-| b,-| 
-  | c-| d-| es8-| g( f es
+  | f!( e f g) as4 d,-!\f
+  | es!-! f-! g-! b,-! 
+  | c-! d-! es8-! g( f es
   | d)es( d c bes)g'( f es
   | d) es( d c bes) g'( f es
   | d) g( f es d) g( f es
@@ -181,7 +181,7 @@ violinIFourthMov =  \relative f'' {
   | \acciaccatura d8 c( bes c d) c-. g'-. f-. es-.
   | d f es d c es d c
   | bes d c bes as c bes as
-  | g4-| \grace { g'16[( a!] } bes4)-| c,2\trill
+  | g4-! \grace { g'16[( a!] } bes4)-! c,2\trill
   | bes4 r r8 d-. c-. bes-.
   | a-. c-. bes-. d-. c-. f-. e-. g-.
   | f a g e f d c bes
@@ -202,11 +202,11 @@ violinIFourthMov =  \relative f'' {
   % 150
   | bes4\f bes'2 bes4 ~
   | bes bes2 bes4 ~
-  | bes8 g-. f-. es-. d4-| e-|
-  | f-| r r e-|
-  | f-| r r a-|
-  | bes-| r r d-|
-  | es-| r g-| r
+  | bes8 g-. f-. es-. d4-! e-!
+  | f-! r r e-!
+  | f-! r r a-!
+  | bes-! r r d-!
+  | es-! r g-! r
   | r2 r8 as,-.\p g-. fis-.
   | g-. as-. g-. fis-. g-. as-. g-. f-.
   | es( d es d) c-. g'-. f-. e-.
@@ -221,10 +221,10 @@ violinIFourthMov =  \relative f'' {
   | g as g f es f es d
   | c1
   | des4( d es e)
-  | f-| bes8-| d-| f4-| bes-|
+  | f-! bes8-! d-! f4-! bes-!
 
   % 170
-  | a-| c-| es-| a,-|
+  | a-! c-! es-! a,-!
   | bes r c r
   | d r a r
   | bes r r2

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/iv-violin2.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/iv-violin2.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIIFourthMov =  \relative f' {
   \key bes \major
   \clef violin
@@ -7,8 +7,8 @@ violinIIFourthMov =  \relative f' {
     f8(-\markup { \italic "mezza voce" } a)
     | bes4 es,8( f) g4-. f8( es)
     | d4 c8( bes) a4 bes8( c)
-    | d4-| es-| f-| \grace { g16[( a] } bes4)\fz-|
-    | a8( bes a bes) a4-| f8( a)
+    | d4-! es-! f-! \grace { g16[( a] } bes4)\fz-!
+    | a8( bes a bes) a4-! f8( a)
     | bes4 es,8( f) g4-. f8( es)
     | d4 c8( bes) a4 bes8( c)
     | d-. d'(\fz c bes) bes4( a)
@@ -21,14 +21,14 @@ violinIIFourthMov =  \relative f' {
 
     % 10
     | bes4( c d) g8( fis)
-    | g4-| bes,-| a8( es' d c)
+    | g4-! bes,-! a8( es' d c)
     | bes4( c d) d8(\p es)
     | \acciaccatura g8 f4( es8 d) c4 d
     | \acciaccatura f8 es4( d8 c) bes4 c
     | \acciaccatura es8 d4( c8 bes a4) d8(\f c)
-    | bes( a g f) e4-| g-|
-    | f-| g-| f-| g-|
-    | a-| g-| f-| f8( g)
+    | bes( a g f) e4-! g-!
+    | f-! g-! f-! g-!
+    | a-! g-! f-! f8( g)
     | a( f) a-. bes-. c( a) c-. d-.
 
     % 20
@@ -39,15 +39,15 @@ violinIIFourthMov =  \relative f' {
     | d( c)es( d) c( es) f,(\f a)
     | bes4 es,8( f) g4-. f8( es)
     | d4 c8( bes) a4 bes8( c)
-    | d4-| es-| f-| \grace { g16[( a] } bes4)\fz-|
+    | d4-! es-! f-! \grace { g16[( a] } bes4)\fz-!
     | a8( bes a bes) a4 f'8( es)
-    | d4-| es-| c-| d8( c)
+    | d4-! es-! c-! d8( c)
 
     % 30
-    | bes4-| c-| a-| bes8( a)
-    | g4-| a8( g) f4-| c'-|
-    | bes-| es,-| d-| as''-|
-    | g-| << { bes,2 a4 } \\ { g4\fz f es } >>
+    | bes4-! c-! a-! bes8( a)
+    | g4-! a8( g) f4-! c'-!
+    | bes-! es,-! d-! as''-!
+    | g-! << { bes,2 a4 } \\ { g4\fz f es } >>
     | <d bes'> r r
   }
 
@@ -57,46 +57,46 @@ violinIIFourthMov =  \relative f' {
 
   \repeat volta 2 {
     r4
-    | f'-|\f es-| des!-| ges!-|
-    | f-| c-| des-| bes,-|
-    | bes'-| as-| ges-| es-|
-    | f-| ges-| as-| es(
-    | f) ges-| es-| f-|
+    | f'-!\f es-! des!-! ges!-!
+    | f-! c-! des-! bes,-!
+    | bes'-! as-! ges-! es-!
+    | f-! ges-! as-! es(
+    | f) ges-! es-! f-!
 
     % 40
-    | ges(\fz es) f-| e(
-    | f)-| e( f) c-|
-    | des-| r r
+    | ges(\fz es) f-! e(
+    | f)-! e( f) c-!
+    | des-! r r
   }
 
   es'-.\p
   | des-. es-. des-. f(\f
-  | es)-| f( es)-| g-.\p
+  | es)-! f( es)-! g-.\p
   | f-. g-. f-. e(\f
-  | f)-| e(\fz f)-| bes,(\p
-  | a)-| bes( a)-| bes(
-  | a)-| a-| a-| r
-  | f'-|\f es-| des-| ges-|
+  | f)-! e(\fz f)-! bes,(\p
+  | a)-! bes( a)-! bes(
+  | a)-! a-! a-! r
+  | f'-!\f es-! des-! ges-!
 
   % 50
-  | f-| c-| des-| bes,-|
-  | bes'( as ges) es-|
-  | ges2.\fz c4-|
-  | des-| r es-| r
-  | f-| r r2
+  | f-! c-! des-! bes,-!
+  | bes'( as ges) es-!
+  | ges2.\fz c4-!
+  | des-! r es-! r
+  | f-! r r2
   | es,4\p r f r
-  | bes, r r es'-|\f
-  | des-| es-| des-| f(\p
-  | es)-| f( es)-| g-|\f
-  | f-| g-| f-| e(\p
+  | bes, r r es'-!\f
+  | des-! es-! des-! f(\p
+  | es)-! f( es)-! g-!\f
+  | f-! g-! f-! e(\p
 
   % 60
-  | f)-| e( f)-| bes,(\f
-  | a)-| bes( a)-| bes(
-  | a)-| a-| a-| r
-  | f'-| es-| des-| ges-|
-  | f-| c-| des-| bes,-|
-  | bes'( as ges) es-|
+  | f)-! e( f)-! bes,(\f
+  | a)-! bes( a)-! bes(
+  | a)-! a-! a-! r
+  | f'-! es-! des-! ges-!
+  | f-! c-! des-! bes,-!
+  | bes'( as ges) es-!
   | ges1\fz
   | R1
   | es\fz
@@ -110,8 +110,8 @@ violinIIFourthMov =  \relative f' {
 
   bes4 es,8( f) g4-. f8( es)
   | d4 c8( bes) a4 bes8( c)
-  | d4-| es-| f-| \grace { g16[( a] } bes4)-|\fz
-  | a8( bes a bes) a4-| r
+  | d4-! es-! f-! \grace { g16[( a] } bes4)-!\fz
+  | a8( bes a bes) a4-! r
   | r f r es
 
   % 80
@@ -120,32 +120,32 @@ violinIIFourthMov =  \relative f' {
   | bes4 r r f8( g)
   | a4( bes c) g8( a)
   | bes4( c d) g8( fis)
-  | g4-| bes,-| a8( es' d c)
+  | g4-! bes,-! a8( es' d c)
   | bes4( c d) d8(\p es)
   | \acciaccatura g8 f4( es8 d) c4 d
   | \acciaccatura f8 es4( d8 c) bes4 c
   | \acciaccatura es8 d4( c8 bes) a4 d8(\fz c)
 
   % 90
-  | bes( a g f) e4-| g-|
-  | a-| g-| f-| g-|
-  | a-| g-| f-| f8-. g-.
+  | bes( a g f) e4-! g-!
+  | a-! g-! f-! g-!
+  | a-! g-! f-! f8-. g-.
   | a8( f) a-. bes-. c( a) c-. d-.
   | es2.( d8 c)
   | es2.(\p d8 c)
   | es( d) c( es) d( c) es( d)
   | c( es) d( c) es( d) c( es)
   | d( c) es( d) c f,(\f g a)
-  | bes4-| es,8( f) g4-. f8( es)
+  | bes4-! es,8( f) g4-. f8( es)
 
   % 100
   | d4 c8( bes) a4 bes8( c)
-  | d4-| es-| f-| \grace { g16[( a] } bes4)-|\fz
-  | a8( bes a bes) a8-| g'-. f-. es-.
+  | d4-! es-! f-! \grace { g16[( a] } bes4)-!\fz
+  | a8( bes a bes) a8-! g'-. f-. es-.
   | d-. f-. es-. d-. c-. es-. d-. c-.
   | bes-. d-. c-. bes-. a4 g ~
-  | g a-| bes-| c-|
-  | bes-| es,-| d-| <bes' as'>-|
+  | g a-! bes-! c-!
+  | bes-! es,-! d-! <bes' as'>-!
   | <bes g'>2 des,^\fz
   | r4 r8 e e4.(\trill d16 e)
   | f1 ~
@@ -158,43 +158,43 @@ violinIIFourthMov =  \relative f' {
   | R1*2
   | d8(\p f es d) c8 r r4
   | R1
-  | r8 g'( f es) d4-| r
+  | r8 g'( f es) d4-! r
   | R1
-  | r8 b( c d) es4-| r
+  | r8 b( c d) es4-! r
   | R1
-  | r8 b'( c d) es4-| r
+  | r8 b'( c d) es4-! r
 
   % 120
-  | r8 a,( bes! c) d4-| r
+  | r8 a,( bes! c) d4-! r
   | r a!( g) r
-  | r g( f) f-|\f
-  | g-| as-| bes-| d,-|
-  | es-| f-| g-| a!-|
+  | r g( f) f-!\f
+  | g-! as-! bes-! d,-!
+  | es-! f-! g-! a!-!
   | bes r r8 es( d c
-  | bes4)-| r r8 es( d c
+  | bes4)-! r r8 es( d c
   | bes) es( d c bes) es( d c
   | bes) es( d c bes) es( d c
   | bes4) r a r
 
   % 130
   | \stemUp bes( g f8) a,-. bes-. c-. \stemNeutral
-  | d4-| es-| f-| bes-|
-  | a8( bes a bes) a4-| r
+  | d4-! es-! f-! bes-!
+  | a8( bes a bes) a4-! r
   | f4 r es r
   | d r f r
   | g8( d' c bes) bes4( a)
-  | bes-| f-| d-| r
-  | f-| g-| a-| bes-|
+  | bes-! f-! d-! r
+  | f-! g-! a-! bes-!
   | a r r2
-  | f4-| g-| a-| bes-|
+  | f4-! g-! a-! bes-!
 
   % 140
   | a r r2
-  | f4-| g-| a-| bes-|
+  | f4-! g-! a-! bes-!
   | c r r2
   | bes4 r a r
   | \stemUp bes( g f8) a,-. bes-. c-. \stemNeutral
-  | d4-| es-| f-| bes-|
+  | d4-! es-! f-! bes-!
   | a8( bes a bes) a4 r
   | r f\p r es
   | r d r f
@@ -203,11 +203,11 @@ violinIIFourthMov =  \relative f' {
   % 150
   | bes8-.\f g'-. f-. es-. d-. es-. d-. c-.
   | bes-. g'-. f-. es-. d-. es-. d-. c-.
-  | bes4-| r r g-|
-  | f-| r r g-|
-  | f-| r r c'-|
-  | bes-| r r f'-|
-  | es-| r <es, bes' g'>-| r
+  | bes4-! r r g-!
+  | f-! r r g-!
+  | f-! r r c'-!
+  | bes-! r r f'-!
+  | es-! r <es, bes' g'>-! r
   | R1
   | d'4\p r d r
   | es r r2
@@ -225,7 +225,7 @@ violinIIFourthMov =  \relative f' {
   | f d'2 d4
 
   % 170
-  | <es, c'>-| <es a>-| <es a>-| <es c'>-|
+  | <es, c'>-! <es a>-! <es a>-! <es c'>-!
   | <d bes'> r <f es'> r
   | <f d'> r <f es'> r
   | <f d'> r r2

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/iv-violoncello.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/iv-violoncello.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 celloFourthMov =  \relative bes, {
   \key bes \major
   \clef bass
@@ -7,7 +7,7 @@ celloFourthMov =  \relative bes, {
     r4
     | r2 r4 bes8(-\markup { \italic "mezza voce" } c)
     | d4( es f es)
-    | d-| c-| bes-| es,-| \fz
+    | d-! c-! bes-! es,-! \fz
     | f2 r
     | r r4 bes8( c)
     | d4( es f es)
@@ -22,7 +22,7 @@ celloFourthMov =  \relative bes, {
     % 10
     | r2 r4 bes'8( a)
     | g4 g, d' d'
-    | es( d8 c) b4-| r
+    | es( d8 c) b4-! r
     | R1*2
     | r2 r4 bes!8(\f a)
     | g( f e d) c4 c'8( bes)
@@ -37,62 +37,62 @@ celloFourthMov =  \relative bes, {
     | R1*2
     | r2 r4 bes8(\f c)
     | d4( es f es)
-    | d-| c-| bes-| es,-|\fz
+    | d-! c-! bes-! es,-!\fz
     | f1 ~
     | f ~
 
     % 30
     | f2. g'8( f)
-    | es4-| f8( es) d4-| a-|
-    | bes-| r r d-|
-    | es-| e-|\fz f2
-    | bes4-| f-| bes,-|
+    | es4-! f8( es) d4-! a-!
+    | bes-! r r d-!
+    | es-! e-!\fz f2
+    | bes4-! f-! bes,-!
   }
 
   \key bes \minor
 
   \repeat volta 2 {
     r4
-    | bes\f-| c-| des!-| es-|
-    | f-| a-| bes-| as-|
-    | ges-| f-| es-| ges-|
-    | f-| es-| des-| c(
-    | des) es-| c-| des-|
+    | bes\f-! c-! des!-! es-!
+    | f-! a-! bes-! as-!
+    | ges-! f-! es-! ges-!
+    | f-! es-! des-! c(
+    | des) es-! c-! des-!
 
     % 40
-    | es(\fz c) des-| g(
-    | as)-| g( as)-|  as,-|
-    | des-| des,-| r
+    | es(\fz c) des-! g(
+    | as)-! g( as)-!  as,-!
+    | des-! des,-! r
   }
 
   c''-.\p
   | des-. c-. des-. d(\f
-  | es)-| d( es)-| e-.\p
+  | es)-! d( es)-! e-.\p
   | f-. e-. f-. f(\f
-  | f)-| f2\fz ges!4(\p
-  | f)-| ges( f)-| ges(
-  | f)-| f-| f-| r
-  | bes,,-|\f c-| des-| es-|
+  | f)-! f2\fz ges!4(\p
+  | f)-! ges( f)-! ges(
+  | f)-! f-! f-! r
+  | bes,,-!\f c-! des-! es-!
 
   % 50
-  | f-| a-| bes-| as-|
-  | ges( f es) es-|
-  | es2.\fz a,4-|
-  | bes-| r c-| r
-  | des-| r r2
+  | f-! a-! bes-! as-!
+  | ges( f es) es-!
+  | es2.\fz a,4-!
+  | bes-! r c-! r
+  | des-! r r2
   | es4\p r f r
-  | bes, r r c'-|\f
-  | des-| c-| des-| d(\p
-  | es)-| d( es)-| e-.\f
+  | bes, r r c'-!\f
+  | des-! c-! des-! d(\p
+  | es)-! d( es)-! e-.\f
   | f-. e-. f-. f(\p
 
   % 60
-  | f)-| f2 ges!4(\f
-  | f)-| ges( f)-| ges(
-  | f)-| f-| f-| r
-  | bes,,-| c-| des-| es-|
-  | f-| a-| bes-| as-|
-  | ges( f es) es-|
+  | f)-! f2 ges!4(\f
+  | f)-! ges( f)-! ges(
+  | f)-! f-! f-! r
+  | bes,,-! c-! des-! es-!
+  | f-! a-! bes-! as-!
+  | ges( f es) es-!
   | es1\fz
   | R1
   | a,\fz
@@ -105,23 +105,23 @@ celloFourthMov =  \relative bes, {
 
   | r2 r4 bes8(\f c)
   | d4( es f es)
-  | d-| c-| bes-| es,-|\fz
+  | d-! c-! bes-! es,-!\fz
   | f2 r
   | r4 bes r f'
 
   % 80
   | r g r d
-  | es-| e-|\fz f2
-  | bes,4-| bes'-| bes,-| r
+  | es-! e-!\fz f2
+  | bes,4-! bes'-! bes,-! r
   | R1
   | r2 r4 bes'8( a)
-  | g4-| g,-| d'-| d'-|
-  | es4( d8 c) b4-| r
+  | g4-! g,-! d'-! d'-!
+  | es4( d8 c) b4-! r
   | R1*2
   | r2 r4 bes!8(\fz a)
 
   % 90
-  | g( f e d) c4-| c'8( bes)
+  | g( f e d) c4-! c'8( bes)
   | a( f) c'( bes) a( f) c( bes)
   | a( f) c'( bes) a( f) r4
   | f r r2
@@ -132,12 +132,12 @@ celloFourthMov =  \relative bes, {
 
   % 100
   | d4( es f es)
-  | d-| c-| bes-| es,-|\fz
+  | d-! c-! bes-! es,-!\fz
   | f1 ~
   | f ~
   | f2 f'8-. fis-. g-. f-.
-  | es-. g-. f-. es-. d4-| a-|
-  | bes-| r r d-|
+  | es-. g-. f-. es-. d4-! a-!
+  | bes-! r r d-!
   | es2 e\fz
   | r4 r8 e, e4.(\trill d16 e)
   | f1 ~
@@ -147,9 +147,9 @@ celloFourthMov =  \relative bes, {
   | R1*3
   | bes'8(\p d c bes) a r r4
   | R1
-  | r8 es'[( d c)] b4-| r
+  | r8 es'[( d c)] b4-! r
   | R1
-  | r8 a[( bes! c)] d4-| r
+  | r8 a[( bes! c)] d4-! r
   | r d( c) r
 
   % 120
@@ -157,36 +157,36 @@ celloFourthMov =  \relative bes, {
   | R1
   | r2 r8 c,[(\f bes as)]
   | g( as g f) es( as g f)
-  | es( f es d) c4-| f-|
+  | es( f es d) c4-! f-!
   | bes r r8 f'[( g a]
-  | bes4)-| r r8 f([ g a]
+  | bes4)-! r r8 f([ g a]
   | bes) f( g a bes) f( g a
   | bes) f( g a bes) f( g a
   | bes4) r f r
 
   % 130
   | g( e f es)
-  | d-| c-| bes-| es,-|
+  | d-! c-! bes-! es,-!
   | f2 r
   | bes'4 r f r
   | g r d r
-  | es-| e-| f2
-  | bes,4-| bes'-| bes,-| r
+  | es-! e-! f2
+  | bes,4-! bes'-! bes,-! r
   | R1*6
   | bes'4 r f r
   | g( e f es)
-  | d-| c-| bes-| es,-|
+  | d-! c-! bes-! es,-!
   | f2 r
   | r4 bes\p r f'
   | r g r d
-  | es-| e-| f2
+  | es-! e-! f2
   | bes,4\f r r2
   | bes4 r r2
   | bes4 r r8 d'-. c-. bes-.
   | a bes a g f d' c bes
   | a bes a g f g f es
   | d-. es-. d-. c-. bes-. c-. bes-. as-.
-  | g as g f es4-| r
+  | g as g f es4-! r
   | R1*4
   | r2 r8 bes''-.\ff a-. g-.
   | f-. g-. f-. es-. d-. bes'-. a-. g-.
@@ -199,7 +199,7 @@ celloFourthMov =  \relative bes, {
   | f1
 
   % 170
-  | f4-| f-| f-| f-|
+  | f4-! f-! f-! f-!
   | bes r f' r
   | bes r f r
   | bes, r r2

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/score.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/score.ly
@@ -1,7 +1,7 @@
 % -*- LilyPond -*-
 % vim: ft=lilypond :
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -21,8 +21,8 @@ markingsIV = {}
 \layout {
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/viola.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/viola.ly
@@ -1,6 +1,6 @@
 % -*- LilyPond -*-
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -27,8 +27,8 @@ violaOverridesIV = {}
   \compressFullBarRests
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/viola_defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/viola_defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
 violaBreakBeforeIII = ##t
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/violin1.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/violin1.ly
@@ -1,6 +1,6 @@
 % -*- LilyPond -*-
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -27,8 +27,8 @@ violinIOverridesIV = {}
   \compressFullBarRests
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/violin1_defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/violin1_defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
 violinIBreakI = {
   s1*107\pageBreak
@@ -9,6 +9,6 @@ violinIBreakBeforeIII = ##t
 violinIBreakIV = {
   s4
   s1*33
-  \once \override TextScript #'extra-offset = #'(5 . -1)
+  \once \override TextScript.extra-offset = #'(5 . -1)
   s2._\markup \large \bold "V.S." \pageBreak
 }

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/violin2.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/violin2.ly
@@ -1,6 +1,6 @@
 % -*- LilyPond -*-
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -27,8 +27,8 @@ violinIIOverridesIV = {}
   \compressFullBarRests
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/violin2_defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/violin2_defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
 violinIIBreakI = {
   s1*141\pageBreak

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/violoncello.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/violoncello.ly
@@ -1,6 +1,6 @@
 % -*- LilyPond -*-
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -27,8 +27,8 @@ celloOverridesIV = {}
   \compressFullBarRests
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/violoncello_defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/4/violoncello_defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
 celloBreakBeforeII = ##t
 celloBreakIV = {

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 \header {
   title = "String Quartet in D major"
   subtitle = "Op. 76 No. 5"
@@ -48,7 +48,7 @@ markingsIII =  {
 
   s2.*32
   s2
-  \override Score.RehearsalMark #'break-visibility = #begin-of-line-invisible
-  \override Score.RehearsalMark #'self-alignment-X = #1
+  \override Score.RehearsalMark.break-visibility = #begin-of-line-invisible
+  \override Score.RehearsalMark.self-alignment-X = #1
   \mark \markup { \large { \italic "Menuetto D.C." } }
 }

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/i-midi.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/i-midi.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
   \midi {
     \tempo 4 = 72

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/i-viola.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/i-viola.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violaFirstMov =  \relative d' {
   \key d \major
   \clef alto
@@ -60,7 +60,7 @@ violaFirstMov =  \relative d' {
   | \repeat unfold 6 <c es> \repeat unfold 6 <bes d>
   | \repeat unfold 6 <bes d> <es, c'> \repeat unfold 5 <c' es>
   | \repeat unfold 6 <c es> \repeat unfold 6 <bes d>
-  | <bes es>8-| <bes es>-| r r4 r8
+  | <bes es>8-! <bes es>-! r r4 r8
   | g'8.(\p as16 g8) es( f g)
   | f r r es' r f,\f
   | bes8.( a16 bes8) c(\(-\> a16)-\! f( a c)\)
@@ -70,7 +70,7 @@ violaFirstMov =  \relative d' {
   | a8 r f ~ f16 e32( f) g-. f-. e-. d-. c-. bes-. a-. g-.
   | f8 r a' g4.
   | f e
-  | d16-| f32( g) a-. g-. f-. e-. d-. c-. bes-. a-. gis4.
+  | d16-! f32( g) a-. g-. f-. e-. d-. c-. bes-. a-. gis4.
   | a8 r cis[( d)] r f[(
   | e)] r e[( f)] r d(
   | a') a,-. a-. a-. r r
@@ -159,10 +159,10 @@ violaFirstMov =  \relative d' {
   % 120
   | a4 r8 g'4 r8
   | d,8. e16-. fis-. g-. a-. b-. cis-. d-. e-. fis-.
-  | g8-| cis,,-| r r4 r8
+  | g8-! cis,,-! r r4 r8
   | d8. e16-. fis-. g-. a-. b-. cis-. d-. e-. fis-.
-  | g8-| cis,,-| r r4 r8
-  | fis'-| d-| a'-| fis-| d-| a-|
+  | g8-! cis,,-! r r4 r8
+  | fis'-! d-! a'-! fis-! d-! a-!
   | fis4 r8 <d a' d>4 r8
   | <d a' d>4 r8 r4 r8
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/i-violin1.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/i-violin1.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIFirstMov =  \relative a' {
   \key d \major
   \clef violin
@@ -57,15 +57,15 @@ violinIFirstMov =  \relative a' {
   % 40
   | a(-\> fis-\! d) bes'8.( a16 bes8)
   | c(-\> a-\! f!) d'\f ~ d16 c32-. bes-. a-. g-. f-. es-.
-  | d8[ r16 \lbcOne f-| bes-| d]-| es8 ~ 
+  | d8[ r16 \lbcOne f-! bes-! d]-! es8 ~ 
   es16 d32-. c-. bes-. a-. g-. f-.
-  | es8[ r16 \lbcOne f-| a-| c]-| d8 ~ 
+  | es8[ r16 \lbcOne f-! a-! c]-! d8 ~ 
   d16 c32-. bes-. a-. g-. f-. es-.
-  | d8[ r16 \lbcOne f-| bes-| d]-| es8 ~ 
+  | d8[ r16 \lbcOne f-! bes-! d]-! es8 ~ 
   es16 d32-. c-. bes-. a-. g-. f-.
-  | es8[ r16 \lbcOne f-| a-| c]-| f8 ~ 
+  | es8[ r16 \lbcOne f-! a-! c]-! f8 ~ 
   f32 es-. d-. c-. bes-. as-. g-. f-.
-  | es8-| g'-| r r4 r8
+  | es8-! g'-! r r4 r8
   | c,8.(\p b16 c8) es( d c)
   | bes! r r a r r
   | R2.
@@ -73,13 +73,13 @@ violinIFirstMov =  \relative a' {
   % 50
   | r4 r8 r r a,\f
   | f'8.( e16 f8) g8(\(-\> e16)-\! c( e g)\)
-  | a16-| a32( bes) c-. bes-. a-. g-. f-. e-. d-. c-. bes8 r r
+  | a16-! a32( bes) c-. bes-. a-. g-. f-. e-. d-. c-. bes8 r r
   | r16 f'32( g) a-. g-. f-. e-. d-. c-. bes-. a-. g8 r r
   | r16 f32( g) a-. g-. f-. e-. d-. c-. bes-. a-. gis8 f' f
-  | e16-| cis32( d e d cis b) a16-. g'-.
-  f16-| f32( g a g f e) d16-. d'-.
-  | cis16-| cis32( d e d cis b) a( cis e g)
-  f16-| f32( g a g f e) d( f a d)
+  | e16-! cis32( d e d cis b) a16-. g'-.
+  f16-! f32( g a g f e) d16-. d'-.
+  | cis16-! cis32( d e d cis b) a( cis e g)
+  f16-! f32( g a g f e) d( f a d)
   | cis8 a,-. a-. a-. r a\p
 
   \bar "||"
@@ -91,7 +91,7 @@ violinIFirstMov =  \relative a' {
   % 60
   | e8.( g32 fis) e16( ais) cis( b a g fis e)
   | d( cis e cis d b) a8( b cis)
-  | d32 d, cis d e fis g a b cis d dis e8\fz-| cis16( e cis a)
+  | d32 d, cis d e fis g a b cis d dis e8\fz-! cis16( e cis a)
   | d!16 d( e) e( fis) fis( g4)\fz fis8
   | e32( fis g fis) e( fis g fis) e( fis g a) b8( g) eis(\fz
   | fis) d16( b) cis( ais) b4 d8
@@ -105,7 +105,7 @@ violinIFirstMov =  \relative a' {
   | r16 d-. r e-. r fis-. g4(\fz gis8)
   | a16( fis) d'( a fis d) a8( b cis)
   | d16( b) fis'( d b fis) d( b gis d' b gis)
-  | a( cis e g! cis e) g[( fis a g)] \times 2/3 { b[( g e)] }
+  | a( cis e g! cis e) g[( fis a g)] \tuplet 3/2 { b[( g e)] }
   | d4.\fermata cis4\fermata r8
 
   \bar "||"
@@ -148,28 +148,28 @@ violinIFirstMov =  \relative a' {
   | fis16( d) g8-. e16( cis) d8-. d16 b e8-.
   | cis16( a) cis( a) d( a) e'( a,) fis'( a,) g'( a,)
   | fis'8. e16-. d-. cis-. b-. a-. g-. fis-. e-. d-.
-  | cis8-| e'-| r r4 r8
+  | cis8-! e'-! r r4 r8
   | fis8. e16-. d-. cis-. b-. a-. g-. fis-. e-. d-.
 
   % 110
-  | cis8-| e'-| r r4 r8
+  | cis8-! e'-! r r4 r8
   | a8. g16-. fis-. e-. d-. c-. b-. a-. g-. fis-.
-  | g8-| b'-| r e,,-| g'-| r
-  | fis,-| a'-| r a,-| cis'-| r
+  | g8-! b'-! r e,,-! g'-! r
+  | fis,-! a'-! r a,-! cis'-! r
   | fis8. e16-. d-. cis-. b-. a-. g-. fis-. e-. d-.
-  | cis8-| g''-| r r4 r8
+  | cis8-! g''-! r r4 r8
   | fis8. e16-. d-. cis-. b-. a-. g-. fis-. e-. d-.
-  | cis8-| g''-| r r4 r8
+  | cis8-! g''-! r r4 r8
   | a8. g16-. fis-. e-. d-. c-. b-. a-. g-. fis-.
-  | g8-| b'-| r e,,,-| g'-| r
+  | g8-! b'-! r e,,,-! g'-! r
 
   % 120
-  | fis,-| a'-| r e,-| cis''-| r
-  | d,,-| d''-| r r4 r8
+  | fis,-! a'-! r e,-! cis''-! r
+  | d,,-! d''-! r r4 r8
   | g,8. fis16-. e-. d-. cis-. b-. a-. g-. fis-. e-.
-  | d8-| fis'-| r r4 r8
+  | d8-! fis'-! r r4 r8
   | g8. fis16-. e-. d-. cis-. b-. a-. g-. fis-. e-.
-  | d8-| fis-| a-| d-| fis-| a-|
+  | d8-! fis-! a-! d-! fis-! a-!
   | d4 r8 <d,, a' fis'>4 r8
   | <d a' fis'>4 r8 r4 r8
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/i-violin2.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/i-violin2.ily
@@ -1,9 +1,9 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIIFirstMov =  \relative a {
   \key d \major
   \clef violin
 
-  \override Staff.Hairpin   #'minimum-length = #5
+  \override Staff.Hairpin.minimum-length = #5
 
   r8
   | <a fis'>-.\p r <a fis'>-. 
@@ -61,16 +61,16 @@ violinIIFirstMov =  \relative a {
 
   % 40
   | g16 fis( a bes c a) d,4 bes'8 ~
-  | bes16( a c d es c) f,!8[\f r16 \lbcOne d-| f-| bes]-|
+  | bes16( a c d es c) f,!8[\f r16 \lbcOne d-! f-! bes]-!
   | d32( c) bes-. a-. g( f) es-. d-. c( bes) a-. bes-. 
-  c8[ r16 \lbcOne f-| a-| c]-|
+  c8[ r16 \lbcOne f-! a-! c]-!
   | es32( d)c-. bes-. a( g) f-. es-. d( c) bes-. a-.
-  bes8[ r16 \lbcOne d-| f-| bes]-|
+  bes8[ r16 \lbcOne d-! f-! bes]-!
   | d32( c) bes-. a-. g( f) es-. d-. c( bes) a-. bes-. 
-  c8[ r16 \lbcOne f-| a-| c]-|
+  c8[ r16 \lbcOne f-! a-! c]-!
   | es32( d)c-. bes-. a( g) f-. es-. d( c) bes-. a-.
-  bes8[ r16 \lbcOne bes'-| d-| f]-|
-  | <es, bes' g'>8-| <es bes' g'>-| r r4 r8
+  bes8[ r16 \lbcOne bes'-! d-! f]-!
+  | <es, bes' g'>8-! <es bes' g'>-! r r4 r8
   | c'8.(\p d16 c8) g'( f es)
   | d r r c r r
   | r4 r8 r4 f,8\f
@@ -80,7 +80,7 @@ violinIIFirstMov =  \relative a {
   | f8( a,) a bes4.
   | c8 r r r16 g'32( a) bes-. a-. g-. f-. e-. d-. c-. bes-.
   | a8 r r r16 e'32( f) g-. f-. e-. d-. cis-. bes!-. a-. g-.
-  | f16-| f32( g) a g f e d c bes a gis8 d' d
+  | f16-! f32( g) a g f e d c bes a gis8 d' d
   | cis r e[( f)] r a[(
   | g)] r cis[( d)] r f(
   | e) a,-. a-. a-. r r
@@ -158,22 +158,22 @@ violinIIFirstMov =  \relative a {
   % 110
   | e a e a e a g a g a g a
   | \repeat unfold 6 { fis a }
-  | g8-| g'-| r g,-| e'-| r
-  | d,-| fis'-| r cis,-| e'-| r
-  | d,-| fis'-| r r4 r8
+  | g8-! g'-! r g,-! e'-! r
+  | d,-! fis'-! r cis,-! e'-! r
+  | d,-! fis'-! r r4 r8
   | g8. fis16-. e-. d-. cis-. b-. a-. g-. fis-. e-.
-  | d8-| fis'-| r r4 r8
+  | d8-! fis'-! r r4 r8
   | g8. fis16-. e-. d-. cis-. b-. a-. g-. fis-. e-.
-  | d8-| a''-| r r4 r8
-  | d,,8-| d'-| r g,-| e'-| r
+  | d8-! a''-! r r4 r8
+  | d,,8-! d'-! r g,-! e'-! r
 
   % 120
-  | d,-| fis'-| r cis,-| e'-| r
+  | d,-! fis'-! r cis,-! e'-! r
   | d'8. cis16-. b-. a-. g-. fis-. e-. d-. cis-. b-.
-  | a8-| e''-| r r4 r8
+  | a8-! e''-! r r4 r8
   | d8. cis16-. b-. a-. g-. fis-. e-. d-. cis-. b-.
-  | a8-| e''-| r r4 r8
-  | a,,,-| d-| fis-| a-| d-| fis-|
+  | a8-! e''-! r r4 r8
+  | a,,,-! d-! fis-! a-! d-! fis-!
   | a4 r8 <d,, a' fis'>4 r8
   | <d a' fis'>4 r8 r4 r8    
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/i-violoncello.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/i-violoncello.ily
@@ -1,9 +1,9 @@
-\version "2.16.0"
+\version "2.18.0"
 celloFirstMov =  \relative d {
   \key d \major
   \clef bass
 
-  \override Staff.Hairpin   #'minimum-length = #5
+  \override Staff.Hairpin.minimum-length = #5
 
   r8
   | d-.\p r d-. << { d4. ~ } { s4-\> s8-\! } >>
@@ -62,7 +62,7 @@ celloFirstMov =  \relative d {
   | \repeat unfold 6 { a, f' } \repeat unfold 12 { bes, f' }
   \repeat unfold 12 { a, f' }
   \repeat unfold 6 { as, f' }
-  | g,8-| es-| r r4 r8
+  | g,8-! es-! r r4 r8
   | es''8.(\p f16 es8) c( d es)
   | f r r f, r r
   | r r bes\f ~ bes16 a32( bes) c-. bes-. a-. g-. f-. es-. d-. c-.
@@ -72,7 +72,7 @@ celloFirstMov =  \relative d {
   | d8 r r r4 r8
   | r4 f'8 e4. ~
   | e8 d4 ~ d8 cis4
-  | d16-| f,32( g) a-. g-. f-. e-. d-. c!-. bes-. a-. gis4.
+  | d16-! f,32( g) a-. g-. f-. e-. d-. c!-. bes-. a-. gis4.
   | a2. ~
   | a ~
   | a8 a-. a-. a-. r r
@@ -138,13 +138,13 @@ celloFirstMov =  \relative d {
   | << { a ~ } { s4. s4 } >>
   | a2. ~
   | a
-  | d8-| d'-| r r4 r8
+  | d8-! d'-! r r4 r8
   | g,8. fis16-. e-. d-. cis-. b-. a-. g-. fis-. e-.
-  | d8-| d'-| r r4 r8
+  | d8-! d'-! r r4 r8
 
   % 110
   | g8. fis16-. e-. d-. cis-. b-. a-. g-. fis-. e-.
-  | d8-| d'-| r r4 r8
+  | d8-! d'-! r r4 r8
   | g,4 r8 r4 r8
   | a4 r8 a4 r8
   | \repeat unfold 6 { d,16-. a'-. }
@@ -156,11 +156,11 @@ celloFirstMov =  \relative d {
 
   % 120
   | a4 r8 a4 r8
-  | d-| d,-| r8 r4 r8
+  | d-! d,-! r8 r4 r8
   | a'8. b16-. cis-. d-. e-. fis-. g-. a-. b-. cis-.
-  | d8-| d,,-| r r4 r8
+  | d8-! d,,-! r r4 r8
   | a'8. b16-. cis-. d-. e-. fis-. g-. a-. b-. cis-.
-  | d8-| a-| fis-| d-| a-| fis-|
+  | d8-! a-! fis-! d-! a-! fis-!
   | d4 r8 d4 r8
   | d4 r8 r4 r8
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/ii-midi.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/ii-midi.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
   \midi {
     \tempo 4 = 60

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/ii-viola.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/ii-viola.ily
@@ -1,9 +1,9 @@
-\version "2.16.0"
+\version "2.18.0"
 violaSecondMov =  \relative ais {
   \key fis \major
   \clef alto
 
-  \override Staff.Hairpin   #'minimum-length = #5
+  \override Staff.Hairpin.minimum-length = #5
 
   r4
   | ais1(\p\<

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/ii-violin1.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/ii-violin1.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinISecondMov =  \relative cis' {
   \key fis \major
   \clef violin

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/ii-violin2.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/ii-violin2.ily
@@ -1,9 +1,9 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIISecondMov =  \relative cis' {
   \key fis \major
   \clef violin
 
-  \override Staff.Hairpin   #'minimum-length = #5
+  \override Staff.Hairpin.minimum-length = #5
 
   r4
   | cis1(\p\<

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/ii-violoncello.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/ii-violoncello.ily
@@ -1,9 +1,9 @@
-\version "2.16.0"
+\version "2.18.0"
 celloSecondMov =  \relative fis {
   \key fis \major
   \clef bass
 
-  \override Staff.Hairpin   #'minimum-length = #5
+  \override Staff.Hairpin.minimum-length = #5
 
   r4
   | << { fis1\p-\markup { \italic "tenuto" } ~ }

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/iii-midi.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/iii-midi.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
   \midi {
     \tempo 4 = 160

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/iii-viola.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/iii-viola.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violaThirdMov =  \relative fis {
   \key d \major
   \clef alto

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/iii-violin1.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/iii-violin1.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIThirdMov =  \relative a {
   \key d \major
   \clef violin

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/iii-violin2.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/iii-violin2.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIIThirdMov =  \relative d' {
   \key d \major
   \clef violin

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/iii-violoncello.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/iii-violoncello.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 celloThirdMov =  \relative d, {
   \key d \major
   \clef bass

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/iv-midi.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/iv-midi.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
   \midi {
     \tempo 4 = 150

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/iv-viola.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/iv-viola.ily
@@ -1,43 +1,43 @@
-\version "2.16.0"
+\version "2.18.0"
 violaFourthMov =  \relative g' {
   \key d \major
   \clef alto
 
-  g8-|\f
-  | fis4-| r
-  | r r8 g-|
-  | fis4-| r
-  | r r8 g-|
-  | fis-| g-| fis-| g-|
+  g8-!\f
+  | fis4-! r
+  | r r8 g-!
+  | fis4-! r
+  | r r8 g-!
+  | fis-! g-! fis-! g-!
   | fis4 r8 d-.\p
   | d-. d-. d-. d-.
   | \repeat unfold 32 d
-  | d[ d d] g-|\f
-  | fis4-| r8 g-|
-  | fis4-| r8 g-|
-  | fis-| g-| fis-| g-|
+  | d[ d d] g-!\f
+  | fis4-! r8 g-!
+  | fis4-! r8 g-!
+  | fis-! g-! fis-! g-!
 
   % 20
-  | fis4-| r8 e-|
-  | d4-| r8 e-|
-  | d4-| r8 d-|
-  | cis-| d-| cis-| d-|
+  | fis4-! r8 e-!
+  | d4-! r8 e-!
+  | d4-! r8 d-!
+  | cis-! d-! cis-! d-!
   | cis4 r8 a-.\p
   | a-. a-. a-. a-.
   | \repeat unfold 32 a
-  | a[ a a] b-|\f
-  | cis-| b-| cis-| b-|
-  | cis4 r8 c-|
-  | b-| c-| b-| c-|
-  | b4 r8 fis'-|
-  | g-| a-| g-| dis-|
-  | e-| dis-| e-| g-|
-  | fis-| g-| fis-| cis-|
-  | d-| cis-| d-| g-|
-  | fis-| g-| fis-| e'-|
-  | d-| e-| d-| cis-|
-  | b-| e-| d-| b-|
-  | b-| b-.\p b-. b-.
+  | a[ a a] b-!\f
+  | cis-! b-! cis-! b-!
+  | cis4 r8 c-!
+  | b-! c-! b-! c-!
+  | b4 r8 fis'-!
+  | g-! a-! g-! dis-!
+  | e-! dis-! e-! g-!
+  | fis-! g-! fis-! cis-!
+  | d-! cis-! d-! g-!
+  | fis-! g-! fis-! e'-!
+  | d-! e-! d-! cis-!
+  | b-! e-! d-! b-!
+  | b-! b-.\p b-. b-.
   | b-. b-. b-. b-.
   | \repeat unfold 16 b
   | ais\f ais ais ais
@@ -161,18 +161,18 @@ violaFourthMov =  \relative g' {
   | \repeat unfold 20 fis
   | e'-\< e e e
   | e cis a e-\!
-  | fis4-|\f r8 <e a>8-|
-  | \repeat unfold 2 { <fis a>4-| r8 <e a>-| }
-  | \repeat unfold 2 { <fis a>-| <e a>-| }
-  | <fis a>4-| r8 <fis cis'>-|
-  | \repeat unfold 2 { <fis d'>-| <fis cis'>-| }
-  | a4-| r8 a-|
+  | fis4-!\f r8 <e a>8-!
+  | \repeat unfold 2 { <fis a>4-! r8 <e a>-! }
+  | \repeat unfold 2 { <fis a>-! <e a>-! }
+  | <fis a>4-! r8 <fis cis'>-!
+  | \repeat unfold 2 { <fis d'>-! <fis cis'>-! }
+  | a4-! r8 a-!
 
   % 200
-  | \repeat unfold 2 { <d, b'>-| <d a'>-| }
-  | <d b'>4 r8 fis-|
-  | \repeat unfold 2 { <b, g'>-| <b fis'>-| }
-  | <b g'>4-| r8 e16( fis)
+  | \repeat unfold 2 { <d, b'>-! <d a'>-! }
+  | <d b'>4 r8 fis-!
+  | \repeat unfold 2 { <b, g'>-! <b fis'>-! }
+  | <b g'>4-! r8 e16( fis)
   | g4. gis8-.
   | a8-. cis,16( d) e8-. r
   | g!4. e8-.
@@ -182,18 +182,18 @@ violaFourthMov =  \relative g' {
 
   % 210
   | cis8-. g'16( fis) e8-. a,-.
-  | a4 r8 e''-|
-  | fis4 r8 b,-|
-  | cis4 r8 ais-|
-  | b4 r8 b-|
-  | ais( b ais) a-|
-  | gis( a gis) g-|
-  | fis( g fis) cis-|
-  | d( cis d) d-|
+  | a4 r8 e''-!
+  | fis4 r8 b,-!
+  | cis4 r8 ais-!
+  | b4 r8 b-!
+  | ais( b ais) a-!
+  | gis( a gis) g-!
+  | fis( g fis) cis-!
+  | d( cis d) d-!
   | d2
 
   % 220
-  | b4. e8-|
+  | b4. e8-!
   | e-. e-.\p e-. e-.
   | \repeat unfold 20 e
   | dis\f dis dis dis
@@ -253,7 +253,7 @@ violaFourthMov =  \relative g' {
   | fis4-. r8 g-.
   | fis4-. r8 e-.
   | fis4-. r8 e-.
-  | fis-| e-| fis-| e-|
+  | fis-! e-! fis-! e-!
   | fis4 r
 
   % 290

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/iv-violin1.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/iv-violin1.ily
@@ -1,14 +1,14 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIFourthMov =  \relative cis''' {
   \key d \major
   \clef violin
 
-  cis8-|\f
-  | d4-| r
-  | r r8 cis-|
-  | d4-| r
-  | r r8 cis-|
-  | d-| cis-| d-| cis-|
+  cis8-!\f
+  | d4-! r
+  | r r8 cis-!
+  | d4-! r
+  | r r8 cis-!
+  | d-! cis-! d-! cis-!
   | d4 r
   | R2
   | r4 r8 a16(\p g)
@@ -19,16 +19,16 @@ violinIFourthMov =  \relative cis''' {
   | fis8-. fis16( e) d8-. e-.
   | fis4( d8)-. r
   | R2*3
-  | r4 r8 cis'-|\f
-  | d4-| r8 cis-|
-  | d4-| r8 cis-|
-  | d-| cis-| d-| cis-|
+  | r4 r8 cis'-!\f
+  | d4-! r8 cis-!
+  | d4-! r8 cis-!
+  | d-! cis-! d-! cis-!
 
   % 20
-  | d4-| r8 ais-|
-  | b4-| r8 ais-|
-  | b4-| r8 gis-|
-  | a!-| gis-| a-| gis-|
+  | d4-! r8 ais-!
+  | b4-! r8 ais-!
+  | b4-! r8 gis-!
+  | a!-! gis-! a-! gis-!
   | a4 r
   | R2
   | r4 r8 e16(\p d)
@@ -39,20 +39,20 @@ violinIFourthMov =  \relative cis''' {
   % 30
   | cis4( a8)-. r
   | R2*3
-  | r4 r8 gis'-|\f
-  | a-| gis-| a-| gis-|
-  | a4 r8 fis-|
-  | g!-| fis-| g-| fis-|
-  | g4 r8 dis-|
-  | e-| dis-| e-| fis-|
+  | r4 r8 gis'-!\f
+  | a-! gis-! a-! gis-!
+  | a4 r8 fis-!
+  | g!-! fis-! g-! fis-!
+  | g4 r8 dis-!
+  | e-! dis-! e-! fis-!
 
   % 40
-  | g-| fis-| g-| cis,-|
-  | d-| cis-| d-| e-|
-  | fis-| e-| fis-| ais-|
-  | b-| ais-| b-| cis-|
-  | d-| cis-| d-| ais-|
-  | b-| ais-| b-| a-|
+  | g-! fis-! g-! cis,-!
+  | d-! cis-! d-! e-!
+  | fis-! e-! fis-! ais-!
+  | b-! ais-! b-! cis-!
+  | d-! cis-! d-! ais-!
+  | b-! ais-! b-! a-!
   | gis4 r
   | R2*3
 
@@ -214,20 +214,20 @@ violinIFourthMov =  \relative cis''' {
   % 190
   | d d d d
   | g-\< g g g
-  | g g g cis-|-\!
-  | d4-|\f r8 cis-|
-  | d4-| r8 cis-|
-  | d4-| r8 cis-|
-  | d-| cis-| d-| cis-|
-  | d4-| r8 ais-|
-  | b-| ais-| b-| ais-|
-  | b4-| r8 fis-|
+  | g g g cis-!-\!
+  | d4-!\f r8 cis-!
+  | d4-! r8 cis-!
+  | d4-! r8 cis-!
+  | d-! cis-! d-! cis-!
+  | d4-! r8 ais-!
+  | b-! ais-! b-! ais-!
+  | b4-! r8 fis-!
 
   % 200
-  | g-| fis-| g-| fis-|
-  | g4-| r8 dis-|
-  | e-| dis-| e-| dis-|
-  | e-| e16( fis) g8-. g16( a)
+  | g-! fis-! g-! fis-!
+  | g4-! r8 dis-!
+  | e-! dis-! e-! dis-!
+  | e-! e16( fis) g8-. g16( a)
   | b8-. g-. e-. d!-.
   | cis-. a16( b) cis8-. cis16( d)
   | e8-. e16( fis) g8-. cis,-.
@@ -237,15 +237,15 @@ violinIFourthMov =  \relative cis''' {
 
   % 210
   | e8-. e16( fis) g8-. cis,-.
-  | d( cis d) cis-|
-  | d( cis d) gis,-|
-  | a( gis a) fis-|
-  | g!( fis g) eis-|
-  | fis( eis fis) dis-|
-  | e!( dis e) cis-|
-  | d!( cis d) e-|
-  | fis( e fis) g-|
-  | a( gis a) ais-|
+  | d( cis d) cis-!
+  | d( cis d) gis,-!
+  | a( gis a) fis-!
+  | g!( fis g) eis-!
+  | fis( eis fis) dis-!
+  | e!( dis e) cis-!
+  | d!( cis d) e-!
+  | fis( e fis) g-!
+  | a( gis a) ais-!
 
   % 220
   | b( g! e) d-.
@@ -319,7 +319,7 @@ violinIFourthMov =  \relative cis''' {
   | d4-. r8 e-.
   | fis4-. r8 cis'-.
   | d4-. r8 cis-.
-  | d-| cis-| d-| cis-|
+  | d-! cis-! d-! cis-!
   | d4 r
 
   % 290

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/iv-violin2.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/iv-violin2.ily
@@ -1,44 +1,44 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIIFourthMov =  \relative e'' {
   \key d \major
   \clef violin
 
-  e8-|\f
-  | fis4-| r
-  | r r8 e-|
-  | fis4-| r
-  | r r8 e-|
-  | fis-| e-| fis-| e-|
+  e8-!\f
+  | fis4-! r
+  | r r8 e-!
+  | fis4-! r
+  | r r8 e-!
+  | fis-! e-! fis-! e-!
   | fis4 r8 a,-.\p
   | a-. a-. a-. a-.
   | \repeat unfold 32 a
-  | a[ a a] e'-|\f
-  | fis4-| r8 e-|
-  | fis4-| r8 e-|
-  | fis-| e-| fis-| e-|
+  | a[ a a] e'-!\f
+  | fis4-! r8 e-!
+  | fis4-! r8 e-!
+  | fis-! e-! fis-! e-!
 
   % 20
-  | fis4-| r8 cis-|
-  | d4-| r8 cis-|
-  | d4-| r8 b-|
-  | cis-| b-| cis-| b-|
+  | fis4-! r8 cis-!
+  | d4-! r8 cis-!
+  | d4-! r8 b-!
+  | cis-! b-! cis-! b-!
   | cis4 r8 e,-.\p
   | e-. e-. e-. e-.
   | \repeat unfold 32 e
-  | e[ e e] d'-|\f
-  | cis-| d-| cis-| d-|
-  | cis4 r8 a-|
-  | b-| a-| b-| a-|
-  | b4 r8 a-|
-  | b-| c-| b-| b-|
+  | e[ e e] d'-!\f
+  | cis-! d-! cis-! d-!
+  | cis4 r8 a-!
+  | b-! a-! b-! a-!
+  | b4 r8 a-!
+  | b-! c-! b-! b-!
 
   % 40
-  | b4. a8-|
-  | a-| bes-| a-| a-|
-  | a4. cis8-|
-  | d-| cis-| d-| g-|
-  | fis-| g-| fis-| e-|
-  | fis-| g-| fis-| fis-|
+  | b4. a8-!
+  | a-! bes-! a-! a-!
+  | a4. cis8-!
+  | d-! cis-! d-! g-!
+  | fis-! g-! fis-! e-!
+  | fis-! g-! fis-! fis-!
   | e4 r
   | R2*3
 
@@ -204,7 +204,7 @@ violinIIFourthMov =  \relative e'' {
   | b e d c b e d c
   | b c b a g c b a
   | g c b a g c b a
-  | g8-| b-. b-. b-.
+  | g8-! b-. b-. b-.
   | b-. b-. b-. b-.
   | e,4. a16( b)
   | cis8-. cis16( d) e8-. g,-.
@@ -214,14 +214,14 @@ violinIIFourthMov =  \relative e'' {
 
   % 210
   | e8-. e16( d) cis8-. e-.
-  | d4 r8 g8-|
-  | a4 r8 d,-|
-  | e4 r8 cis-|
-  | d4 r8 d-|
-  | cis( d cis) c-|
-  | b( c b) bes-|
-  | a( bes a) a-|
-  | a4. d8-|
+  | d4 r8 g8-!
+  | a4 r8 d,-!
+  | e4 r8 cis-!
+  | d4 r8 d-!
+  | cis( d cis) c-!
+  | b( c b) bes-!
+  | a( bes a) a-!
+  | a4. d8-!
   | d2 ~
 
   % 220
@@ -287,7 +287,7 @@ violinIIFourthMov =  \relative e'' {
   | fis4-. r8 cis'-.
   | d4-. r8 g-.
   | fis4-. r8 g-.
-  | fis-| g-| fis-| g-|
+  | fis-! g-! fis-! g-!
   | fis4 r
 
   % 290

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/iv-violoncello.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/iv-violoncello.ily
@@ -1,47 +1,47 @@
-\version "2.16.0"
+\version "2.18.0"
 celloFourthMov =  \relative a {
   \key d \major
   \clef bass
 
-  a8-|\f
-  | d,4-| r
-  | r r8 a'-|
-  | d,4-| r
-  | r r8 a'-|
-  | d,-| a'-| d,-| a'-|
+  a8-!\f
+  | d,4-! r
+  | r r8 a'-!
+  | d,4-! r
+  | r r8 a'-!
+  | d,-! a'-! d,-! a'-!
   | d,4 r
   | R2*5
   | r4 r8 a'16(\p g)
   | fis8-. fis16( e) d8-. e-.
   | fis16( g fis e) d8-. a'16( g)
   | fis8-. fis16( e) d8-. e-.
-  | fis4( d8)-. a'-|\f
-  | d,4-| r8 a'-|
-  | d,4-| r8 a'-|
-  | d,-| a'-| d,-| a'-|
+  | fis4( d8)-. a'-!\f
+  | d,4-! r8 a'-!
+  | d,4-! r8 a'-!
+  | d,-! a'-! d,-! a'-!
 
   % 20
-  | d,4-| r8 fis-|
-  | b,4-| r8 fis'-|
-  | b,4-| r8 e-|
-  | a,-| e'-| a,-| e'-|
+  | d,4-! r8 fis-!
+  | b,4-! r8 fis'-!
+  | b,4-! r8 e-!
+  | a,-! e'-! a,-! e'-!
   | a,4 r
   | R2*5
   | r4 r8 e'16(\p d)
   | cis8-. cis16( b) a8-. b-.
   | cis16( d cis b) a8-. e'16( d)
   | cis8-. cis16( b) a8-. b-.
-  | cis4( a8)-.\noBeam e'-|\f
-  | a,-| e'-| a,-| e'-|
-  | a,4 r8 d-|
-  | g,!-| d'-| g,-| d'-|
+  | cis4( a8)-.\noBeam e'-!\f
+  | a,-! e'-! a,-! e'-!
+  | a,4 r8 d-!
+  | g,!-! d'-! g,-! d'-!
   | g,4 r
   | R2*3
-  | r4 r8 e''-|
-  | d-| e-| d-| ais-|
-  | b-| ais-| b-| cis-|
-  | d-| cis-| d-| dis-|
-  | e-| e-.\p e-. e-.
+  | r4 r8 e''-!
+  | d-! e-! d-! ais-!
+  | b-! ais-! b-! cis-!
+  | d-! cis-! d-! dis-!
+  | e-! e-.\p e-. e-.
   | e-. e-. e-. e-.
   | \repeat unfold 16 e
   | e\f e e e
@@ -182,19 +182,19 @@ celloFourthMov =  \relative a {
   % 191
   | a-\< a a a
   | a, a a a-\!
-  | d,4\f r8 a''-|
-  | d4-| r8 a-|
-  | d4-| r8 a-| 
-  | d-| a-| d-| a-|
-  | d4-| r8 fis,-|
-  | b-| fis-| b-| fis-|
-  | b4-| r8 d,-|
+  | d,4\f r8 a''-!
+  | d4-! r8 a-!
+  | d4-! r8 a-! 
+  | d-! a-! d-! a-!
+  | d4-! r8 fis,-!
+  | b-! fis-! b-! fis-!
+  | b4-! r8 d,-!
 
   % 200
-  | g-| d-| g-| d-|
-  | g4-| r8 b,-|
-  | e-| b-| e-| b-|
-  | e-| e-. e-. e-.
+  | g-! d-! g-! d-!
+  | g4-! r8 b,-!
+  | e-! b-! e-! b-!
+  | e-! e-. e-. e-.
   | e-. e-. g-. gis-.
   | a-. a-. a-. a-.
   | a a a a
@@ -207,7 +207,7 @@ celloFourthMov =  \relative a {
   | fis4 r
   | R2*6
   | r4 r8 b
-  | fis( eis fis) fis-|
+  | fis( eis fis) fis-!
 
   % 220
   | g4.( gis8)-.
@@ -270,7 +270,7 @@ celloFourthMov =  \relative a {
   | a,
   | \repeat unfold 6 { d4 r8 a'-. }
   | d,4-. r8 a-.
-  | d,-| a'-| d,-| a'-|
+  | d,-! a'-! d,-! a'-!
   | d,4 r
 
   % 290

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/score.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/score.ly
@@ -1,7 +1,7 @@
 % -*- LilyPond -*-
 % vim: ft=lilypond :
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -21,8 +21,8 @@ markingsIV = {}
 \layout {
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/viola.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/viola.ly
@@ -1,6 +1,6 @@
 % -*- LilyPond -*-
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -27,8 +27,8 @@ violaOverridesIV = {}
   \compressFullBarRests
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/viola_defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/viola_defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
 violaBreakI = {
   s8

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/violin1.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/violin1.ly
@@ -1,6 +1,6 @@
 % -*- LilyPond -*-
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -27,8 +27,8 @@ violinIOverridesIV = {}
   \compressFullBarRests
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/violin1_defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/violin1_defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
 violinIBreakI = {
   s8

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/violin2.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/violin2.ly
@@ -1,6 +1,6 @@
 % -*- LilyPond -*-
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -27,8 +27,8 @@ violinIIOverridesIV = {}
   \compressFullBarRests
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/violin2_defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/violin2_defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
 violinIIBreakBeforeII = ##t
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/violoncello.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/violoncello.ly
@@ -1,6 +1,6 @@
 % -*- LilyPond -*-
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -27,8 +27,8 @@ celloOverridesIV = {}
   \compressFullBarRests
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/violoncello_defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/5/violoncello_defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
 celloBreakI = {
   s8

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 \header {
   title = "String Quartet in E-flat major"
   subtitle = "Op. 76 No. 6"
@@ -49,7 +49,7 @@ markingsIII =  {
   s2.*95
 
   s2
-  \override Score.RehearsalMark #'break-visibility = #begin-of-line-invisible
-  \override Score.RehearsalMark #'self-alignment-X = #1
+  \override Score.RehearsalMark.break-visibility = #begin-of-line-invisible
+  \override Score.RehearsalMark.self-alignment-X = #1
   \mark \markup { \large { \italic "Menuetto D.C." } }
 }

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/i-midi.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/i-midi.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
   \midi {
     \tempo 4 = 88

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/i-viola.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/i-viola.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violaFirstMov =  \relative bes {
   \key es \major
   \clef alto

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/i-violin1.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/i-violin1.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIFirstMov =  \relative bes' {
   \key es \major
   \clef violin

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/i-violin2.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/i-violin2.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIIFirstMov =  \relative es' {
   \key es \major
   \clef violin

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/i-violoncello.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/i-violoncello.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 celloFirstMov =  \relative es {
   \key es \major
   \clef bass

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/ii-midi.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/ii-midi.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
   \midi {
     \tempo 4 = 52

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/ii-viola.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/ii-viola.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violaSecondMov =  \relative dis' {
   \key c \major
   \clef alto

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/ii-violin1.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/ii-violin1.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinISecondMov =  \relative b' {
   \key c \major
   \clef violin
@@ -11,7 +11,7 @@ violinISecondMov =  \relative b' {
   | b( ais8) r r4
   | b4( ais b)
   | << { cis8.( dis16 e4 dis) } { s8 s8^\turn } >>
-  | \times 2/3 { cis8( e gis) } b,4( ais)
+  | \tuplet 3/2 { cis8( e gis) } b,4( ais)
   | cis4(-> b8)-. r r4
   | b4(\pp ais b)
 
@@ -47,7 +47,7 @@ violinISecondMov =  \relative b' {
   | bes4(\pp a bes)
   | ces8.( des16) es2
   | cis8.(-\< dis16) e!2-\!
-  | \times 2/3 { dis8(-\markup { \italic "poco " \dynamic "f" } e fis) }
+  | \tuplet 3/2 { dis8(-\markup { \italic "poco " \dynamic "f" } e fis) }
   b,4( ais)
   | b-. b-. b-.
 
@@ -69,7 +69,7 @@ violinISecondMov =  \relative b' {
   | as( g8) r r4
   | as(\mf g as)
   | << { bes8.( c16 des4 c) } { s8 s8^\turn } >>
-  | \times 4/6 { c16[( bes des f des bes]) } as4( g)
+  | \tuplet 6/4 { c16[( bes des f des bes]) } as4( g)
   | as4 r r
   | R2.*3
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/ii-violin2.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/ii-violin2.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIISecondMov =  \relative fis' {
   \key c \major
   \clef violin

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/ii-violoncello.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/ii-violoncello.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 celloSecondMov =  \relative b {
   \key c \major
   \clef bass

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/iii-midi.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/iii-midi.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
   \midi {
     \tempo 4 = 212

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/iii-viola.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/iii-viola.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violaThirdMov =  \relative g' {
   \key es \major
   \clef alto

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/iii-violin1.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/iii-violin1.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIThirdMov =  \relative es'' {
   \key es \major
   \clef violin

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/iii-violin2.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/iii-violin2.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIIThirdMov =  \relative bes' {
   \key es \major
   \clef violin

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/iii-violoncello.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/iii-violoncello.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 celloThirdMov =  \relative es' {
   \key es \major
   \clef bass

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/iv-midi.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/iv-midi.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
   \midi {
     \tempo 4 = 150

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/iv-viola.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/iv-viola.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violaFourthMov =  \relative es' {
   \key es \major
   \clef alto

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/iv-violin1.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/iv-violin1.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIFourthMov =  \relative bes' {
   \key es \major
   \clef violin

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/iv-violin2.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/iv-violin2.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 violinIIFourthMov =  \relative g' {
   \key es \major
   \clef violin

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/iv-violoncello.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/iv-violoncello.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 celloFourthMov =  \relative es {
   \key es \major
   \clef bass

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/score.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/score.ly
@@ -1,7 +1,7 @@
 % -*- LilyPond -*-
 % vim: ft=lilypond :
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -21,8 +21,8 @@ markingsIV = {}
 \layout {
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/viola.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/viola.ly
@@ -1,6 +1,6 @@
 % -*- LilyPond -*-
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -27,8 +27,8 @@ violaOverridesIV = {}
   \compressFullBarRests
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/viola_defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/viola_defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
 violaBreakBeforeII = ##t
 violaBreakBeforeIV = ##t

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/violin1.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/violin1.ly
@@ -1,6 +1,6 @@
 % -*- LilyPond -*-
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -27,8 +27,8 @@ violinIOverridesIV = {}
   \compressFullBarRests
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/violin1_defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/violin1_defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
 violinIBreakI = {
   s16

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/violin2.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/violin2.ly
@@ -1,6 +1,6 @@
 % -*- LilyPond -*-
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -27,8 +27,8 @@ violinIIOverridesIV = {}
   \compressFullBarRests
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/violin2_defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/violin2_defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
 violinIIBreakI = {
   s16

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/violoncello.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/violoncello.ly
@@ -1,6 +1,6 @@
 % -*- LilyPond -*-
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -27,8 +27,8 @@ celloOverridesIV = {}
   \compressFullBarRests
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/violoncello_defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/6/violoncello_defs.ily
@@ -1,4 +1,4 @@
-\version "2.16.0"
+\version "2.18.0"
 
 celloBreakBeforeIII = ##t
 celloBreakIV = {

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/defs.ily
@@ -1,6 +1,6 @@
 % vim: ft=lilypond
 
-\version "2.16.0"
+\version "2.18.0"
 
 #(ly:set-option 'point-and-click #f)
 
@@ -9,45 +9,45 @@
 staccato = \markup { \italic staccato }
 legato = \markup { \italic legato }
 
-tupletNum = \revert TupletNumber #'stencil
+tupletNum = \revert TupletNumber.stencil
 
-noTupletNum = \override TupletNumber #'stencil = ##f
+noTupletNum = \override TupletNumber.stencil = ##f
 
-tupletBracket = \override TupletBracket #'bracket-visibility = ##t
+tupletBracket = \override TupletBracket.bracket-visibility = ##t
 
-noTupletBracket = \override TupletBracket #'bracket-visibility = ##f
+noTupletBracket = \override TupletBracket.bracket-visibility = ##f
 
-preNaturalTrill = \once \override TextScript #'self-alignment-X = #-0.6
+preNaturalTrill = \once \override TextScript.self-alignment-X = #-0.6
 naturalTrill = \markup { \center-column { { \fontsize #-1 \natural }
   { \musicglyph #"scripts.trill" } } }
 
-preFlatTrill = \once \override TextScript #'self-alignment-X = #-0.6
+preFlatTrill = \once \override TextScript.self-alignment-X = #-0.6
 flatTrill = \markup { \center-column { { \fontsize #-1 \flat }
   { \musicglyph #"scripts.trill" } } }
 
-preSharpTrill = \once \override TextScript #'self-alignment-X = #-0.6
+preSharpTrill = \once \override TextScript.self-alignment-X = #-0.6
 sharpTrill = \markup { \center-column { { \fontsize #-1 \sharp }
   { \musicglyph #"scripts.trill" } } }
 
 preNaturalTurn = {
-  \once \override TextScript #'self-alignment-X = #-0.6
-  \once \override TextScript #'baseline-skip = #1.8
+  \once \override TextScript.self-alignment-X = #-0.6
+  \once \override TextScript.baseline-skip = #1.8
 }
 naturalTurn = \markup { \center-column { { \fontsize #-2 \natural }
   { \musicglyph #"scripts.turn" } } }
 preTurnNatural = {
-  \once \override TextScript #'self-alignment-X = #-0.6
-  \once \override TextScript #'baseline-skip = #1.8
+  \once \override TextScript.self-alignment-X = #-0.6
+  \once \override TextScript.baseline-skip = #1.8
 }
 turnNatural = \markup { \center-column { { \musicglyph #"scripts.turn" }
 { \fontsize #-2 \natural } } }
 
-preSharpTurn = \once \override TextScript #'self-alignment-X = #-0.6
+preSharpTurn = \once \override TextScript.self-alignment-X = #-0.6
 sharpTurn = \markup { \center-column { { \fontsize #-2 \sharp }
   { \musicglyph #"scripts.turn" } } }
 preTurnSharp = {
-  \once \override TextScript #'self-alignment-X = #-0.6
-  \once \override TextScript #'baseline-skip = #1.8
+  \once \override TextScript.self-alignment-X = #-0.6
+  \once \override TextScript.baseline-skip = #1.8
 }
 turnSharp = \markup { \center-column { { \musicglyph #"scripts.turn" }
   { \fontsize #-2 \sharp } } }

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/part_template.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/part_template.ly
@@ -1,6 +1,6 @@
 % -*- LilyPond -*-
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -27,8 +27,8 @@ markingsIV = {}
   \compressFullBarRests
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/score_template.ly
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/score_template.ly
@@ -1,7 +1,7 @@
 % -*- LilyPond -*-
 % vim: ft=lilypond :
 
-\version "2.16.0"
+\version "2.18.0"
 
 markingsI = {}
 markingsII = {}
@@ -21,8 +21,8 @@ markingsIV = {}
 \layout {
   \context {
     \Score
-    \override BarNumber #'font-size = #1
-    \override BarNumber #'padding = #3
+    \override BarNumber.font-size = #1
+    \override BarNumber.padding = #3
   }
 }
 


### PR DESCRIPTION
The conversion was performed with the following commands:

    find ftp/HaydnFJ/O76/op76-n1/op76-n1-lys -name "*.ly" | xargs convert-ly -e --from=2.16.0 --to=2.18.2
    find ftp/HaydnFJ/O76/op76-n1/op76-n1-lys -name "*.ily" | xargs convert-ly -e --from=2.16.0 --to=2.18.2

After the update all files compile cleanly with lilypond 2.18.2.