### PR TITLE
use mytagline instead of tagline, move mutopia fields together

### DIFF
--- a/ftp/TarregaF/claro-de-luna/claro-de-luna.ly
+++ b/ftp/TarregaF/claro-de-luna/claro-de-luna.ly
@@ -12,9 +12,8 @@
  composer = "Arr: de F. Tárrega"
  style = "Classical"
  date = "c.1885" % Beethoven d.1827, Tarrega d.1909, Alier d.1938
- mutopiadate = "c.1885"
  source = "Madrid: Ildefonso Alier, n.d. Plate 5754" % via IMSLP293004
- mutopiasource = "Madrid: Ildefonso Alier, n.d. Plate 5754"
+ mytagline = \markup{ \column { \vspace #2 \smaller \italic "Ildefonso Alier (1864-1938), Editor de Musica, Madrid.  Placa № 5754. IMSLP № 293004."} }
 
  %            o_
  %       (\___\/_____/)
@@ -25,6 +24,8 @@
 
  mutopiacomposer = "TarregaF"
  mutopiatitle = "Claro de Luna (Beethoven's Moonlight Sonata)"
+ mutopiadate = "c.1885"
+ mutopiasource = "Madrid: Ildefonso Alier, n.d. Plate 5754"
  mutopiainstrument = "Guitar"
 
  footer = "Mutopia-2015/11/17-2074"
@@ -43,6 +44,12 @@
   ragged-last-bottom = ##f
   print-first-page-number = ##t
   evenHeaderMarkup = \oddHeaderMarkup % so all page numbers to right
+  oddFooterMarkup = \markup { \column {
+      \fill-line { \on-the-fly #first-page \column { \vspace #1 \fromproperty #'header:copyright } } 
+      \fill-line { \on-the-fly #last-page \fromproperty #'header:mytagline }
+    }
+  }
+  evenFooterMarkup = \oddFooterMarkup
 }
 
 


### PR DESCRIPTION
As mentioned in commit 213407643652746ec61e2c5ace81a3ae2b8092d6, this change will work around the way Mutopia -f resets the copyright and tagline fields.  You should now see an historical note at the end of the piece even though tagline is false.  There is also a bit more space above the copyright on the first page, even though the copyright field has not been modified.

The mutopia fields (mutopiadate and mutopiasource) have also been grouped together with the other mutopia* fields.