### PR TITLE
Prep 929

### DIFF
--- a/ftp/SousaJP/TheStarsAndStripesForever/TheStarsAndStripesForever.ly
+++ b/ftp/SousaJP/TheStarsAndStripesForever/TheStarsAndStripesForever.ly
@@ -10,13 +10,14 @@
  mutopiacomposer = "SousaJP"
  mutopiainstrument = "Piano"
  date = "1896"
- source = "The John Church Company"
+ source = "Cincinnati: The John Church Company, 1897"
  style = "March"
  maintainer = "Benjamin Bloomfield"
  maintainerEmail = "bhb123@gmail.com"
- copyright = "Public Domain"
 
- footer = "Mutopia-2017/11/03-626"
+ license = "Public Domain"
+
+ footer = "Mutopia-2017/11/06-626"
  copyright = \markup {\override #'(font-name . "DejaVu Sans, Bold") \override #'(baseline-skip . 0) \right-column {\with-url #"http://www.MutopiaProject.org" {\abs-fontsize #9  "Mutopia " \concat {\abs-fontsize #12 \with-color #white "ǀ" \abs-fontsize #9 "Project "}}}\override #'(font-name . "DejaVu Sans, Bold") \override #'(baseline-skip . 0 ) \center-column {\abs-fontsize #11.9 \with-color #grey \bold {"ǀ" "ǀ"}}\override #'(font-name . "DejaVu Sans,sans-serif") \override #'(baseline-skip . 0) \column { \abs-fontsize #8 \concat {"Typeset using " \with-url #"http://www.lilypond.org" "LilyPond " "by " \maintainer " — " \footer}\concat {\concat {\abs-fontsize #8 { "Placed in the " \with-url #"http://creativecommons.org/licenses/publicdomain" "Public Domain" " by the typesetter " " — free to distribute, modify, and perform" }}\abs-fontsize #13 \with-color #white "ǀ" }}}
  tagline = ##f
 }


### PR DESCRIPTION
Updated license to reflect what was embedded in the existing copyright tag.

Closes #929 