### PR TITLE
Bwv 528 update

### DIFF
--- a/ftp/BachJS/BWV528/SonataIV/SonataIV-lys/Adagio.ly
+++ b/ftp/BachJS/BWV528/SonataIV/SonataIV-lys/Adagio.ly
@@ -21,7 +21,7 @@ bintro = \relative c
 {
 	e4 r8 dis e4 r8 fis|
 	g4 r8 c8 fis,4 r8 h,|
-	e, e' g h h, c'16 h c8 c,|
+	e, e' g h c, c'16 h c8 c,|
 	h16 h'a h g h e, g ais,2|
 }
 
@@ -214,8 +214,8 @@ bassA = \relative c
 	e d c|
 %35
 	h4 r8 h e h|
-	c4 r8 f d d|
-	a4 g f|
+	c4 r8 f d e|
+	a,4 g f|
 	e d' c|
 %39
 	h r8 e gis e|
@@ -243,7 +243,7 @@ bassA = \relative c
 	h h' fis a dis, fis|
 %59
 	a,4 r8 c h a|
-	g a h g h4|
+	g a h a h4|
 	e,8 e' e e fis g|
 	cis, cis cis dis e fis|
 	h,4. g8 c4|

--- a/ftp/BachJS/BWV528/SonataIV/SonataIV-lys/Andante.ly
+++ b/ftp/BachJS/BWV528/SonataIV/SonataIV-lys/Andante.ly
@@ -54,7 +54,7 @@ sopranB = \relative c'
 	g16 a,32 h cis h a16 d a e' a, fis'2~ |
 %38
 	fis16 g,32 a h g fis g cis g fis g d' g, fis g
-		e'16 g, fis d' fis, d' cis fis, |
+		e'16 g, fis d' e, d' cis e, |
 	cis' e, d h' cis, h' a c, a' c, h g' a, g' fis a, |
 	fis' a, g e' fis, e' d h' ais8 fis h e |
 	cis e, a d h d, g c |
@@ -114,7 +114,7 @@ altB = \relative c'
 	g, e h'8 r4 r16 fis'32 e d fis g fis cis fis g fis h, fis' g fis |
 	ais,8 h ais gis fis32 ais h cis d h fis d'cis ais fis cis'h gis eis h'|
 %35
-	ais8 h ais gis fis16 fis32 gis a16 fis h fis cis' fis, |
+	ais8 h ais gis fis16 fis32 gis ais16 fis h fis cis' fis, |
 	d'2~d16 e,32 fis g fis e16 a e h' e, |
 	cis'2~cis16 d,32 e fis d cis d g d cis d a' d, cis d |
 %38
@@ -142,7 +142,7 @@ bassB = \relative c'
 %8
 	d r h r cis fis cis' cis, |
 	fis r d r e r cis r |
-	d r h r cis fis cis cis |
+	d r h r cis fis, cis' cis |
 %11
 	fis, fis' gis ais h h, cis d |
 	e, e' fis g a a, h cis |
@@ -189,5 +189,5 @@ bassB = \relative c'
 	a r fis r g r e r |
 	fis h fis' fis, gis4-\fermata r8 g8 |
 	fis h fis' fis, h2-\fermata|
-	
+
 }


### PR DESCRIPTION
Corrected a few notes in 1st and 2nd movement.
Kept old Lilypond version 2.8.4, as newer versions (tried 2.14 and 2.18)
didn't produce correct beaming of triplets in 3rd movement.