### PR TITLE
Joplin, Scott: The Entertainer. Updated syntax and better coding

### DIFF
--- a/ftp/JoplinS/entertainer/entertainer.ly
+++ b/ftp/JoplinS/entertainer/entertainer.ly
@@ -1,337 +1,337 @@
-\version "2.10.33"
+\version "2.19.32"
 
 \header {
- title = "The Entertainer"
- subtitle = "A Ragtime Two Step"
- composer = "Scott Joplin"
- piece = "INTRO"
- 
- mutopiatitle = "The Entertainer"
- mutopiacomposer = "JoplinS"
- mutopiainstrument = "Piano"
- date = "c. 1902"
- style = "Jazz"
- copyright = "Public Domain"
- source = "Reproduction of original edition (1902)"
- 
- maintainer = "Chris Sawer"
- maintainerEmail = "chris@mutopiaproject.org"
- maintainerWeb = "http://www.whitewillow.co.uk/"
- 
- footer = "Mutopia-2008/12/21-263"
- tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-align { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \line { \teeny www. \hspace #-1.0 MutopiaProject \hspace #-1.0 \teeny .org \hspace #0.5 } • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \line { \teeny www. \hspace #-1.0 LilyPond \hspace #-1.0 \teeny .org } by \maintainer \hspace #-1.0 . \hspace #0.5 Reference: \footer } } \line { \teeny \line { This sheet music has been placed in the public domain by the typesetter, for details see: \hspace #-0.5 \with-url #"http://creativecommons.org/licenses/publicdomain" http://creativecommons.org/licenses/publicdomain } } } }
+  title = "The Entertainer"
+  subtitle = "A Ragtime Two Step"
+  composer = "Scott Joplin"
+  piece = "INTRO"
+
+  mutopiatitle = "The Entertainer"
+  mutopiacomposer = "JoplinS"
+  mutopiainstrument = "Piano"
+  date = "c. 1902"
+  style = "Jazz"
+  copyright = "Public Domain"
+  source = "Reproduction of original edition (1902)"
+
+  maintainer = "Chris Sawer"
+  maintainerEmail = "chris@mutopiaproject.org"
+  maintainerWeb = "http://www.whitewillow.co.uk/"
+
+  footer = "Mutopia-2008/12/21-263"
+  tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-column { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \line { \teeny www. \hspace #-1.0 MutopiaProject \hspace #-1.0 \teeny .org \hspace #0.5 } • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \line { \teeny www. \hspace #-1.0 LilyPond \hspace #-1.0 \teeny .org } by \maintainer \hspace #-1.0 . \hspace #0.5 Reference: \footer } } \line { \teeny \line { This sheet music has been placed in the public domain by the typesetter, for details see: \hspace #-0.5 \with-url #"http://creativecommons.org/licenses/publicdomain" http://creativecommons.org/licenses/publicdomain } } } }
 }
 
-blanknotes = { \override NoteHead
-                 #'transparent  = ##t
-               \override Stem
-                 #'transparent = ##t }
-unblanknotes = { \revert NoteHead
- #'transparent
-                 \revert Stem
- #'transparent }
+blanknotes = {
+  \override NoteHead.transparent  = ##t
+  \override Stem.transparent = ##t
+}
+unblanknotes = {
+  \revert NoteHead.transparent
+  \revert Stem.transparent
+}
 
 top =  \relative c' {
- \override TextScript   #'padding = #2
+  \override TextScript.padding = #2
 
- \key c \major
- \time 2/4
- \clef treble
- 
- \stemUp
+  \key c \major
+  \time 2/4
+  \clef treble
+
+  \stemUp
   d''16^\markup {\large "Not fast"} e c a ~ a b g8 |				%1
- \stemNeutral
- d16 e c a ~ a b g8 |
- \stemUp
+  \stemNeutral
+  d16 e c a ~ a b g8 |
+  \stemUp
   d16 e c
   \change Staff = "down"
-   a ~ a b a as |
-   g8
-   \once \override Rest #'direction = #UP
-   r
+  a ~ a b a as |
+  g8
+  \once \override Rest.direction = #UP
+  r
   \change Staff = "up"
- \stemNeutral
- <g'' d b g>^^ d,16-(-\> dis-)-\! |
- 
- \repeat volta 2 {
-  e16-\p c'8 e,16 c'8 e,16 c' ~ |						%5
-  c4 ~ c16-\< <c' e, c> <d f, d> <dis fis, dis>-\! |
-  <e g, e>-\f <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 |
-  <c e, c>4 ~ <c e, c>8-\> d,,16-( dis-)-\! |
-  e16-\p c'8 e,16 c'8 e,16 c' ~ |						%9
-  c4 ~ c8-\< <a' c, a>16 <g c, g>-\! |
-  <fis c fis,>16-\f <a a,> <c c,> <e e,> ~ <e e,> <d d,> <c c,> <a a,> |
-  <d f,! d>4 ~ <d f, d>8-\> d,,16-(-[ dis-)-]-\! |
-  e16-\p c'8 e,16 c'8 e,16 c' ~ |						%13
-  c4 ~ c16-\< <c' e, c> <d f, d> <dis fis, dis>-\! |
-  <e g, e>-\f <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 |
-  <c e, c>4 ~ <c e, c>8 <c c,>16 <d d,> |
-  <e e,> <c c,> <d d,> <e e,> ~ <e e,> <c c,> <d d,> <c c,> |			%17
-  <e e,> <c c,> <d d,> <e e,> ~ <e e,> <c c,> <d d,> <c c,> |
-  <e g, e> <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 |
- } \alternative {
-  {
-   <c e, c>4 ~ <c e, c>8-\> d,,16-( dis-)-\!
-  }
-  { <c'' e, c>4 ~ <c e, c>16 <e, c e,> <f d f,> <fis dis fis,> }		%21
- }
- 
- \break
- 
- \repeat volta 2 {
-  <g e g,>8^\markup {\italic "Repeat 8va"}-\f <a e a,>16 <g e g,> ~ <g e g,> <e c e,> <f d f,> <fis dis fis,> |
-  <g e g,>8 <a e a,>16 <g e g,> ~ <g e g,> e c g |
-  a b c d e d c d |
-  g, e' f g a g e f |								%25
-  <g e g,>8 <a e a,>16 <g e g,> ~ <g e g,> <e c e,> <f d f,> <fis dis fis,> |
-  <g e g,>8 <a e a,>16 <g e g,> ~ <g e g,> g a ais |
-  <b g d> <b g d>8 <b fis c>16 ~ <b fis c> a <fis c> d |
-  <g b,>4 ~ <g b,>16 <e c e,> <f d f,> <fis dis fis,> |				%29
-  <g e g,>8-\p <a e a,>16 <g e g,> ~ <g e g,> <e c e,> <f d f,> <fis dis fis,> |
-  <g e g,>8 <a e a,>16 <g e g,> ~ <g e g,> e c g |
-  a b c d e d c d |
-  c4 ~ c16-\> g fis g-\! |							%33
-  c8-\p a16 c ~ c a c a |
-  g-\< c e g ~ g e c-\! g |
-  <a fis>8 <c fis,> <e f,>16 <d f,>8 <c e,>16 ~ |
- } \alternative {
-  { <c e,>4 ~ <c e,>16 #(set-octavation 1) <e' c e,> <f d f,> <fis dis fis,> #(set-octavation 0) } %37
-  { <c, e,>4 ~ <c e,>8-\> d,16 dis-\! }
- }
- 
- \bar "||"
- 
- e16-\p c'8 e,16 c'8 e,16 c' ~ |
- c4 ~ c16-\< <c' e, c> <d f, d> <dis fis, dis>-\! |
- <e g, e>-\f <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 |		%41
- <c e, c>4 ~ <c e, c>8-\> d,,16-( dis-)-\! |
- e16-\p c'8 e,16 c'8 e,16 c' ~ |
- c4 ~ c8-\< <a' c, a>16 <g c, g>-\! |
- <fis c fis,>16-\f <a a,> <c c,> <e e,> ~ <e e,> <d d,> <c c,> <a a,> |		%45
- <d f,! d>4 ~ <d f, d>8-\> d,,16-(-[ dis-)-]-\! |
- e16-\p c'8 e,16 c'8 e,16 c' ~ |
- c4 ~ c16-\< <c' e, c> <d f, d> <dis fis, dis>-\! |
- <e g, e>-\f <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 |		%49
- <c e, c>4 ~ <c e, c>8 <c c,>16 <d d,> |
- <e e,> <c c,> <d d,> <e e,> ~ <e e,> <c c,> <d d,> <c c,> |
- <e e,> <c c,> <d d,> <e e,> ~ <e e,> <c c,> <d d,> <c c,> |
- <e g, e> <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 |		%53
- <c e, c>4 <c e, c>8 r |
- 
- \key f \major
- 
- \repeat volta 2 {
-  <a f>16-\f gis <a f>8 ~ <a f> <c a f> |
-  << { <d bes f>2 } \\ { r8 bes,16 a bes c d8 } >> |
-  <f d>16 e <f d>8 ~ <f d> <a f d> |						%57
-  << { <bes g d>4 ~ <bes g d>8. g16 } \\ { r8 g,16 fis g a bes8 } >> |
-  d8 g16 d ~ d g d8 |
-  c4 f |
-  e16 gis b e ~ e d b! c |							%61
-  a4 bes! |
-  <a f>16 gis <a f>8 ~ <a f> <c a f> |
-  << { <d bes f>2 } \\ { r8 bes,16 a bes c d8 } >> |
-  <f d>16 e <f d>8 ~ <f d> <a f d> |						%65
-  << { <bes g d>4 ~ <bes g d>8. g16 } \\ { r8 g,16 fis g a bes8 } >> |
-  d8 g16 d ~ d g d8 |
-  c4-\< <f b, gis>8.-\fz-\!-\> f16-\! |
-  << { \stemDown <a c, a>16-\f <c c,>8 <g bes,>16 ~ \stemUp g c, d e }
-  \\ { s8. \blanknotes bes4*1/4 ~ \unblanknotes bes8 bes } >> |			%69 - slight kludge
- } \alternative {
-  { <f' a,>8 b,16-( c d e f g-) }
-  { <f a,>8 r <f' c a f> r }
- }
- 
- \key c \major
- \bar "||"
- 
- \break
- 
- c,8 a16 c ~ c a c a |
- g c e g ~ g e c g |								%73
- <a fis>8 <c fis,> <e f,>16 <d f,>8 <c e,>16 ~ |
- <c e,>4 <c' g e c>8 r |
+  \stemNeutral
+  <g'' d b g>^^ d,16-(-\> dis-)-\! |
 
- \repeat volta 2 {
-  <f,, d> <e cis>16 <f d> ~ <f d> <e cis> <f d>8 |
-  r16 a <d f,> a c d c a |							%77
-  <g e>8 <fis dis>16 <g e> ~ <g e> <fis dis> <g e>8 |
-  r16 c <e g,> c d e d c |
-  <d b>8 <cis ais>16 <d b> ~ <d b> <cis ais> <d b>8 |
-  r16 f <a b,> f g a g f |							%81
-  <c' c,> <c c,> <c c,>4 <a c,>8 |
-  <g c,> <g, e>16 <g e> <g e>8 <g e> |
-  <f d> <e cis>16 <f d> ~ <f d> <e cis> <f d>8 |
-  r16 a <d f,> a c d c a |							%85
-  <g e>8 <fis dis>16 <g e> ~ <g e> <fis dis> <g e>8 |
-  r16 c <e g,> c d e d c |
-  a gis a <g' a,> ~ <g a,> <f a,>8 <c a>16 |
-  <e g,> dis e a ~ a c g e |							%89
-  <c fis,>8 <c fis,> <e b f>16 <d b f>8 <c g e>16 ~ |
- } \alternative {
-  { <c g e>8 <g e>16 <g e> <g e>8 <g e> }
-  { <c g e>4 <c' g e c>8 r }
- }
- \bar "|."
+  \repeat volta 2 {
+    e16-\p c'8 e,16 c'8 e,16 c' ~ |						%5
+    c4 ~ c16-\< <c' e, c> <d f, d> <dis fis, dis>-\! |
+    <e g, e>-\f <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 |
+    <c e, c>4 ~ <c e, c>8-\> d,,16-( dis-)-\! |
+    e16-\p c'8 e,16 c'8 e,16 c' ~ |						%9
+    c4 ~ c8-\< <a' c, a>16 <g c, g>-\! |
+    <fis c fis,>16-\f <a a,> <c c,> <e e,> ~ <e e,> <d d,> <c c,> <a a,> |
+    <d f,! d>4 ~ <d f, d>8-\> d,,16-(-[ dis-)-]-\! |
+    e16-\p c'8 e,16 c'8 e,16 c' ~ |						%13
+    c4 ~ c16-\< <c' e, c> <d f, d> <dis fis, dis>-\! |
+    <e g, e>-\f <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 |
+    <c e, c>4 ~ <c e, c>8 <c c,>16 <d d,> |
+    <e e,> <c c,> <d d,> <e e,> ~ <e e,> <c c,> <d d,> <c c,> |			%17
+    <e e,> <c c,> <d d,> <e e,> ~ <e e,> <c c,> <d d,> <c c,> |
+    <e g, e> <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 |
+  } \alternative {
+    {
+      <c e, c>4 ~ <c e, c>8-\> d,,16-( dis-)-\!
+    }
+    { <c'' e, c>4 ~ <c e, c>16 <e, c e,> <f d f,> <fis dis fis,> }		%21
+  }
+
+  \break
+
+  \repeat volta 2 {
+    <g e g,>8^\markup {\italic "Repeat 8va"}-\f <a e a,>16 <g e g,> ~ <g e g,> <e c e,> <f d f,> <fis dis fis,> |
+    <g e g,>8 <a e a,>16 <g e g,> ~ <g e g,> e c g |
+    a b c d e d c d |
+    g, e' f g a g e f |								%25
+    <g e g,>8 <a e a,>16 <g e g,> ~ <g e g,> <e c e,> <f d f,> <fis dis fis,> |
+    <g e g,>8 <a e a,>16 <g e g,> ~ <g e g,> g a ais |
+    <b g d> <b g d>8 <b fis c>16 ~ <b fis c> a <fis c> d |
+    <g b,>4 ~ <g b,>16 <e c e,> <f d f,> <fis dis fis,> |				%29
+    <g e g,>8-\p <a e a,>16 <g e g,> ~ <g e g,> <e c e,> <f d f,> <fis dis fis,> |
+    <g e g,>8 <a e a,>16 <g e g,> ~ <g e g,> e c g |
+    a b c d e d c d |
+    c4 ~ c16-\> g fis g-\! |							%33
+    c8-\p a16 c ~ c a c a |
+    g-\< c e g ~ g e c-\! g |
+    <a fis>8 <c fis,> <e f,>16 <d f,>8 <c e,>16 ~ |
+  } \alternative {
+    { <c e,>4 ~ <c e,>16 \ottava #1 <e' c e,> <f d f,> <fis dis fis,> \ottava #0 } %37
+    { <c, e,>4 ~ <c e,>8-\> d,16 dis-\! }
+  }
+
+  \bar "||"
+
+  e16-\p c'8 e,16 c'8 e,16 c' ~ |
+  c4 ~ c16-\< <c' e, c> <d f, d> <dis fis, dis>-\! |
+  <e g, e>-\f <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 |		%41
+  <c e, c>4 ~ <c e, c>8-\> d,,16-( dis-)-\! |
+  e16-\p c'8 e,16 c'8 e,16 c' ~ |
+  c4 ~ c8-\< <a' c, a>16 <g c, g>-\! |
+  <fis c fis,>16-\f <a a,> <c c,> <e e,> ~ <e e,> <d d,> <c c,> <a a,> |		%45
+  <d f,! d>4 ~ <d f, d>8-\> d,,16-(-[ dis-)-]-\! |
+  e16-\p c'8 e,16 c'8 e,16 c' ~ |
+  c4 ~ c16-\< <c' e, c> <d f, d> <dis fis, dis>-\! |
+  <e g, e>-\f <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 |		%49
+  <c e, c>4 ~ <c e, c>8 <c c,>16 <d d,> |
+  <e e,> <c c,> <d d,> <e e,> ~ <e e,> <c c,> <d d,> <c c,> |
+  <e e,> <c c,> <d d,> <e e,> ~ <e e,> <c c,> <d d,> <c c,> |
+  <e g, e> <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 |		%53
+  <c e, c>4 <c e, c>8 r |
+
+  \key f \major
+
+  \repeat volta 2 {
+    <a f>16-\f gis <a f>8 ~ <a f> <c a f> |
+    << { <d bes f>2 } \\ { r8 bes,16 a bes c d8 } >> |
+    <f d>16 e <f d>8 ~ <f d> <a f d> |						%57
+    << { <bes g d>4 ~ <bes g d>8. g16 } \\ { r8 g,16 fis g a bes8 } >> |
+    d8 g16 d ~ d g d8 |
+    c4 f |
+    e16 gis b e ~ e d b! c |							%61
+    a4 bes! |
+    <a f>16 gis <a f>8 ~ <a f> <c a f> |
+    << { <d bes f>2 } \\ { r8 bes,16 a bes c d8 } >> |
+    <f d>16 e <f d>8 ~ <f d> <a f d> |						%65
+    << { <bes g d>4 ~ <bes g d>8. g16 } \\ { r8 g,16 fis g a bes8 } >> |
+    d8 g16 d ~ d g d8 |
+    c4-\< <f b, gis>8.-\fz-\!-\> f16-\! |
+    <<
+      { \stemDown <a c, a>16-\f <c c,>8 <g bes,>16 ~ \stemUp g c, d e }
+      \\ { s8. \blanknotes bes4*1/4 ~ \unblanknotes bes8 bes }
+    >> |			%69 - slight kludge
+  } \alternative {
+    { <f' a,>8 b,16-( c d e f g-) }
+    { <f a,>8 r <f' c a f> r }
+  }
+
+  \key c \major
+  \bar "||"
+
+  \break
+
+  c,8 a16 c ~ c a c a |
+  g c e g ~ g e c g |								%73
+  <a fis>8 <c fis,> <e f,>16 <d f,>8 <c e,>16 ~ |
+  <c e,>4 <c' g e c>8 r |
+
+  \repeat volta 2 {
+    <f,, d> <e cis>16 <f d> ~ <f d> <e cis> <f d>8 |
+    r16 a <d f,> a c d c a |							%77
+    <g e>8 <fis dis>16 <g e> ~ <g e> <fis dis> <g e>8 |
+    r16 c <e g,> c d e d c |
+    <d b>8 <cis ais>16 <d b> ~ <d b> <cis ais> <d b>8 |
+    r16 f <a b,> f g a g f |							%81
+    <c' c,> <c c,> <c c,>4 <a c,>8 |
+    <g c,> <g, e>16 <g e> <g e>8 <g e> |
+    <f d> <e cis>16 <f d> ~ <f d> <e cis> <f d>8 |
+    r16 a <d f,> a c d c a |							%85
+    <g e>8 <fis dis>16 <g e> ~ <g e> <fis dis> <g e>8 |
+    r16 c <e g,> c d e d c |
+    a gis a <g' a,> ~ <g a,> <f a,>8 <c a>16 |
+    <e g,> dis e a ~ a c g e |							%89
+    <c fis,>8 <c fis,> <e b f>16 <d b f>8 <c g e>16 ~ |
+  } \alternative {
+    { <c g e>8 <g e>16 <g e> <g e>8 <g e> }
+    { <c g e>4 <c' g e c>8 r }
+  }
+  \bar "|."
 }
 
 bottom =  \relative c {
- \key c \major
- \time 2/4
- \clef bass
- \change Staff = "up"
+  \key c \major
+  \time 2/4
+  \clef bass
+  \change Staff = "up"
   \stemDown
-   d''16 \f e c a ~ a b g8 |			%1
+  d''16 \f e c a ~ a b g8 |			%1
   \stemNeutral
- \change Staff = "down"
- d16 e c a ~ a b g8 |
- \stemDown
+  \change Staff = "down"
+  d16 e c a ~ a b g8 |
+  \stemDown
   d16 e c a ~ a b a as |
   g8
-  \once \override Rest #'direction = #DOWN
+  \once \override Rest.direction = #DOWN
   r
- \stemUp <g g,>^^ <b' g>
+  \stemUp <g g,>^^ <b' g>
 
- \stemNeutral
- \repeat volta 2 {
-  c, <c' g e> <g g,> <c bes g> |		%5
-  <f, f,> <c' a> <e, e,> <c' g> |
-  g, <c' g e> g, <b' g f> |
-  c, <c' g e> <c g e> <b g> |
-  c, <c' g e> <g g,> <c bes g> |		%9
-  <f, f,> <c' a> <e, e,> <es es,> |
-  <d d,> <c' a fis d> d, <c' a fis> |
-  <b g> <g g,> <a a,> <b b,> |
-  c, <c' g e> <g g,> <c bes g> |		%13
-  <f, f,> <c' a> <e, e,> <c' g> |
-  g, <c' g e> g, <b' g f> |
-  c, <c' g e> <e c g> r |
-  <c c,> <e c g> <bes bes,> <e c g> |		%17
-  <a, a,> <f' c a> <as, as,> <f' c as> |
-  <g, g,> <e' c g> g,, <b' g> |
- } \alternative {
-  { <c g c,> <g g,> <a a,> <b b,> }
-  { <c g c,> <g g,> <c, c,> r }			%21
- }
- 
- \repeat volta 2 {
-  <c c,> <e' c g> g,, <e'' c g> |
-  c, <e' c g> g,, <e'' c g> |
-  f,, <f'' c a> f, <f' c as> |
-  e, <e' c g> g,, <e'' c g> |			%25
-  c, <e' c g> g,, <e'' c g> |
-  c, <e' c g> e, es |
-  d <d' b g> d, <d' c a> |
-  <d b g> <f,! f,!>^^ <e e,>^^ <d d,>^^ |	%29
-  <c c,>^^ <e' c g> g,, <e'' c g> |
-  c, <e' c g> g,, <e'' c g> |
-  f,, <f'' c a> f, <f' c as> |
-  e, <e' c g> c, <e' c bes> |			%33
-  <f c a f> <f c a f> <dis c a fis> <dis c a fis> |
-  <e c g> <e c g> <e c g> <e c g> |
-  <c d,> <a d,> <b g> <b g> |
- } \alternative {
-  { <c c,> <g g,>^^ <e e,>^^ <d d,>^^ }		%37
-  { <c' c,> <g g,> <c, c,> r }
- }
-
- \bar "||"
- 
- c <c' g e> <g g,> <c bes g> |
- <f, f,> <c' a> <e, e,> <c' g> |
- g, <c' g e> g, <b' g f> |			%41
- c, <c' g e> <c g e> <b g> |
- c, <c' g e> <g g,> <c bes g> |
- <f, f,> <c' a> <e, e,> <es es,> |
- <d d,> <c' a fis d> d, <c' a fis> |		%45
- <b g> <g g,> <a a,> <b b,> |
- c, <c' g e> <g g,> <c bes g> |
- <f, f,> <c' a> <e, e,> <c' g> |
- g, <c' g e> g, <b' g f> |			%49
- c, <c' g e> <e c g> r |
- <c c,> <e c g> <bes bes,> <e c g> |
- <a, a,> <f' c a> <as, as,> <f' c as> |
- <g, g,> <e' c g> g,, <b' g> |			%53
- <c g c,> <g g,> <c, c,> r |
- 
- \key f \major
- 
- \repeat volta 2 {
-  f, <f'' c a> c, <f' c a> |
-  bes,, <f'' d bes> f, <f' d bes> |
-  d,, <f'' d a> a,, <f'' d a> |			%57
-  g,, <d'' bes> d, <d' bes> |
-  <bes bes,> <d bes> <g, g,> <gis gis,> |
-  <a a,> <f' c a> d, <f' d a> |
-  e, <e' d b> gis, <e' d b> |			%61
-  <e c a>4 << { <e c g!> } \\ { g,8 c, } >> |
-  f,8 <f'' c a> c, <f' c a> |
-  bes,, <f'' d bes> f, <f' d bes> |
-  d,, <f'' d a> a,, <f'' d a> |			%65
-  g,, <d'' bes> d, <d' bes> |
-  <bes bes,> <d bes> <g, g,> <gis gis,> |
-  <a a,>16 <f f,> <e e,> <d d,> <des des,>4 |
-  <c c,>8 <f' c a> <c c,> <c, c,> |		%69
- } \alternative {
-  { <f f,> r r4 }
-  { <f f,>8 r <f, f,> r }
- }
- 
- \key c \major
- \bar "||"
- 
- <f'' c a f> <f c a f> <dis c a fis> <dis c a fis> |
- <e c g> <e c g> <e c g> <e c g> |		%73
- <c d,> <a d,> <b g> <b g> |
- <c c,>4 <c, c,>8 r |
- 
- \repeat volta 2 {
-  f, <a' f> a, <a' f> |
-  f, <a' f> a, <a' f> |				%77
-  c, <c' g e> g, <c' g e> |
-  c, <c' g e> g, <c' g e> |
-  g, <b' g f> b, <b' g f> |
-  g, <b' g f> d, <b' g f> |			%81
-  <c fis, dis> <c fis, dis>4 <c fis, dis>8 |
-  <c g e> r r4 |
-  f,,8 <a' f> a, <a' f> |
-  f, <a' f> a, <a' f> |				%85
-  c, <c' g e> g, <c' g e> |
-  c, <c' g e> g, <c' g e> |
-  <f, f,> <d d,> <e e,> <f f,> |
-  <g g,> <e' c g> <dis c fis,> <e c g> |	%89
-  <a, a,> <d, d,> <g g,> <b b,> |
- } \alternative {
-  { <c c,> r r4 }
-  { <c c,>8 <g g,> <c, c,> r }
- }
- \bar "|."
-}
-
-\score {
-  \context PianoStaff <<
-  \context Staff = "up"
-   \top
-  \context Staff = "down"
-   \bottom
- >>
-
-\layout {}
-}
-
-\score {
-  \context PianoStaff <<
-  \context Staff = "up"
-   \applyMusic #unfold-repeats \top 
-  \context Staff = "down"
-   \applyMusic #unfold-repeats \bottom
- >>
- 
- \midi {
-  tempoWholesPerMinute = #(ly:make-moment 72 4)
-  \context {
-   \Voice
-   \remove Dynamic_performer
+  \stemNeutral
+  \repeat volta 2 {
+    c, <c' g e> <g g,> <c bes g> |		%5
+    <f, f,> <c' a> <e, e,> <c' g> |
+    g, <c' g e> g, <b' g f> |
+    c, <c' g e> <c g e> <b g> |
+    c, <c' g e> <g g,> <c bes g> |		%9
+    <f, f,> <c' a> <e, e,> <es es,> |
+    <d d,> <c' a fis d> d, <c' a fis> |
+    <b g> <g g,> <a a,> <b b,> |
+    c, <c' g e> <g g,> <c bes g> |		%13
+    <f, f,> <c' a> <e, e,> <c' g> |
+    g, <c' g e> g, <b' g f> |
+    c, <c' g e> <e c g> r |
+    <c c,> <e c g> <bes bes,> <e c g> |		%17
+    <a, a,> <f' c a> <as, as,> <f' c as> |
+    <g, g,> <e' c g> g,, <b' g> |
+  } \alternative {
+    { <c g c,> <g g,> <a a,> <b b,> }
+    { <c g c,> <g g,> <c, c,> r }			%21
   }
- }
+
+  \repeat volta 2 {
+    <c c,> <e' c g> g,, <e'' c g> |
+    c, <e' c g> g,, <e'' c g> |
+    f,, <f'' c a> f, <f' c as> |
+    e, <e' c g> g,, <e'' c g> |			%25
+    c, <e' c g> g,, <e'' c g> |
+    c, <e' c g> e, es |
+    d <d' b g> d, <d' c a> |
+    <d b g> <f,! f,!>^^ <e e,>^^ <d d,>^^ |	%29
+    <c c,>^^ <e' c g> g,, <e'' c g> |
+    c, <e' c g> g,, <e'' c g> |
+    f,, <f'' c a> f, <f' c as> |
+    e, <e' c g> c, <e' c bes> |			%33
+    <f c a f> <f c a f> <dis c a fis> <dis c a fis> |
+    <e c g> <e c g> <e c g> <e c g> |
+    <c d,> <a d,> <b g> <b g> |
+  } \alternative {
+    { <c c,> <g g,>^^ <e e,>^^ <d d,>^^ }		%37
+    { <c' c,> <g g,> <c, c,> r }
+  }
+
+  \bar "||"
+
+  c <c' g e> <g g,> <c bes g> |
+  <f, f,> <c' a> <e, e,> <c' g> |
+  g, <c' g e> g, <b' g f> |			%41
+  c, <c' g e> <c g e> <b g> |
+  c, <c' g e> <g g,> <c bes g> |
+  <f, f,> <c' a> <e, e,> <es es,> |
+  <d d,> <c' a fis d> d, <c' a fis> |		%45
+  <b g> <g g,> <a a,> <b b,> |
+  c, <c' g e> <g g,> <c bes g> |
+  <f, f,> <c' a> <e, e,> <c' g> |
+  g, <c' g e> g, <b' g f> |			%49
+  c, <c' g e> <e c g> r |
+  <c c,> <e c g> <bes bes,> <e c g> |
+  <a, a,> <f' c a> <as, as,> <f' c as> |
+  <g, g,> <e' c g> g,, <b' g> |			%53
+  <c g c,> <g g,> <c, c,> r |
+
+  \key f \major
+
+  \repeat volta 2 {
+    f, <f'' c a> c, <f' c a> |
+    bes,, <f'' d bes> f, <f' d bes> |
+    d,, <f'' d a> a,, <f'' d a> |			%57
+    g,, <d'' bes> d, <d' bes> |
+    <bes bes,> <d bes> <g, g,> <gis gis,> |
+    <a a,> <f' c a> d, <f' d a> |
+    e, <e' d b> gis, <e' d b> |			%61
+    <e c a>4 << { <e c g!> } \\ { g,8 c, } >> |
+    f,8 <f'' c a> c, <f' c a> |
+    bes,, <f'' d bes> f, <f' d bes> |
+    d,, <f'' d a> a,, <f'' d a> |			%65
+    g,, <d'' bes> d, <d' bes> |
+    <bes bes,> <d bes> <g, g,> <gis gis,> |
+    <a a,>16 <f f,> <e e,> <d d,> <des des,>4 |
+    <c c,>8 <f' c a> <c c,> <c, c,> |		%69
+  } \alternative {
+    { <f f,> r r4 }
+    { <f f,>8 r <f, f,> r }
+  }
+
+  \key c \major
+  \bar "||"
+
+  <f'' c a f> <f c a f> <dis c a fis> <dis c a fis> |
+  <e c g> <e c g> <e c g> <e c g> |		%73
+  <c d,> <a d,> <b g> <b g> |
+  <c c,>4 <c, c,>8 r |
+
+  \repeat volta 2 {
+    f, <a' f> a, <a' f> |
+    f, <a' f> a, <a' f> |				%77
+    c, <c' g e> g, <c' g e> |
+    c, <c' g e> g, <c' g e> |
+    g, <b' g f> b, <b' g f> |
+    g, <b' g f> d, <b' g f> |			%81
+    <c fis, dis> <c fis, dis>4 <c fis, dis>8 |
+    <c g e> r r4 |
+    f,,8 <a' f> a, <a' f> |
+    f, <a' f> a, <a' f> |				%85
+    c, <c' g e> g, <c' g e> |
+    c, <c' g e> g, <c' g e> |
+    <f, f,> <d d,> <e e,> <f f,> |
+    <g g,> <e' c g> <dis c fis,> <e c g> |	%89
+    <a, a,> <d, d,> <g g,> <b b,> |
+  } \alternative {
+    { <c c,> r r4 }
+    { <c c,>8 <g g,> <c, c,> r }
+  }
+  \bar "|."
+}
+
+\score {
+  \new PianoStaff <<
+    \new Staff = "up" \top
+    \new Staff = "down" \bottom
+  >>
+
+  \layout {}
+}
+
+\score {
+  \context PianoStaff <<
+    \context Staff = "up"
+    \unfoldRepeats \top
+    \context Staff = "down"
+    \unfoldRepeats \bottom
+  >>
+
+  \midi {
+    tempoWholesPerMinute = #(ly:make-moment 72/4)
+    \context {
+      \Voice
+      \remove Dynamic_performer
+    }
+  }
 }

--- a/ftp/JoplinS/entertainer/entertainer.ly
+++ b/ftp/JoplinS/entertainer/entertainer.ly
@@ -214,7 +214,7 @@ bottom = \relative c {
     <e c g> <e c g> <e c g> <e c g> |
     <c d,> <a d,> <b g> <b g> |
   } \alternative {
-    { <c c,> <g g,>^^ <e e,>^^ <d d,>^^ } %37
+    { <c c,> <g g,>-^ <e e,>-^ <d d,>-^ } %37
     { <c' c,> <g g,> <c, c,> r }
   }
 

--- a/ftp/JoplinS/entertainer/entertainer.ly
+++ b/ftp/JoplinS/entertainer/entertainer.ly
@@ -16,6 +16,7 @@
   maintainer = "Chris Sawer"
   maintainerEmail = "chris@mutopiaproject.org"
   maintainerWeb = "http://www.whitewillow.co.uk/"
+  %% completely overhauled by Simon Albrecht on 2015/12/27
 
   footer = "Mutopia-2008/12/21-263"
   tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-column { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \line { \teeny www. \hspace #-1.0 MutopiaProject \hspace #-1.0 \teeny .org \hspace #0.5 } • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \line { \teeny www. \hspace #-1.0 LilyPond \hspace #-1.0 \teeny .org } by \maintainer \hspace #-1.0 . \hspace #0.5 Reference: \footer } } \line { \teeny \line { This sheet music has been placed in the public domain by the typesetter, for details see: \hspace #-0.5 \with-url #"http://creativecommons.org/licenses/publicdomain" http://creativecommons.org/licenses/publicdomain } } } }

--- a/ftp/JoplinS/entertainer/entertainer.ly
+++ b/ftp/JoplinS/entertainer/entertainer.ly
@@ -86,7 +86,7 @@ top = \relative c' {
     <a fis>8 <c fis,> <e f,>16 <d f,>8 <c e,>16 ~ |
   } \alternative {
     { <c e,>4 ~ <c e,>16 \ottava #1 <e' c e,> <f d f,> <fis dis fis,> \ottava #0 } %37
-    { <c, e,>4 ~ <c e,>8\> d,16 dis\! }
+    { <c, e,>4\repeatTie ~ <c e,>8\> d,16 dis\! }
   }
 
   \bar "||"

--- a/ftp/JoplinS/entertainer/entertainer.ly
+++ b/ftp/JoplinS/entertainer/entertainer.ly
@@ -29,8 +29,6 @@ global = {
 }
 
 top = \relative c' {
-  \override TextScript.padding = #2
-
   \global
   \clef treble
 

--- a/ftp/JoplinS/entertainer/entertainer.ly
+++ b/ftp/JoplinS/entertainer/entertainer.ly
@@ -409,7 +409,12 @@ dyn = {
     \new Staff = "down" \bottom
   >>
 
-  \layout {}
+  \layout {
+    \context {
+      \Voice
+      \override Tie.minimum-length = 3
+    }
+  }
 }
 
 \score {

--- a/ftp/JoplinS/entertainer/entertainer.ly
+++ b/ftp/JoplinS/entertainer/entertainer.ly
@@ -13,9 +13,8 @@
   copyright = "Public Domain"
   source = "Reproduction of original edition (1902)"
 
-  maintainer = "Chris Sawer"
-  maintainerEmail = "chris@mutopiaproject.org"
-  maintainerWeb = "http://www.whitewillow.co.uk/"
+  maintainer = "Simon Albrecht"
+  maintainerEmail = "sincero@my.mail.de"
 
   footer = "Mutopia-2008/12/21-263"
   tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-column { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \line { \teeny www. \hspace #-1.0 MutopiaProject \hspace #-1.0 \teeny .org \hspace #0.5 } • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \line { \teeny www. \hspace #-1.0 LilyPond \hspace #-1.0 \teeny .org } by \maintainer \hspace #-1.0 . \hspace #0.5 Reference: \footer } } \line { \teeny \line { This sheet music has been placed in the public domain by the typesetter, for details see: \hspace #-0.5 \with-url #"http://creativecommons.org/licenses/publicdomain" http://creativecommons.org/licenses/publicdomain } } } }

--- a/ftp/JoplinS/entertainer/entertainer.ly
+++ b/ftp/JoplinS/entertainer/entertainer.ly
@@ -23,7 +23,7 @@
 }
 
 blanknotes = {
-  \override NoteHead.transparent  = ##t
+  \override NoteHead.transparent = ##t
   \override Stem.transparent = ##t
 }
 unblanknotes = {
@@ -31,7 +31,7 @@ unblanknotes = {
   \revert Stem.transparent
 }
 
-top =  \relative c' {
+top = \relative c' {
   \override TextScript.padding = #2
 
   \key c \major
@@ -39,7 +39,7 @@ top =  \relative c' {
   \clef treble
 
   \stemUp
-  d''16^\markup {\large "Not fast"} e c a ~ a b g8 |				%1
+  d''16^\markup {\large "Not fast"} e c a ~ a b g8 | %1
   \stemNeutral
   d16 e c a ~ a b g8 |
   \stemUp
@@ -51,96 +51,96 @@ top =  \relative c' {
   r
   \change Staff = "up"
   \stemNeutral
-  <g'' d b g>^^ d,16-(-\> dis-)-\! |
+  <g'' d b g>^^ d,16(\> dis)\! |
 
   \repeat volta 2 {
-    e16-\p c'8 e,16 c'8 e,16 c' ~ |						%5
-    c4 ~ c16-\< <c' e, c> <d f, d> <dis fis, dis>-\! |
-    <e g, e>-\f <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 |
-    <c e, c>4 ~ <c e, c>8-\> d,,16-( dis-)-\! |
-    e16-\p c'8 e,16 c'8 e,16 c' ~ |						%9
-    c4 ~ c8-\< <a' c, a>16 <g c, g>-\! |
-    <fis c fis,>16-\f <a a,> <c c,> <e e,> ~ <e e,> <d d,> <c c,> <a a,> |
-    <d f,! d>4 ~ <d f, d>8-\> d,,16-(-[ dis-)-]-\! |
-    e16-\p c'8 e,16 c'8 e,16 c' ~ |						%13
-    c4 ~ c16-\< <c' e, c> <d f, d> <dis fis, dis>-\! |
-    <e g, e>-\f <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 |
+    e16\p c'8 e,16 c'8 e,16 c' ~ | %5
+    c4 ~ c16\< <c' e, c> <d f, d> <dis fis, dis>\! |
+    <e g, e>\f <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 |
+    <c e, c>4 ~ <c e, c>8\> d,,16( dis)\! |
+    e16\p c'8 e,16 c'8 e,16 c' ~ | %9
+    c4 ~ c8\< <a' c, a>16 <g c, g>\! |
+    <fis c fis,>16\f <a a,> <c c,> <e e,> ~ <e e,> <d d,> <c c,> <a a,> |
+    <d f,! d>4 ~ <d f, d>8\> d,,16([ dis)]\! |
+    e16\p c'8 e,16 c'8 e,16 c' ~ | %13
+    c4 ~ c16\< <c' e, c> <d f, d> <dis fis, dis>\! |
+    <e g, e>\f <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 |
     <c e, c>4 ~ <c e, c>8 <c c,>16 <d d,> |
-    <e e,> <c c,> <d d,> <e e,> ~ <e e,> <c c,> <d d,> <c c,> |			%17
+    <e e,> <c c,> <d d,> <e e,> ~ <e e,> <c c,> <d d,> <c c,> |      %17
     <e e,> <c c,> <d d,> <e e,> ~ <e e,> <c c,> <d d,> <c c,> |
     <e g, e> <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 |
   } \alternative {
     {
-      <c e, c>4 ~ <c e, c>8-\> d,,16-( dis-)-\!
+      <c e, c>4 ~ <c e, c>8\> d,,16( dis)\!
     }
-    { <c'' e, c>4 ~ <c e, c>16 <e, c e,> <f d f,> <fis dis fis,> }		%21
+    { <c'' e, c>4 ~ <c e, c>16 <e, c e,> <f d f,> <fis dis fis,> }    %21
   }
 
   \break
 
   \repeat volta 2 {
-    <g e g,>8^\markup {\italic "Repeat 8va"}-\f <a e a,>16 <g e g,> ~ <g e g,> <e c e,> <f d f,> <fis dis fis,> |
+    <g e g,>8^\markup \italic "Repeat 8va" \f <a e a,>16 <g e g,> ~ <g e g,> <e c e,> <f d f,> <fis dis fis,> |
     <g e g,>8 <a e a,>16 <g e g,> ~ <g e g,> e c g |
     a b c d e d c d |
-    g, e' f g a g e f |								%25
+    g, e' f g a g e f | %25
     <g e g,>8 <a e a,>16 <g e g,> ~ <g e g,> <e c e,> <f d f,> <fis dis fis,> |
     <g e g,>8 <a e a,>16 <g e g,> ~ <g e g,> g a ais |
     <b g d> <b g d>8 <b fis c>16 ~ <b fis c> a <fis c> d |
-    <g b,>4 ~ <g b,>16 <e c e,> <f d f,> <fis dis fis,> |				%29
-    <g e g,>8-\p <a e a,>16 <g e g,> ~ <g e g,> <e c e,> <f d f,> <fis dis fis,> |
+    <g b,>4 ~ <g b,>16 <e c e,> <f d f,> <fis dis fis,> | %29
+    <g e g,>8\p <a e a,>16 <g e g,> ~ <g e g,> <e c e,> <f d f,> <fis dis fis,> |
     <g e g,>8 <a e a,>16 <g e g,> ~ <g e g,> e c g |
     a b c d e d c d |
-    c4 ~ c16-\> g fis g-\! |							%33
-    c8-\p a16 c ~ c a c a |
-    g-\< c e g ~ g e c-\! g |
+    c4 ~ c16\> g fis g\! | %33
+    c8\p a16 c ~ c a c a |
+    g\< c e g ~ g e c\! g |
     <a fis>8 <c fis,> <e f,>16 <d f,>8 <c e,>16 ~ |
   } \alternative {
     { <c e,>4 ~ <c e,>16 \ottava #1 <e' c e,> <f d f,> <fis dis fis,> \ottava #0 } %37
-    { <c, e,>4 ~ <c e,>8-\> d,16 dis-\! }
+    { <c, e,>4 ~ <c e,>8\> d,16 dis\! }
   }
 
   \bar "||"
 
-  e16-\p c'8 e,16 c'8 e,16 c' ~ |
-  c4 ~ c16-\< <c' e, c> <d f, d> <dis fis, dis>-\! |
-  <e g, e>-\f <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 |		%41
-  <c e, c>4 ~ <c e, c>8-\> d,,16-( dis-)-\! |
-  e16-\p c'8 e,16 c'8 e,16 c' ~ |
-  c4 ~ c8-\< <a' c, a>16 <g c, g>-\! |
-  <fis c fis,>16-\f <a a,> <c c,> <e e,> ~ <e e,> <d d,> <c c,> <a a,> |		%45
-  <d f,! d>4 ~ <d f, d>8-\> d,,16-(-[ dis-)-]-\! |
-  e16-\p c'8 e,16 c'8 e,16 c' ~ |
-  c4 ~ c16-\< <c' e, c> <d f, d> <dis fis, dis>-\! |
-  <e g, e>-\f <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 |		%49
+  e16\p c'8 e,16 c'8 e,16 c' ~ |
+  c4 ~ c16\< <c' e, c> <d f, d> <dis fis, dis>\! |
+  <e g, e>\f <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 | %41
+  <c e, c>4 ~ <c e, c>8\> d,,16( dis)\! |
+  e16\p c'8 e,16 c'8 e,16 c' ~ |
+  c4 ~ c8\< <a' c, a>16 <g c, g>\! |
+  <fis c fis,>16\f <a a,> <c c,> <e e,> ~ <e e,> <d d,> <c c,> <a a,> | %45
+  <d f,! d>4 ~ <d f, d>8\> d,,16([ dis)]\! |
+  e16\p c'8 e,16 c'8 e,16 c' ~ |
+  c4 ~ c16\< <c' e, c> <d f, d> <dis fis, dis>\! |
+  <e g, e>\f <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 | %49
   <c e, c>4 ~ <c e, c>8 <c c,>16 <d d,> |
   <e e,> <c c,> <d d,> <e e,> ~ <e e,> <c c,> <d d,> <c c,> |
   <e e,> <c c,> <d d,> <e e,> ~ <e e,> <c c,> <d d,> <c c,> |
-  <e g, e> <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 |		%53
+  <e g, e> <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 | %53
   <c e, c>4 <c e, c>8 r |
 
   \key f \major
 
   \repeat volta 2 {
-    <a f>16-\f gis <a f>8 ~ <a f> <c a f> |
+    <a f>16\f gis <a f>8 ~ <a f> <c a f> |
     << { <d bes f>2 } \\ { r8 bes,16 a bes c d8 } >> |
-    <f d>16 e <f d>8 ~ <f d> <a f d> |						%57
+    <f d>16 e <f d>8 ~ <f d> <a f d> | %57
     << { <bes g d>4 ~ <bes g d>8. g16 } \\ { r8 g,16 fis g a bes8 } >> |
     d8 g16 d ~ d g d8 |
     c4 f |
-    e16 gis b e ~ e d b! c |							%61
+    e16 gis b e ~ e d b! c | %61
     a4 bes! |
     <a f>16 gis <a f>8 ~ <a f> <c a f> |
     << { <d bes f>2 } \\ { r8 bes,16 a bes c d8 } >> |
-    <f d>16 e <f d>8 ~ <f d> <a f d> |						%65
+    <f d>16 e <f d>8 ~ <f d> <a f d> | %65
     << { <bes g d>4 ~ <bes g d>8. g16 } \\ { r8 g,16 fis g a bes8 } >> |
     d8 g16 d ~ d g d8 |
-    c4-\< <f b, gis>8.-\fz-\!-\> f16-\! |
+    c4\< <f b, gis>8.\fz\!\> f16\! |
     <<
-      { \stemDown <a c, a>16-\f <c c,>8 <g bes,>16 ~ \stemUp g c, d e }
+      { \stemDown <a c, a>16\f <c c,>8 <g bes,>16 ~ \stemUp g c, d e }
       \\ { s8. \blanknotes bes4*1/4 ~ \unblanknotes bes8 bes }
-    >> |			%69 - slight kludge
+    >> | %69 - slight kludge
   } \alternative {
-    { <f' a,>8 b,16-( c d e f g-) }
+    { <f' a,>8 b,16( c d e f g) }
     { <f a,>8 r <f' c a f> r }
   }
 
@@ -150,25 +150,25 @@ top =  \relative c' {
   \break
 
   c,8 a16 c ~ c a c a |
-  g c e g ~ g e c g |								%73
+  g c e g ~ g e c g | %73
   <a fis>8 <c fis,> <e f,>16 <d f,>8 <c e,>16 ~ |
   <c e,>4 <c' g e c>8 r |
 
   \repeat volta 2 {
     <f,, d> <e cis>16 <f d> ~ <f d> <e cis> <f d>8 |
-    r16 a <d f,> a c d c a |							%77
+    r16 a <d f,> a c d c a | %77
     <g e>8 <fis dis>16 <g e> ~ <g e> <fis dis> <g e>8 |
     r16 c <e g,> c d e d c |
     <d b>8 <cis ais>16 <d b> ~ <d b> <cis ais> <d b>8 |
-    r16 f <a b,> f g a g f |							%81
+    r16 f <a b,> f g a g f | %81
     <c' c,> <c c,> <c c,>4 <a c,>8 |
     <g c,> <g, e>16 <g e> <g e>8 <g e> |
     <f d> <e cis>16 <f d> ~ <f d> <e cis> <f d>8 |
-    r16 a <d f,> a c d c a |							%85
+    r16 a <d f,> a c d c a | %85
     <g e>8 <fis dis>16 <g e> ~ <g e> <fis dis> <g e>8 |
     r16 c <e g,> c d e d c |
     a gis a <g' a,> ~ <g a,> <f a,>8 <c a>16 |
-    <e g,> dis e a ~ a c g e |							%89
+    <e g,> dis e a ~ a c g e | %89
     <c fis,>8 <c fis,> <e b f>16 <d b f>8 <c g e>16 ~ |
   } \alternative {
     { <c g e>8 <g e>16 <g e> <g e>8 <g e> }
@@ -177,13 +177,13 @@ top =  \relative c' {
   \bar "|."
 }
 
-bottom =  \relative c {
+bottom = \relative c {
   \key c \major
   \time 2/4
   \clef bass
   \change Staff = "up"
   \stemDown
-  d''16 \f e c a ~ a b g8 |			%1
+  d''16 \f e c a ~ a b g8 | %1
   \stemNeutral
   \change Staff = "down"
   d16 e c a ~ a b g8 |
@@ -196,44 +196,44 @@ bottom =  \relative c {
 
   \stemNeutral
   \repeat volta 2 {
-    c, <c' g e> <g g,> <c bes g> |		%5
+    c, <c' g e> <g g,> <c bes g> | %5
     <f, f,> <c' a> <e, e,> <c' g> |
     g, <c' g e> g, <b' g f> |
     c, <c' g e> <c g e> <b g> |
-    c, <c' g e> <g g,> <c bes g> |		%9
+    c, <c' g e> <g g,> <c bes g> | %9
     <f, f,> <c' a> <e, e,> <es es,> |
     <d d,> <c' a fis d> d, <c' a fis> |
     <b g> <g g,> <a a,> <b b,> |
-    c, <c' g e> <g g,> <c bes g> |		%13
+    c, <c' g e> <g g,> <c bes g> | %13
     <f, f,> <c' a> <e, e,> <c' g> |
     g, <c' g e> g, <b' g f> |
     c, <c' g e> <e c g> r |
-    <c c,> <e c g> <bes bes,> <e c g> |		%17
+    <c c,> <e c g> <bes bes,> <e c g> | %17
     <a, a,> <f' c a> <as, as,> <f' c as> |
     <g, g,> <e' c g> g,, <b' g> |
   } \alternative {
     { <c g c,> <g g,> <a a,> <b b,> }
-    { <c g c,> <g g,> <c, c,> r }			%21
+    { <c g c,> <g g,> <c, c,> r } %21
   }
 
   \repeat volta 2 {
     <c c,> <e' c g> g,, <e'' c g> |
     c, <e' c g> g,, <e'' c g> |
     f,, <f'' c a> f, <f' c as> |
-    e, <e' c g> g,, <e'' c g> |			%25
+    e, <e' c g> g,, <e'' c g> | %25
     c, <e' c g> g,, <e'' c g> |
     c, <e' c g> e, es |
     d <d' b g> d, <d' c a> |
-    <d b g> <f,! f,!>^^ <e e,>^^ <d d,>^^ |	%29
+    <d b g> <f,! f,!>^^ <e e,>^^ <d d,>^^ | %29
     <c c,>^^ <e' c g> g,, <e'' c g> |
     c, <e' c g> g,, <e'' c g> |
     f,, <f'' c a> f, <f' c as> |
-    e, <e' c g> c, <e' c bes> |			%33
+    e, <e' c g> c, <e' c bes> | %33
     <f c a f> <f c a f> <dis c a fis> <dis c a fis> |
     <e c g> <e c g> <e c g> <e c g> |
     <c d,> <a d,> <b g> <b g> |
   } \alternative {
-    { <c c,> <g g,>^^ <e e,>^^ <d d,>^^ }		%37
+    { <c c,> <g g,>^^ <e e,>^^ <d d,>^^ } %37
     { <c' c,> <g g,> <c, c,> r }
   }
 
@@ -241,19 +241,19 @@ bottom =  \relative c {
 
   c <c' g e> <g g,> <c bes g> |
   <f, f,> <c' a> <e, e,> <c' g> |
-  g, <c' g e> g, <b' g f> |			%41
+  g, <c' g e> g, <b' g f> | %41
   c, <c' g e> <c g e> <b g> |
   c, <c' g e> <g g,> <c bes g> |
   <f, f,> <c' a> <e, e,> <es es,> |
-  <d d,> <c' a fis d> d, <c' a fis> |		%45
+  <d d,> <c' a fis d> d, <c' a fis> | %45
   <b g> <g g,> <a a,> <b b,> |
   c, <c' g e> <g g,> <c bes g> |
   <f, f,> <c' a> <e, e,> <c' g> |
-  g, <c' g e> g, <b' g f> |			%49
+  g, <c' g e> g, <b' g f> | %49
   c, <c' g e> <e c g> r |
   <c c,> <e c g> <bes bes,> <e c g> |
   <a, a,> <f' c a> <as, as,> <f' c as> |
-  <g, g,> <e' c g> g,, <b' g> |			%53
+  <g, g,> <e' c g> g,, <b' g> | %53
   <c g c,> <g g,> <c, c,> r |
 
   \key f \major
@@ -261,19 +261,19 @@ bottom =  \relative c {
   \repeat volta 2 {
     f, <f'' c a> c, <f' c a> |
     bes,, <f'' d bes> f, <f' d bes> |
-    d,, <f'' d a> a,, <f'' d a> |			%57
+    d,, <f'' d a> a,, <f'' d a> | %57
     g,, <d'' bes> d, <d' bes> |
     <bes bes,> <d bes> <g, g,> <gis gis,> |
     <a a,> <f' c a> d, <f' d a> |
-    e, <e' d b> gis, <e' d b> |			%61
+    e, <e' d b> gis, <e' d b> | %61
     <e c a>4 << { <e c g!> } \\ { g,8 c, } >> |
     f,8 <f'' c a> c, <f' c a> |
     bes,, <f'' d bes> f, <f' d bes> |
-    d,, <f'' d a> a,, <f'' d a> |			%65
+    d,, <f'' d a> a,, <f'' d a> | %65
     g,, <d'' bes> d, <d' bes> |
     <bes bes,> <d bes> <g, g,> <gis gis,> |
     <a a,>16 <f f,> <e e,> <d d,> <des des,>4 |
-    <c c,>8 <f' c a> <c c,> <c, c,> |		%69
+    <c c,>8 <f' c a> <c c,> <c, c,> | %69
   } \alternative {
     { <f f,> r r4 }
     { <f f,>8 r <f, f,> r }
@@ -283,25 +283,25 @@ bottom =  \relative c {
   \bar "||"
 
   <f'' c a f> <f c a f> <dis c a fis> <dis c a fis> |
-  <e c g> <e c g> <e c g> <e c g> |		%73
+  <e c g> <e c g> <e c g> <e c g> | %73
   <c d,> <a d,> <b g> <b g> |
   <c c,>4 <c, c,>8 r |
 
   \repeat volta 2 {
     f, <a' f> a, <a' f> |
-    f, <a' f> a, <a' f> |				%77
+    f, <a' f> a, <a' f> | %77
     c, <c' g e> g, <c' g e> |
     c, <c' g e> g, <c' g e> |
     g, <b' g f> b, <b' g f> |
-    g, <b' g f> d, <b' g f> |			%81
+    g, <b' g f> d, <b' g f> | %81
     <c fis, dis> <c fis, dis>4 <c fis, dis>8 |
     <c g e> r r4 |
     f,,8 <a' f> a, <a' f> |
-    f, <a' f> a, <a' f> |				%85
+    f, <a' f> a, <a' f> | %85
     c, <c' g e> g, <c' g e> |
     c, <c' g e> g, <c' g e> |
     <f, f,> <d d,> <e e,> <f f,> |
-    <g g,> <e' c g> <dis c fis,> <e c g> |	%89
+    <g g,> <e' c g> <dis c fis,> <e c g> | %89
     <a, a,> <d, d,> <g g,> <b b,> |
   } \alternative {
     { <c c,> r r4 }
@@ -328,7 +328,7 @@ bottom =  \relative c {
   >>
 
   \midi {
-    tempoWholesPerMinute = #(ly:make-moment 72/4)
+    \tempo 4 = 72
     \context {
       \Voice
       \remove Dynamic_performer

--- a/ftp/JoplinS/entertainer/entertainer.ly
+++ b/ftp/JoplinS/entertainer/entertainer.ly
@@ -40,27 +40,27 @@ top = \relative c' {
   d16 e c a ~ a b g8 |
 
   d16 e c \change Staff = "down" \voiceOne a ~ a b a as |
-  g8 r \change Staff = "up" \oneVoice   <g'' d b g>^^ d,16(\> dis)\! |
+  g8 r \change Staff = "up" \oneVoice   <g'' d b g>^^ d,16( dis) |
 
   \repeat volta 2 {
-    e16\p c'8 e,16 c'8 e,16 c' ~ | %5
-    c4 ~ c16\< <c' e, c> <d f, d> <dis fis, dis>\! |
-    <e g, e>\f <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 |
-    <c e, c>4 ~ <c e, c>8\> d,,16( dis)\! |
-    e16\p c'8 e,16 c'8 e,16 c' ~ | %9
-    c4 ~ c8\< <a' c, a>16 <g c, g>\! |
-    <fis c fis,>16\f <a a,> <c c,> <e e,> ~ <e e,> <d d,> <c c,> <a a,> |
-    <d f,! d>4 ~ <d f, d>8\> d,,16([ dis)]\! |
-    e16\p c'8 e,16 c'8 e,16 c' ~ | %13
-    c4 ~ c16\< <c' e, c> <d f, d> <dis fis, dis>\! |
-    <e g, e>\f <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 |
+    e16 c'8 e,16 c'8 e,16 c' ~ | %5
+    c4 ~ c16 <c' e, c> <d f, d> <dis fis, dis> |
+    <e g, e> <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 |
+    <c e, c>4 ~ <c e, c>8 d,,16( dis) |
+    e16 c'8 e,16 c'8 e,16 c' ~ | %9
+    c4 ~ c8 <a' c, a>16 <g c, g> |
+    <fis c fis,>16 <a a,> <c c,> <e e,> ~ <e e,> <d d,> <c c,> <a a,> |
+    <d f,! d>4 ~ <d f, d>8 d,,16([ dis)] |
+    e16 c'8 e,16 c'8 e,16 c' ~ | %13
+    c4 ~ c16 <c' e, c> <d f, d> <dis fis, dis> |
+    <e g, e> <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 |
     <c e, c>4 ~ <c e, c>8 <c c,>16 <d d,> |
     <e e,> <c c,> <d d,> <e e,> ~ <e e,> <c c,> <d d,> <c c,> |      %17
     <e e,> <c c,> <d d,> <e e,> ~ <e e,> <c c,> <d d,> <c c,> |
     <e g, e> <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 |
   } \alternative {
     {
-      <c e, c>4 ~ <c e, c>8\> d,,16( dis)\!
+      <c e, c>4 ~ <c e, c>8 d,,16( dis)
     }
     { <c'' e, c>4 ~ <c e, c>16 <e, c e,> <f d f,> <fis dis fis,> }    %21
   }
@@ -68,7 +68,7 @@ top = \relative c' {
   \break
 
   \repeat volta 2 {
-    <g e g,>8^\markup \italic "Repeat 8va" \f <a e a,>16 <g e g,> ~ <g e g,> <e c e,> <f d f,> <fis dis fis,> |
+    <g e g,>8^\markup \italic "Repeat 8va"  <a e a,>16 <g e g,> ~ <g e g,> <e c e,> <f d f,> <fis dis fis,> |
     <g e g,>8 <a e a,>16 <g e g,> ~ <g e g,> e c g |
     a b c d e d c d |
     g, e' f g a g e f | %25
@@ -76,31 +76,31 @@ top = \relative c' {
     <g e g,>8 <a e a,>16 <g e g,> ~ <g e g,> g a ais |
     <b g d> <b g d>8 <b fis c>16 ~ <b fis c> a <fis c> d |
     <g b,>4 ~ <g b,>16 <e c e,> <f d f,> <fis dis fis,> | %29
-    <g e g,>8\p <a e a,>16 <g e g,> ~ <g e g,> <e c e,> <f d f,> <fis dis fis,> |
+    <g e g,>8 <a e a,>16 <g e g,> ~ <g e g,> <e c e,> <f d f,> <fis dis fis,> |
     <g e g,>8 <a e a,>16 <g e g,> ~ <g e g,> e c g |
     a b c d e d c d |
-    c4 ~ c16\> g fis g\! | %33
-    c8\p a16 c ~ c a c a |
-    g\< c e g ~ g e c\! g |
+    c4 ~ c16 g fis g | %33
+    c8 a16 c ~ c a c a |
+    g c e g ~ g e c g |
     <a fis>8 <c fis,> <e f,>16 <d f,>8 <c e,>16 ~ |
   } \alternative {
     { <c e,>4 ~ <c e,>16 \ottava #1 <e' c e,> <f d f,> <fis dis fis,> \ottava #0 } %37
-    { <c, e,>4\repeatTie ~ <c e,>8\> d,16 dis\! }
+    { <c, e,>4\repeatTie ~ <c e,>8 d,16 dis }
   }
 
   \bar "||"
 
-  e16\p c'8 e,16 c'8 e,16 c' ~ |
-  c4 ~ c16\< <c' e, c> <d f, d> <dis fis, dis>\! |
-  <e g, e>\f <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 | %41
-  <c e, c>4 ~ <c e, c>8\> d,,16( dis)\! |
-  e16\p c'8 e,16 c'8 e,16 c' ~ |
-  c4 ~ c8\< <a' c, a>16 <g c, g>\! |
-  <fis c fis,>16\f <a a,> <c c,> <e e,> ~ <e e,> <d d,> <c c,> <a a,> | %45
-  <d f,! d>4 ~ <d f, d>8\> d,,16([ dis)]\! |
-  e16\p c'8 e,16 c'8 e,16 c' ~ |
-  c4 ~ c16\< <c' e, c> <d f, d> <dis fis, dis>\! |
-  <e g, e>\f <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 | %49
+  e16 c'8 e,16 c'8 e,16 c' ~ |
+  c4 ~ c16 <c' e, c> <d f, d> <dis fis, dis> |
+  <e g, e> <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 | %41
+  <c e, c>4 ~ <c e, c>8 d,,16( dis) |
+  e16 c'8 e,16 c'8 e,16 c' ~ |
+  c4 ~ c8 <a' c, a>16 <g c, g> |
+  <fis c fis,>16 <a a,> <c c,> <e e,> ~ <e e,> <d d,> <c c,> <a a,> | %45
+  <d f,! d>4 ~ <d f, d>8 d,,16([ dis)] |
+  e16 c'8 e,16 c'8 e,16 c' ~ |
+  c4 ~ c16 <c' e, c> <d f, d> <dis fis, dis> |
+  <e g, e> <c e, c> <d f, d> <e g, e> ~ <e g, e> <b d, b> <d f, d>8 | %49
   <c e, c>4 ~ <c e, c>8 <c c,>16 <d d,> |
   <e e,> <c c,> <d d,> <e e,> ~ <e e,> <c c,> <d d,> <c c,> |
   <e e,> <c c,> <d d,> <e e,> ~ <e e,> <c c,> <d d,> <c c,> |
@@ -110,7 +110,7 @@ top = \relative c' {
   \key f \major
 
   \repeat volta 2 {
-    <a f>16\f gis <a f>8 ~ <a f> <c a f> |
+    <a f>16 gis <a f>8 ~ <a f> <c a f> |
     << { <d bes f>2 } \\ { r8 bes,16 a bes c d8 } >> |
     <f d>16 e <f d>8 ~ <f d> <a f d> | %57
     << { <bes g d>4 ~ <bes g d>8. g16 } \\ { r8 g,16 fis g a bes8 } >> |
@@ -123,9 +123,9 @@ top = \relative c' {
     <f d>16 e <f d>8 ~ <f d> <a f d> | %65
     << { <bes g d>4 ~ <bes g d>8. g16 } \\ { r8 g,16 fis g a bes8 } >> |
     d8 g16 d ~ d g d8 |
-    c4\< <f b, gis>8.\fz\!\> f16\! |
+    c4 <f b, gis>8. f16 |
     <<
-      { \stemDown <a c, a>16\f <c c,>8 <g bes,>16 ~ \stemUp g c, d e }
+      { \stemDown <a c, a>16 <c c,>8 <g bes,>16 ~ \stemUp g c, d e }
       \\ { s8. \hideNotes bes4*1/4 ~ \unHideNotes bes8 bes }
     >> | %69 - slight kludge
   } \alternative {
@@ -170,7 +170,7 @@ bottom = \relative c {
   \global
   \clef bass
   \change Staff = "up" \voiceTwo
-  d''16 \f e c a ~ a b g8 | %1
+  d''16 e c a ~ a b g8 | %1
   \change Staff = "down" \oneVoice
   d16 e c a ~ a b g8 |
   \voiceTwo
@@ -293,9 +293,81 @@ bottom = \relative c {
   \bar "|."
 }
 
+dyn = {
+  s2\f
+  s
+  s
+  s4. s8\>
+
+  \repeat volta 2 {
+    s2\p
+    s4 s\<
+    s2\f
+    s4 s\>
+
+    s2\p
+    s4 s\<
+    s2\f
+    s4 s\>
+
+    s2\p
+    s4 s\<
+    s2\f
+    s
+
+    s2*3
+  }
+  \alternative { { s4 s\> } { s2 } }
+
+  \repeat volta 2 {
+    s2*8\f
+
+    s2*3\p
+    s4 s\>
+
+    s2\p
+    s\<
+    s\!
+  }
+  \alternative { { s2 } { s4 s\> } }
+
+  s2\p
+  s4 s\<
+  s2\f
+  s4 s\>
+
+  s2\p
+  s4 s\<
+  s2\f
+  s4 s\>
+
+  s2\p
+  s4 s\<
+  s2*2\f
+
+  s2*4
+
+  \repeat volta 2 {
+    s2*12\f
+
+    s2
+    s4\< s\fz\>
+    s2\f
+  }
+  \alternative { { s2 } { s2 } }
+
+  s2*4
+
+  \repeat volta 2 {
+    s2*15
+  }
+  \alternative { { s2 } { s2 } }
+}
+
 \score {
   \new PianoStaff <<
     \new Staff = "up" \top
+    \new Dynamics \dyn
     \new Staff = "down" \bottom
   >>
 
@@ -312,9 +384,5 @@ bottom = \relative c {
 
   \midi {
     \tempo 4 = 72
-    \context {
-      \Voice
-      \remove Dynamic_performer
-    }
   }
 }

--- a/ftp/JoplinS/entertainer/entertainer.ly
+++ b/ftp/JoplinS/entertainer/entertainer.ly
@@ -17,7 +17,41 @@
   maintainerEmail = "sincero@my.mail.de"
 
   footer = "Mutopia-2015/12/27-xxx"
-  tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-column { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \concat { \teeny www. MutopiaProject \teeny .org } \hspace #0.5 • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \concat { \teeny www. LilyPond \teeny .org } by \concat { \maintainer . } \hspace #0.5 Reference: \footer } } \line { \teeny \line { This sheet music has been placed in the public domain by the typesetter, for details see: \hspace #-0.5 \with-url #"http://creativecommons.org/licenses/publicdomain" http://creativecommons.org/licenses/publicdomain } } } }
+  tagline = \markup {
+    \override #'(box-padding . 1.0)
+    \override #'(baseline-skip . 2.7)
+    \box
+    \center-column {
+      \small \line {
+        Sheet music from
+        \with-url #"http://www.MutopiaProject.org"
+        \concat { \teeny www. MutopiaProject \teeny .org }
+
+        \hspace #0.5 • \hspace #0.5
+
+        \italic Free to download,
+        with the \italic freedom to distribute, modify and perform.
+      }
+      \line {
+        \small \line {
+          Typeset using
+          \with-url #"http://www.LilyPond.org"
+          \concat { \teeny www. LilyPond \teeny .org }
+          by \concat { \maintainer . }
+          \hspace #0.5
+          Reference: \footer
+        }
+      }
+      \line {
+        \teeny \line {
+          This sheet music has been placed in the public domain
+          by the typesetter, for details see:
+          \with-url #"http://creativecommons.org/licenses/publicdomain"
+          http://creativecommons.org/licenses/publicdomain
+        }
+      }
+    }
+  }
 }
 
 \paper {

--- a/ftp/JoplinS/entertainer/entertainer.ly
+++ b/ftp/JoplinS/entertainer/entertainer.ly
@@ -34,20 +34,13 @@ top = \relative c' {
   \global
   \clef treble
 
-  \stemUp
+  \voiceOne
   d''16 e c a ~ a b g8 | %1
-  \stemNeutral
+  \oneVoice
   d16 e c a ~ a b g8 |
-  \stemUp
-  d16 e c
-  \change Staff = "down"
-  a ~ a b a as |
-  g8
-  \once \override Rest.direction = #UP
-  r
-  \change Staff = "up"
-  \stemNeutral
-  <g'' d b g>^^ d,16(\> dis)\! |
+
+  d16 e c \change Staff = "down" \voiceOne a ~ a b a as |
+  g8 r \change Staff = "up" \oneVoice   <g'' d b g>^^ d,16(\> dis)\! |
 
   \repeat volta 2 {
     e16\p c'8 e,16 c'8 e,16 c' ~ | %5
@@ -176,18 +169,13 @@ top = \relative c' {
 bottom = \relative c {
   \global
   \clef bass
-  \change Staff = "up"
-  \stemDown
+  \change Staff = "up" \voiceTwo
   d''16 \f e c a ~ a b g8 | %1
-  \stemNeutral
-  \change Staff = "down"
+  \change Staff = "down" \oneVoice
   d16 e c a ~ a b g8 |
-  \stemDown
+  \voiceTwo
   d16 e c a ~ a b a as |
-  g8
-  \once \override Rest.direction = #DOWN
-  r
-  \stemUp <g g,>^^ <b' g>
+  g8 r \oneVoice <g g,>^^ <b' g>
 
   \stemNeutral
   \repeat volta 2 {

--- a/ftp/JoplinS/entertainer/entertainer.ly
+++ b/ftp/JoplinS/entertainer/entertainer.ly
@@ -13,8 +13,9 @@
   copyright = "Public Domain"
   source = "Reproduction of original edition (1902)"
 
-  maintainer = "Simon Albrecht"
-  maintainerEmail = "sincero@my.mail.de"
+  maintainer = "Chris Sawer"
+  maintainerEmail = "chris@mutopiaproject.org"
+  maintainerWeb = "http://www.whitewillow.co.uk/"
 
   footer = "Mutopia-2008/12/21-263"
   tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-column { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \line { \teeny www. \hspace #-1.0 MutopiaProject \hspace #-1.0 \teeny .org \hspace #0.5 } • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \line { \teeny www. \hspace #-1.0 LilyPond \hspace #-1.0 \teeny .org } by \maintainer \hspace #-1.0 . \hspace #0.5 Reference: \footer } } \line { \teeny \line { This sheet music has been placed in the public domain by the typesetter, for details see: \hspace #-0.5 \with-url #"http://creativecommons.org/licenses/publicdomain" http://creativecommons.org/licenses/publicdomain } } } }

--- a/ftp/JoplinS/entertainer/entertainer.ly
+++ b/ftp/JoplinS/entertainer/entertainer.ly
@@ -22,11 +22,16 @@
   tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-column { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \line { \teeny www. \hspace #-1.0 MutopiaProject \hspace #-1.0 \teeny .org \hspace #0.5 } • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \line { \teeny www. \hspace #-1.0 LilyPond \hspace #-1.0 \teeny .org } by \maintainer \hspace #-1.0 . \hspace #0.5 Reference: \footer } } \line { \teeny \line { This sheet music has been placed in the public domain by the typesetter, for details see: \hspace #-0.5 \with-url #"http://creativecommons.org/licenses/publicdomain" http://creativecommons.org/licenses/publicdomain } } } }
 }
 
+global = {
+  \key c \major
+  \time 2/4
+  \tempo "Not fast"
+}
+
 top = \relative c' {
   \override TextScript.padding = #2
 
-  \key c \major
-  \time 2/4
+  \global
   \clef treble
 
   \stemUp
@@ -169,8 +174,7 @@ top = \relative c' {
 }
 
 bottom = \relative c {
-  \key c \major
-  \time 2/4
+  \global
   \clef bass
   \change Staff = "up"
   \stemDown

--- a/ftp/JoplinS/entertainer/entertainer.ly
+++ b/ftp/JoplinS/entertainer/entertainer.ly
@@ -17,41 +17,7 @@
   maintainerEmail = "sincero@my.mail.de"
 
   footer = "Mutopia-2015/12/27-xxx"
-  tagline = \markup {
-    \override #'(box-padding . 1.0)
-    \override #'(baseline-skip . 2.7)
-    \box
-    \center-column {
-      \small \line {
-        Sheet music from
-        \with-url #"http://www.MutopiaProject.org"
-        \concat { \teeny www. MutopiaProject \teeny .org }
-
-        \hspace #0.5 • \hspace #0.5
-
-        \italic Free to download,
-        with the \italic freedom to distribute, modify and perform.
-      }
-      \line {
-        \small \line {
-          Typeset using
-          \with-url #"http://www.LilyPond.org"
-          \concat { \teeny www. LilyPond \teeny .org }
-          by \concat { \maintainer . }
-          \hspace #0.5
-          Reference: \footer
-        }
-      }
-      \line {
-        \teeny \line {
-          This sheet music has been placed in the public domain
-          by the typesetter, for details see:
-          \with-url #"http://creativecommons.org/licenses/publicdomain"
-          http://creativecommons.org/licenses/publicdomain
-        }
-      }
-    }
-  }
+  tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-column { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \concat { \teeny www. MutopiaProject \teeny .org } \hspace #0.5 • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \concat { \teeny www. LilyPond \teeny .org } by \concat { \maintainer . } \hspace #0.5 Reference: \footer } } \line { \teeny \line { This sheet music has been placed in the public domain by the typesetter, for details see: \hspace #-0.5 \with-url #"http://creativecommons.org/licenses/publicdomain" http://creativecommons.org/licenses/publicdomain } } } }
 }
 
 \paper {

--- a/ftp/JoplinS/entertainer/entertainer.ly
+++ b/ftp/JoplinS/entertainer/entertainer.ly
@@ -22,15 +22,6 @@
   tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-column { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \line { \teeny www. \hspace #-1.0 MutopiaProject \hspace #-1.0 \teeny .org \hspace #0.5 } • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \line { \teeny www. \hspace #-1.0 LilyPond \hspace #-1.0 \teeny .org } by \maintainer \hspace #-1.0 . \hspace #0.5 Reference: \footer } } \line { \teeny \line { This sheet music has been placed in the public domain by the typesetter, for details see: \hspace #-0.5 \with-url #"http://creativecommons.org/licenses/publicdomain" http://creativecommons.org/licenses/publicdomain } } } }
 }
 
-blanknotes = {
-  \override NoteHead.transparent = ##t
-  \override Stem.transparent = ##t
-}
-unblanknotes = {
-  \revert NoteHead.transparent
-  \revert Stem.transparent
-}
-
 top = \relative c' {
   \override TextScript.padding = #2
 
@@ -137,7 +128,7 @@ top = \relative c' {
     c4\< <f b, gis>8.\fz\!\> f16\! |
     <<
       { \stemDown <a c, a>16\f <c c,>8 <g bes,>16 ~ \stemUp g c, d e }
-      \\ { s8. \blanknotes bes4*1/4 ~ \unblanknotes bes8 bes }
+      \\ { s8. \hideNotes bes4*1/4 ~ \unHideNotes bes8 bes }
     >> | %69 - slight kludge
   } \alternative {
     { <f' a,>8 b,16( c d e f g) }

--- a/ftp/JoplinS/entertainer/entertainer.ly
+++ b/ftp/JoplinS/entertainer/entertainer.ly
@@ -16,12 +16,8 @@
   maintainer = "Simon Albrecht"
   maintainerEmail = "sincero@my.mail.de"
 
-  footer = "Mutopia-2015/12/27-xxx"
-  tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-column { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \concat { \teeny www. MutopiaProject \teeny .org } \hspace #0.5 • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \concat { \teeny www. LilyPond \teeny .org } by \concat { \maintainer . } \hspace #0.5 Reference: \footer } } \line { \teeny \line { This sheet music has been placed in the public domain by the typesetter, for details see: \hspace #-0.5 \with-url #"http://creativecommons.org/licenses/publicdomain" http://creativecommons.org/licenses/publicdomain } } } }
-}
-
-\paper {
-  ragged-last-bottom = ##f
+  footer = "Mutopia-2008/12/21-263"
+  tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-column { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \line { \teeny www. \hspace #-1.0 MutopiaProject \hspace #-1.0 \teeny .org \hspace #0.5 } • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \line { \teeny www. \hspace #-1.0 LilyPond \hspace #-1.0 \teeny .org } by \maintainer \hspace #-1.0 . \hspace #0.5 Reference: \footer } } \line { \teeny \line { This sheet music has been placed in the public domain by the typesetter, for details see: \hspace #-0.5 \with-url #"http://creativecommons.org/licenses/publicdomain" http://creativecommons.org/licenses/publicdomain } } } }
 }
 
 global = {

--- a/ftp/JoplinS/entertainer/entertainer.ly
+++ b/ftp/JoplinS/entertainer/entertainer.ly
@@ -35,7 +35,7 @@ top = \relative c' {
   \clef treble
 
   \stemUp
-  d''16^\markup {\large "Not fast"} e c a ~ a b g8 | %1
+  d''16 e c a ~ a b g8 | %1
   \stemNeutral
   d16 e c a ~ a b g8 |
   \stemUp

--- a/ftp/JoplinS/entertainer/entertainer.ly
+++ b/ftp/JoplinS/entertainer/entertainer.ly
@@ -16,8 +16,12 @@
   maintainer = "Simon Albrecht"
   maintainerEmail = "sincero@my.mail.de"
 
-  footer = "Mutopia-2008/12/21-263"
-  tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-column { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \line { \teeny www. \hspace #-1.0 MutopiaProject \hspace #-1.0 \teeny .org \hspace #0.5 } • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \line { \teeny www. \hspace #-1.0 LilyPond \hspace #-1.0 \teeny .org } by \maintainer \hspace #-1.0 . \hspace #0.5 Reference: \footer } } \line { \teeny \line { This sheet music has been placed in the public domain by the typesetter, for details see: \hspace #-0.5 \with-url #"http://creativecommons.org/licenses/publicdomain" http://creativecommons.org/licenses/publicdomain } } } }
+  footer = "Mutopia-2015/12/27-xxx"
+  tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-column { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \concat { \teeny www. MutopiaProject \teeny .org } \hspace #0.5 • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \concat { \teeny www. LilyPond \teeny .org } by \concat { \maintainer . } \hspace #0.5 Reference: \footer } } \line { \teeny \line { This sheet music has been placed in the public domain by the typesetter, for details see: \hspace #-0.5 \with-url #"http://creativecommons.org/licenses/publicdomain" http://creativecommons.org/licenses/publicdomain } } } }
+}
+
+\paper {
+  ragged-last-bottom = ##f
 }
 
 global = {

--- a/ftp/JoplinS/entertainer/entertainer.ly
+++ b/ftp/JoplinS/entertainer/entertainer.ly
@@ -4,7 +4,6 @@
   title = "The Entertainer"
   subtitle = "A Ragtime Two Step"
   composer = "Scott Joplin"
-  piece = "INTRO"
 
   mutopiatitle = "The Entertainer"
   mutopiacomposer = "JoplinS"
@@ -32,6 +31,10 @@ top = \relative c' {
   \global
   \clef treble
 
+  %% to print RehearsalMark above MetronomeMark,
+  %% align them to the same ‘break-align-symbol’
+  \once\override Score.RehearsalMark.break-align-symbols = #'(time-signature)
+  \mark "INTRO:"
   \voiceOne
   d''16 e c a ~ a b g8 | %1
   \oneVoice


### PR DESCRIPTION
Hello,

I’ve taken on The Entertainer by Scott Joplin and made a new version of the file. There should be few changes to the actual content, nevertheless few of the lines remain untouched. I tried to make it understandable through well-delimited commits, and here’s what I mainly did:
– Update syntax to v2.19.32.
– Use what I think is better (i.e. more standard-compliant and legible) code formatting: No tabs, correct indenting, no trailing whitespace &c.
– And some more substantial changes which should be understandable from the commit messages.

I didn’t quite know what to do about the footer and tagline header fields. Are these updated automatically? The old standard mutopia tagline used here has some hideous abuse of negative `\hspace`, where using `\concat` would be appropriate; and it’s very difficult to read in the code due to total lack of code formatting. I fixed both here.

Yours, Simon