### PR TITLE
Remove point and click off

### DIFF
--- a/collections/blakeop2/blakeop2-lys/blake_op2.ly
+++ b/collections/blakeop2/blakeop2-lys/blake_op2.ly
@@ -1,6 +1,6 @@
 \version "2.16.0"
 \include "book-titling.ily"
-\pointAndClickOff
+
 \paper {
   %#(set-paper-size "tabloid" 'landscape)
   %#(set-paper-size "a2" 'landscape)

--- a/ftp/AlbenizIMF/O71/Rumores_de_la-caleta/Rumores_de_la-caleta.ly
+++ b/ftp/AlbenizIMF/O71/Rumores_de_la-caleta/Rumores_de_la-caleta.ly
@@ -1,5 +1,4 @@
 \version "2.10.0"
-#(ly:set-option 'point-and-click #f)
 \include "english.ly"
 
 \paper {

--- a/ftp/AlyabyevA/alyabyev-cherubic/alyabyev-cherubic.ly
+++ b/ftp/AlyabyevA/alyabyev-cherubic/alyabyev-cherubic.ly
@@ -1,7 +1,6 @@
 \version "2.11.41"
 
 #(set-global-staff-size 18)
-#(ly:set-option 'point-and-click #f)
 
 \paper {
 	% We need a font with the Cyrillic "yat" character (U+0463).

--- a/ftp/ArchangelskyA/archangelsky-let-us-hasten/archangelsky-let-us-hasten.ly
+++ b/ftp/ArchangelskyA/archangelsky-let-us-hasten/archangelsky-let-us-hasten.ly
@@ -1,7 +1,6 @@
 \version "2.11.41"
 
 #(set-global-staff-size 18)
-#(ly:set-option 'point-and-click #f)
 
 \paper {
 	% We need a font with the Cyrillic "yat" character (U+0463).

--- a/ftp/BachJS/BWV230/bach_BWV_230_Lobet_den_Herrn_alle_Heiden/bach_BWV_230_Lobet_den_Herrn_alle_Heiden.ly
+++ b/ftp/BachJS/BWV230/bach_BWV_230_Lobet_den_Herrn_alle_Heiden/bach_BWV_230_Lobet_den_Herrn_alle_Heiden.ly
@@ -33,7 +33,6 @@
   after-title-space = #0.1
   ragged-last-bottom = ##f %% stretch and center systems of last page
   %% annotate-spacing = ##t
-  #(ly:set-option 'point-and-click #f) %% for smaller PDFs
 }
 
 \layout {

--- a/ftp/BachJS/BWV36b/bwv0036b/bwv0036b-lys/bwv0036b_midi.ly
+++ b/ftp/BachJS/BWV36b/bwv0036b/bwv0036b-lys/bwv0036b_midi.ly
@@ -2,7 +2,7 @@
 
 \include "common/version.ily"
 \include "common/definitions.ily"
-\pointAndClickOff
+
 markupInstrumentName =
 #(define-scheme-function
    (parser location text)

--- a/ftp/BachJS/BWV36b/bwv0036b/bwv0036b-lys/common/bwv0036b.ily
+++ b/ftp/BachJS/BWV36b/bwv0036b/bwv0036b-lys/common/bwv0036b.ily
@@ -1,6 +1,6 @@
 \include "version.ily"
 \include "definitions.ily"
-\pointAndClickOff
+
 
 \header {
   date = "1735"

--- a/ftp/BachJS/BWV846/wtk1-prelude1/wtk1-prelude1.ly
+++ b/ftp/BachJS/BWV846/wtk1-prelude1/wtk1-prelude1.ly
@@ -42,7 +42,7 @@
   ragged-last-bottom = ##f
 }
 
-\pointAndClickOff
+
 
 %% 
 %% Define the left and the right hand in new variables

--- a/ftp/BachJS/BWVAnh114/anna-magdalena-04/anna-magdalena-04.ly
+++ b/ftp/BachJS/BWVAnh114/anna-magdalena-04/anna-magdalena-04.ly
@@ -23,7 +23,7 @@
  tagline = ##f
 }
 #(set-global-staff-size 21)
-\pointAndClickOff
+
 
 \version "2.19.49"
 

--- a/ftp/BeethovenLv/O27/moonlight-guitar-duo/moonlight-guitar-duo.ly
+++ b/ftp/BeethovenLv/O27/moonlight-guitar-duo/moonlight-guitar-duo.ly
@@ -54,8 +54,6 @@
   evenFooterMarkup = \oddFooterMarkup
 }
 
-% suppress local file system path in pdf
-#(ly:set-option 'point-and-click #f)
 
 % guitar neck position indicators
 pI    = ^\markup { "I" }

--- a/ftp/BeethovenLv/O27/moonlight/moonlight-lys/moonlight1-a4.ly
+++ b/ftp/BeethovenLv/O27/moonlight/moonlight-lys/moonlight1-a4.ly
@@ -1,6 +1,5 @@
 \version "2.10.16"
 
-#(ly:set-option 'point-and-click #f)
 #(set-default-paper-size "a4" )
 #(set-global-staff-size 20 )
 

--- a/ftp/BeethovenLv/O27/moonlight/moonlight-lys/moonlight1-let.ly
+++ b/ftp/BeethovenLv/O27/moonlight/moonlight-lys/moonlight1-let.ly
@@ -1,6 +1,5 @@
 \version "2.10.16"
 
-#(ly:set-option 'point-and-click #f)
 #(set-default-paper-size "letter" )
 #(set-global-staff-size 20 )
 

--- a/ftp/BeethovenLv/O27/moonlight/moonlight-lys/moonlight3-a4.ly
+++ b/ftp/BeethovenLv/O27/moonlight/moonlight-lys/moonlight3-a4.ly
@@ -1,6 +1,5 @@
 \version "2.10.16"
 
-#(ly:set-option 'point-and-click #f)
 #(set-global-staff-size 20)
 #(set-default-paper-size "a4")
 

--- a/ftp/BeethovenLv/O27/moonlight/moonlight-lys/moonlight3-let.ly
+++ b/ftp/BeethovenLv/O27/moonlight/moonlight-lys/moonlight3-let.ly
@@ -1,6 +1,5 @@
 \version "2.10.16"
 
-#(ly:set-option 'point-and-click #f)
 #(set-global-staff-size 20)
 #(set-default-paper-size "letter")
 

--- a/ftp/BeethovenLv/O67/sym5-1-guitar-duo/sym5-1-guitar-duo.ly
+++ b/ftp/BeethovenLv/O67/sym5-1-guitar-duo/sym5-1-guitar-duo.ly
@@ -53,8 +53,6 @@
   evenFooterMarkup = \oddFooterMarkup
 }
 
-% suppress local file system path in pdf
-\pointAndClickOff
 
 
 % pitch limits for standard clasical guitar

--- a/ftp/BeethovenLv/WoO30/Drei_Equali/Drei_Equali-lys/MakePart.lyi
+++ b/ftp/BeethovenLv/WoO30/Drei_Equali/Drei_Equali-lys/MakePart.lyi
@@ -1,6 +1,5 @@
 \version "2.14.0"
 
-#(ly:set-option 'point-and-click #f)
 
 \paper { ragged-last-bottom = ##f }
 

--- a/ftp/BeethovenLv/WoO30/Drei_Equali/Drei_Equali-lys/Score_Drei_Equali.ly
+++ b/ftp/BeethovenLv/WoO30/Drei_Equali/Drei_Equali-lys/Score_Drei_Equali.ly
@@ -16,7 +16,6 @@
 \include "Notes_Trombone4_Movement3.lyi"
 
 #(set-global-staff-size 14)
-#(ly:set-option 'point-and-click #f)
 
 \paper
 {

--- a/ftp/BortnianskyD/bortniansky-xmas-kontakion/bortniansky-xmas-kontakion.ly
+++ b/ftp/BortnianskyD/bortniansky-xmas-kontakion/bortniansky-xmas-kontakion.ly
@@ -1,7 +1,6 @@
 \version "2.11.35"
 
 #(set-global-staff-size 18)
-#(ly:set-option 'point-and-click #f)
 
 \paper {
 	% We need a font with the Cyrillic "yat" character (U+0463).

--- a/ftp/BruchM/Wiegenlied/Wiegenlied.ly
+++ b/ftp/BruchM/Wiegenlied/Wiegenlied.ly
@@ -1,5 +1,4 @@
 #(set-global-staff-size 15.5) 
-#(ly:set-option 'point-and-click #f) 
 
 \version "2.18.0" 
 

--- a/ftp/BuxtehudeD/Wv208/buxtehude_Wv208_nun_bitten_wir/buxtehude_Wv208_nun_bitten_wir.ly
+++ b/ftp/BuxtehudeD/Wv208/buxtehude_Wv208_nun_bitten_wir/buxtehude_Wv208_nun_bitten_wir.ly
@@ -25,7 +25,6 @@
     between-system-space = #0.3
     after-title-space = #0.1
     ragged-last-bottom = ##f %% stretch and center systems of last page
-    #(ly:set-option 'point-and-click #f) %% for smaller PDFs
 }
 
 \layout {

--- a/ftp/BuxtehudeD/Wv209/buxtehude_Wv209_nun_bitten_wir/buxtehude_Wv209_nun_bitten_wir.ly
+++ b/ftp/BuxtehudeD/Wv209/buxtehude_Wv209_nun_bitten_wir/buxtehude_Wv209_nun_bitten_wir.ly
@@ -25,7 +25,6 @@
     between-system-space = #0.3
     after-title-space = #0.1
     ragged-last-bottom = ##f %% stretch and center systems of last page
-    #(ly:set-option 'point-and-click #f) %% for smaller PDFs
 }
 
 \layout {

--- a/ftp/CarcassiM/O59/CarcassiMethodPreludes/CarcassiMethodPreludes.ly
+++ b/ftp/CarcassiM/O59/CarcassiMethodPreludes/CarcassiMethodPreludes.ly
@@ -47,8 +47,6 @@
   evenFooterMarkup = \oddFooterMarkup
 }
 
-% suppress local file system path in pdf
-\pointAndClickOff
 
 % guitar neck position indicators
 pI    = ^\markup { "I" }

--- a/ftp/CarcassiM/O59/TwoMinorPreludes/TwoMinorPreludes.ly
+++ b/ftp/CarcassiM/O59/TwoMinorPreludes/TwoMinorPreludes.ly
@@ -48,8 +48,6 @@
   evenFooterMarkup = \oddFooterMarkup
 }
 
-% suppress local file system path in pdf
-\pointAndClickOff
 
 % guitar neck position indicators
 pI    = ^\markup { "I" }

--- a/ftp/CharpentierMA/H490/DavidEtJonathas/DavidEtJonathas-lys/common/layout.ily
+++ b/ftp/CharpentierMA/H490/DavidEtJonathas/DavidEtJonathas-lys/common/layout.ily
@@ -20,7 +20,6 @@
 
 #(set-default-paper-size (symbol->string (*paper-size*)))
 
-#(ly:set-option 'point-and-click #f)
 
 \paper {
   %% Page breaking

--- a/ftp/ChopinFF/O23/chopin-op23-ballade-1/chopin-op23-ballade-1-lys/chopin-op23-ballade-1.ly
+++ b/ftp/ChopinFF/O23/chopin-op23-ballade-1/chopin-op23-ballade-1-lys/chopin-op23-ballade-1.ly
@@ -17,7 +17,7 @@
 \version "2.18.2"
 %#(set-default-paper-size "letter")
 #(set-global-staff-size 17.8)
-\pointAndClickOff
+
 
 %--------Definitions
 \include "chopin-op23-ballade-1-defs.ly"

--- a/ftp/ChopinFF/O28/Chop-28-20/Chop-28-20.ly
+++ b/ftp/ChopinFF/O28/Chop-28-20/Chop-28-20.ly
@@ -48,7 +48,7 @@
   ragged-bottom = ##t
   ragged-last-bottom = ##f
 }
-\pointAndClickOff
+
 
 
 shortStem = \once \override Stem #'length-fraction = #(magstep -4)

--- a/ftp/ChopinFF/O45/chopin_prelude_op45/chopin_prelude_op45.ly
+++ b/ftp/ChopinFF/O45/chopin_prelude_op45/chopin_prelude_op45.ly
@@ -26,7 +26,7 @@
   ragged-last-bottom = ##f
   first-page-number = #2
 }
-\pointAndClickOff
+
 
 % Definitions to override page-breaking
 myBreak = {

--- a/ftp/ChopinFF/O9/chopin_nocturne_op9_n2/chopin_nocturne_op9_n2.ly
+++ b/ftp/ChopinFF/O9/chopin_nocturne_op9_n2/chopin_nocturne_op9_n2.ly
@@ -7,7 +7,6 @@ between-system-padding = 1
 between-system-space = 3
   %ragged-bottom=##f
   ragged-last-bottom=##f
-#(ly:set-option 'point-and-click #f)
 }
 
 #(set-global-staff-size 18.26)

--- a/ftp/ClementiM/O42/clementi-op42/clementi-op42-lys/clementi-op42.ly
+++ b/ftp/ClementiM/O42/clementi-op42/clementi-op42-lys/clementi-op42.ly
@@ -11,7 +11,7 @@
 
 \version "2.16.1"
 
-\pointAndClickOff
+
 %#(set-default-paper-size "letter")
 
 %----------------------- HEADERS --------------------------%

--- a/ftp/CouperinF/ArtDeToucherLeClavecin/ArtDeToucherLeClavecin-lys/common.ily
+++ b/ftp/CouperinF/ArtDeToucherLeClavecin/ArtDeToucherLeClavecin-lys/common.ily
@@ -1,7 +1,6 @@
 \version "2.11.9"
 
 
-#(ly:set-option 'point-and-click #f)
 #(use-modules (srfi srfi-39))
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -55,7 +54,6 @@
 \include "book-page-layout.ily"
 \include "book-toc.ily"
 
-#(ly:set-option 'point-and-click #f)
 
 %% Staff size
 #(set-global-staff-size 18)

--- a/ftp/CouperinF/AspiratioMentisAdDeum/AspiratioMentisAdDeum-lys/common/common.ily
+++ b/ftp/CouperinF/AspiratioMentisAdDeum/AspiratioMentisAdDeum-lys/common/common.ily
@@ -3,7 +3,6 @@
 
 %% Staff size
 #(set-global-staff-size 16)
-#(ly:set-option 'point-and-click #f)
 
 \include "common/functions.ily"
 

--- a/ftp/CouperinF/DialogusInterJesumEtHominem/DialogusInterJesumEtHominem-lys/common/common.ily
+++ b/ftp/CouperinF/DialogusInterJesumEtHominem/DialogusInterJesumEtHominem-lys/common/common.ily
@@ -3,7 +3,6 @@
 
 %% Staff size
 #(set-global-staff-size 16)
-#(ly:set-option 'point-and-click #f)
 
 \include "common/functions.ily"
 

--- a/ftp/CouperinF/PrecatioAdDeum/PrecatioAdDeum-lys/common/common.ily
+++ b/ftp/CouperinF/PrecatioAdDeum/PrecatioAdDeum-lys/common/common.ily
@@ -3,7 +3,6 @@
 
 %% Staff size
 #(set-global-staff-size 16)
-#(ly:set-option 'point-and-click #f)
 
 \include "common/functions.ily"
 

--- a/ftp/CouperinF/SalveRegina/SalveRegina-lys/common/common.ily
+++ b/ftp/CouperinF/SalveRegina/SalveRegina-lys/common/common.ily
@@ -3,7 +3,6 @@
 
 %% Staff size
 #(set-global-staff-size 16)
-#(ly:set-option 'point-and-click #f)
 
 \include "common/functions.ily"
 

--- a/ftp/CouperinF/SalvumMeFacDeus/SalvumMeFacDeus-lys/common/common.ily
+++ b/ftp/CouperinF/SalvumMeFacDeus/SalvumMeFacDeus-lys/common/common.ily
@@ -3,7 +3,6 @@
 
 %% Staff size
 #(set-global-staff-size 16)
-#(ly:set-option 'point-and-click #f)
 
 \include "common/functions.ily"
 

--- a/ftp/CouperinF/UsquequoDomine/UsquequoDomine-lys/common/common.ily
+++ b/ftp/CouperinF/UsquequoDomine/UsquequoDomine-lys/common/common.ily
@@ -3,7 +3,6 @@
 
 %% Staff size
 #(set-global-staff-size 16)
-#(ly:set-option 'point-and-click #f)
 
 \include "common/functions.ily"
 

--- a/ftp/DebussyC/L66/debussy_Arabesque_1/debussy_Arabesque_1.ly
+++ b/ftp/DebussyC/L66/debussy_Arabesque_1/debussy_Arabesque_1.ly
@@ -16,7 +16,7 @@
  footer = "Mutopia-2011/10/25-1777"
  tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-column { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \line { \teeny www. \hspace #-1.0 MutopiaProject \hspace #-1.0 \teeny .org \hspace #0.5 } • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \line { \teeny www. \hspace #-1.0 LilyPond \hspace #-1.0 \teeny .org } by \maintainer \hspace #-1.0 . \hspace #0.5 Reference: \footer } } \line { \teeny \line { This sheet music has been placed in the public domain by the typesetter, for details see: \hspace #-0.5 \with-url #"http://creativecommons.org/licenses/publicdomain" http://creativecommons.org/licenses/publicdomain } } } }
 }
-\pointAndClickOff
+
 
 \paper {
   %{ comment out for mutopiaproject }

--- a/ftp/DebussyC/L75/debussy_Ste_Bergamesq_Clair/debussy_Ste_Bergamesq_Clair.ly
+++ b/ftp/DebussyC/L75/debussy_Ste_Bergamesq_Clair/debussy_Ste_Bergamesq_Clair.ly
@@ -15,7 +15,7 @@
  footer = "Mutopia-2010/12/21-1778"
  tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-column { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \line { \teeny www. \hspace #-1.0 MutopiaProject \hspace #-1.0 \teeny .org \hspace #0.5 } • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \line { \teeny www. \hspace #-1.0 LilyPond \hspace #-1.0 \teeny .org } by \maintainer \hspace #-1.0 . \hspace #0.5 Reference: \footer } } \line { \teeny \line { This sheet music has been placed in the public domain by the typesetter, for details see: \hspace #-0.5 \with-url #"http://creativecommons.org/licenses/publicdomain" http://creativecommons.org/licenses/publicdomain } } } }
 }
-\pointAndClickOff
+
 \paper {
   %{
   #(set-paper-size "letter")

--- a/ftp/GobbaertsL/Les_Etoiles_dOr_No1/Les_Etoiles_dOr_No1.ly
+++ b/ftp/GobbaertsL/Les_Etoiles_dOr_No1/Les_Etoiles_dOr_No1.ly
@@ -24,7 +24,7 @@
  tagline = ##f
 }
 
-\pointAndClickOff
+
 
 global = {
   \time 3/4

--- a/ftp/GranadosE/O37/oriental-duo/oriental-duo.ly
+++ b/ftp/GranadosE/O37/oriental-duo/oriental-duo.ly
@@ -46,8 +46,6 @@
   evenFooterMarkup = \oddFooterMarkup
 }
 
-% suppress local file system path in pdf
-#(ly:set-option 'point-and-click #f)
 
 % guitar neck position indicators
 pI    = ^\markup { "I" }

--- a/ftp/GriegE/O73/7-MountaineersSong/7-MountaineersSong.ly
+++ b/ftp/GriegE/O73/7-MountaineersSong/7-MountaineersSong.ly
@@ -1,6 +1,5 @@
 \version "2.12.1"
 \include "english.ly"
-#(ly:set-option 'point-and-click #f)
 
 \header {
 	title = "Lualåt"

--- a/ftp/HallRB/TenthRegimentMarch/TenthRegimentMarch-lys/TenthRegiment.ly
+++ b/ftp/HallRB/TenthRegimentMarch/TenthRegimentMarch-lys/TenthRegiment.ly
@@ -1,7 +1,7 @@
 \version "2.18.2"
 \include "changePitch.ly"
 
-\pointAndClickOff
+
 
 \header {
   title = "Tenth Regiment March"

--- a/ftp/HandelGF/HWV17/giulio-cesare/giulio-cesare-lys/common/common.ily
+++ b/ftp/HandelGF/HWV17/giulio-cesare/giulio-cesare-lys/common/common.ily
@@ -1,6 +1,5 @@
 \version "2.9.2"
 #(use-modules (ice-9 optargs))
-#(ly:set-option 'point-and-click #f)
 
 \include "common/loop-guile.ily"
 

--- a/ftp/HandelGF/HWV17/giulio-cesare/giulio-cesare-lys/parts/parts-common.ily
+++ b/ftp/HandelGF/HWV17/giulio-cesare/giulio-cesare-lys/parts/parts-common.ily
@@ -1,6 +1,5 @@
 \version "2.7.13"
 #(use-modules (ice-9 optargs))
-#(ly:set-option 'point-and-click #f)
 
 %% #{ ... #} syntax redefinition, in order to allow text substitution
 \include "../common/sharp-curly.ily"

--- a/ftp/HandelGF/HWV56/Messiah/Messiah-lys/common/layout.ily
+++ b/ftp/HandelGF/HWV56/Messiah/Messiah-lys/common/layout.ily
@@ -20,7 +20,6 @@
 
 #(set-default-paper-size (symbol->string (*paper-size*)))
 
-#(ly:set-option 'point-and-click #f)
 
 \paper {
   %% Margins, line width

--- a/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/defs.ily
+++ b/ftp/HaydnFJ/O76/op76-n1/op76-n1-lys/defs.ily
@@ -2,7 +2,6 @@
 
 \version "2.18.0"
 
-#(ly:set-option 'point-and-click #f)
 
 % Some useful macros
 

--- a/ftp/Ippolitov-IvanovM/O37/ippolitov-ivanov-liturgy/ippolitov-ivanov-liturgy-lys/ippolitov-ivanov-liturgy.ly
+++ b/ftp/Ippolitov-IvanovM/O37/ippolitov-ivanov-liturgy/ippolitov-ivanov-liturgy-lys/ippolitov-ivanov-liturgy.ly
@@ -1,7 +1,6 @@
 \version "2.11.26"
 
 #(set-global-staff-size 18)
-#(ly:set-option 'point-and-click #f)
 
 \paper {
 	% Note: we need fonts that contains "yat" (Unicode 0x0463), hence Times Ten Cyrillic.

--- a/ftp/KeyperFJ/Romance-et-Rondo/Romance-et-Rondo.ly
+++ b/ftp/KeyperFJ/Romance-et-Rondo/Romance-et-Rondo.ly
@@ -29,7 +29,7 @@
  tagline = ##f
 }
 
-\pointAndClickOff
+
 
 #(define modern-accidentals-style
   `(Staff ,(make-accidental-rule 'same-octave 0)

--- a/ftp/KumarR/flat/flat.ly
+++ b/ftp/KumarR/flat/flat.ly
@@ -24,7 +24,6 @@ onceStem =
   $music #}
 )
 
-#(ly:set-option 'point-and-click #f)
 
 \score {
   \context PianoStaff <<

--- a/ftp/KumarR/unfixed/unfixed.ly
+++ b/ftp/KumarR/unfixed/unfixed.ly
@@ -16,7 +16,6 @@
  tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-align { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \line { \teeny www. \hspace #-1.0 MutopiaProject \hspace #-1.0 \teeny .org \hspace #0.5 } • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \line { \teeny www. \hspace #-1.0 LilyPond \hspace #-1.0 \teeny .org } by \maintainer \hspace #-1.0 . \hspace #0.5 Copyright © 2007. \hspace #0.5 Reference: \footer } } \line { \teeny \line { Licensed under the Creative Commons Attribution-ShareAlike 3.0 (Unported) License, for details see: \hspace #-0.5 \with-url #"http://creativecommons.org/licenses/by-sa/3.0" http://creativecommons.org/licenses/by-sa/3.0 } } } }
 }
 
-#(ly:set-option 'point-and-click #f)
 
 pushUp = #(define-music-function (parser location padding) (number?)
   #{

--- a/ftp/KumarR/vase/vase.ly
+++ b/ftp/KumarR/vase/vase.ly
@@ -20,7 +20,6 @@
  tagline = ""
 }
 
-#(ly:set-option 'point-and-click #f)
 
 md = \change Staff=right
 mg = \change Staff=left

--- a/ftp/LassusOd/samia/samia-lys/samia-a4.ly
+++ b/ftp/LassusOd/samia/samia-lys/samia-a4.ly
@@ -7,7 +7,6 @@
 
 
 \version "2.10.33"
-#(ly:set-option 'point-and-click #f)
 \include "english.ly"
 
 \header {

--- a/ftp/LassusOd/samia/samia-lys/samia-let.ly
+++ b/ftp/LassusOd/samia/samia-lys/samia-let.ly
@@ -7,7 +7,6 @@
 
 
 \version "2.10.33"
-#(ly:set-option 'point-and-click #f)
 \include "english.ly"
 
 \header {

--- a/ftp/LullyJB/LWV05/lwv05/lwv05-lys/lully/common/common.ily
+++ b/ftp/LullyJB/LWV05/lwv05/lwv05-lys/lully/common/common.ily
@@ -3,7 +3,6 @@
 
 %% Staff size
 #(set-global-staff-size 16)
-#(ly:set-option 'point-and-click #f)
 
 \include "common/loop-guile.ily"
 \include "common/figured-bass.ily"

--- a/ftp/LullyJB/LWV08/lwv08/lwv08-lys/lully/common/common.ily
+++ b/ftp/LullyJB/LWV08/lwv08/lwv08-lys/lully/common/common.ily
@@ -3,7 +3,6 @@
 
 %% Staff size
 #(set-global-staff-size 16)
-#(ly:set-option 'point-and-click #f)
 
 \include "common/loop-guile.ily"
 \include "common/figured-bass.ily"

--- a/ftp/LullyJB/LWV22/LWV22LesPlaisirsDeLIleEnchantee/LWV22LesPlaisirsDeLIleEnchantee-lys/common/layout.ily
+++ b/ftp/LullyJB/LWV22/LWV22LesPlaisirsDeLIleEnchantee/LWV22LesPlaisirsDeLIleEnchantee-lys/common/layout.ily
@@ -20,7 +20,6 @@
 
 #(set-default-paper-size (symbol->string (*paper-size*)))
 
-#(ly:set-option 'point-and-click #f)
 
 \paper {
   %% Page breaking

--- a/ftp/LullyJB/LWV43/lwv43/lwv43-lys/common/common.ily
+++ b/ftp/LullyJB/LWV43/lwv43/lwv43-lys/common/common.ily
@@ -3,7 +3,6 @@
 
 %% Staff size
 #(set-global-staff-size 16)
-#(ly:set-option 'point-and-click #f)
 
 \include "common/loop-guile.ily"
 \include "common/figured-bass.ily"

--- a/ftp/LullyJB/LWV56/lwv56/lwv56-lys/common/layout.ily
+++ b/ftp/LullyJB/LWV56/lwv56/lwv56-lys/common/layout.ily
@@ -21,7 +21,6 @@
 
 #(set-default-paper-size (symbol->string (*paper-size*)))
 
-#(ly:set-option 'point-and-click #f)
 
 \paper {
   %% Page breaking

--- a/ftp/LullyJB/LWV61/LWV61Phaeton/LWV61Phaeton-lys/common/layout.ily
+++ b/ftp/LullyJB/LWV61/LWV61Phaeton/LWV61Phaeton-lys/common/layout.ily
@@ -20,7 +20,6 @@
 
 #(set-default-paper-size (symbol->string (*paper-size*)))
 
-#(ly:set-option 'point-and-click #f)
 
 \paper {
   %% Page breaking

--- a/ftp/LullyJB/LWV71/lwv71/lwv71-lys/common/common.ily
+++ b/ftp/LullyJB/LWV71/lwv71/lwv71-lys/common/common.ily
@@ -1,6 +1,5 @@
 \include "italiano.ly"
 \version "2.11.30"
-#(ly:set-option 'point-and-click #f)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Page layout

--- a/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Alto.ly
+++ b/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Alto.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking)
     top-margin = 3.0

--- a/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Basson1.ly
+++ b/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Basson1.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking)
     top-margin = 3.0

--- a/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Basson2.ly
+++ b/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Basson2.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking)
     top-margin = 3.0

--- a/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Clarinette1.ly
+++ b/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Clarinette1.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ 
     top-margin = 5.0

--- a/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Clarinette2.ly
+++ b/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Clarinette2.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ 
     top-margin = 5.0

--- a/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Contrebasse.ly
+++ b/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Contrebasse.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking)
     top-margin = 3.0

--- a/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Cor1.ly
+++ b/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Cor1.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking)
     top-margin = 5.0

--- a/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Cor2.ly
+++ b/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Cor2.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking)
     top-margin = 5.0

--- a/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Flute1.ly
+++ b/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Flute1.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ 
     top-margin = 5.0

--- a/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Flute2.ly
+++ b/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Flute2.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ 
     top-margin = 5.0

--- a/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Hautbois1.ly
+++ b/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Hautbois1.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ 
     top-margin = 5.0

--- a/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Hautbois2.ly
+++ b/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Hautbois2.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ 
     top-margin = 5.0

--- a/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Score-1.ly
+++ b/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Score-1.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"   
                   
 #(set-global-staff-size 14)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ 
 		#(define page-breaking ly:minimal-breaking)

--- a/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Score-2.ly
+++ b/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Score-2.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"   
                   
 #(set-global-staff-size 14)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ 
 		#(define page-breaking ly:minimal-breaking)

--- a/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Score-3.ly
+++ b/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Score-3.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"   
                   
 #(set-global-staff-size 14)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ 
 		#(define page-breaking ly:minimal-breaking)

--- a/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Score-4.ly
+++ b/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Score-4.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"   
                   
 #(set-global-staff-size 14)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ 
 		#(define page-breaking ly:minimal-breaking)

--- a/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Timbales.ly
+++ b/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Timbales.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking)
     top-margin = 5.0

--- a/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Violon1.ly
+++ b/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Violon1.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking)
     top-margin = 3.0

--- a/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Violon2.ly
+++ b/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Violon2.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking)
     top-margin = 3.0

--- a/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Violoncelle.ly
+++ b/ftp/MehulEN/Symphonie-1/Symphonie-1-lys/Violoncelle.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking)
     top-margin = 3.0

--- a/ftp/MozartWA/KV299/Mozart-Concerto/Mozart-Concerto-lys/allegro/DirectorScore.ly
+++ b/ftp/MozartWA/KV299/Mozart-Concerto/Mozart-Concerto-lys/allegro/DirectorScore.ly
@@ -21,7 +21,6 @@ arc = \markup { \italic "arco"}
 vl = \markup { \italic "Vcl."}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-#(ly:set-option 'point-and-click #f)
 #(set-global-staff-size 14)
 
 

--- a/ftp/MozartWA/KV299/Mozart-Concerto/Mozart-Concerto-lys/allegro/basso.ly
+++ b/ftp/MozartWA/KV299/Mozart-Concerto/Mozart-Concerto-lys/allegro/basso.ly
@@ -1,7 +1,6 @@
 \version "2.11.45"
 #(set-global-staff-size 22)
 \include "Misdefiniciones.ly"
-#(ly:set-option 'point-and-click #f)
 
 
 \header{

--- a/ftp/MozartWA/KV299/Mozart-Concerto/Mozart-Concerto-lys/allegro/cello.ly
+++ b/ftp/MozartWA/KV299/Mozart-Concerto/Mozart-Concerto-lys/allegro/cello.ly
@@ -1,7 +1,6 @@
 \version "2.11.43"
 #(set-global-staff-size 23)
 \include "Misdefiniciones.ly"
-#(ly:set-option 'point-and-click #f)
 
 
  \header{

--- a/ftp/MozartWA/KV299/Mozart-Concerto/Mozart-Concerto-lys/allegro/corni.ly
+++ b/ftp/MozartWA/KV299/Mozart-Concerto/Mozart-Concerto-lys/allegro/corni.ly
@@ -1,7 +1,6 @@
 \version "2.11.43"
 #(set-global-staff-size 23)
 \include "Misdefiniciones.ly"
-#(ly:set-option 'point-and-click #f)
 
 \header{
 title= "Concerto in C for Flute and Harp"

--- a/ftp/MozartWA/KV299/Mozart-Concerto/Mozart-Concerto-lys/allegro/flauto-allegro.ly
+++ b/ftp/MozartWA/KV299/Mozart-Concerto/Mozart-Concerto-lys/allegro/flauto-allegro.ly
@@ -1,7 +1,6 @@
 \version "2.11.43"
 #(set-global-staff-size 22)
 \include "Misdefiniciones.ly"
-#(ly:set-option 'point-and-click #f)
 
 \header{
 title= "Concerto in C for Flute and Harp"

--- a/ftp/MozartWA/KV299/Mozart-Concerto/Mozart-Concerto-lys/allegro/oboi.ly
+++ b/ftp/MozartWA/KV299/Mozart-Concerto/Mozart-Concerto-lys/allegro/oboi.ly
@@ -1,7 +1,6 @@
 \version "2.11.43"
 #(set-global-staff-size 23)
 \include "Misdefiniciones.ly"
-#(ly:set-option 'point-and-click #f)
 
 \header{
           title= "Concerto in C for Flute and Harp"

--- a/ftp/MozartWA/KV299/Mozart-Concerto/Mozart-Concerto-lys/allegro/viola.ly
+++ b/ftp/MozartWA/KV299/Mozart-Concerto/Mozart-Concerto-lys/allegro/viola.ly
@@ -1,7 +1,6 @@
 ﻿\version "2.11.43"
 #(set-global-staff-size 22)
 \include "Misdefiniciones.ly"
-#(ly:set-option 'point-and-click #f)
 
 \header{
           title= "Concerto in C for Flute and Harp"

--- a/ftp/MozartWA/KV299/Mozart-Concerto/Mozart-Concerto-lys/allegro/violinoI.ly
+++ b/ftp/MozartWA/KV299/Mozart-Concerto/Mozart-Concerto-lys/allegro/violinoI.ly
@@ -1,7 +1,6 @@
      \version "2.11.43"
      #(set-global-staff-size 22)
      \include "Misdefiniciones.ly"
-     #(ly:set-option 'point-and-click #f)
      
      \header{
      

--- a/ftp/MozartWA/KV299/Mozart-Concerto/Mozart-Concerto-lys/allegro/violinoII.ly
+++ b/ftp/MozartWA/KV299/Mozart-Concerto/Mozart-Concerto-lys/allegro/violinoII.ly
@@ -1,7 +1,6 @@
 \version "2.11.43"
 #(set-global-staff-size 22)
 \include "Misdefiniciones.ly"
-#(ly:set-option 'point-and-click #f)
 
 \header{
           

--- a/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Alto.ly
+++ b/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Alto.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 19)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking)
     top-margin = 3.0

--- a/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Basson1.ly
+++ b/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Basson1.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 19)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking)
     top-margin = 3.0

--- a/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Basson2.ly
+++ b/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Basson2.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 19)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking)
     top-margin = 3.0

--- a/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Contrebasse.ly
+++ b/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Contrebasse.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 19)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking)
     top-margin = 3.0

--- a/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Cor1.ly
+++ b/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Cor1.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 19)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking)
     top-margin = 5.0

--- a/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Cor2.ly
+++ b/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Cor2.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 19)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking)
     top-margin = 5.0

--- a/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Flute1.ly
+++ b/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Flute1.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 19)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ 
     top-margin = 5.0

--- a/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Flute2.ly
+++ b/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Flute2.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 19)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ 
     top-margin = 5.0

--- a/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Score-1.ly
+++ b/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Score-1.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"   
                   
 #(set-global-staff-size 14)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ 
 		#(define page-breaking ly:minimal-breaking)

--- a/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Score-2.ly
+++ b/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Score-2.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"   
                   
 #(set-global-staff-size 14)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ 
 		#(define page-breaking ly:minimal-breaking)

--- a/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Score-3.ly
+++ b/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Score-3.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"   
                   
 #(set-global-staff-size 14)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ 
 		#(define page-breaking ly:minimal-breaking)

--- a/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Violon1.ly
+++ b/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Violon1.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 19)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking)
     top-margin = 3.0

--- a/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Violon2.ly
+++ b/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Violon2.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 19)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking)
     top-margin = 3.0

--- a/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Violoncelle.ly
+++ b/ftp/MozartWA/KV622/MozartK622/MozartK622-lys/Violoncelle.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 19)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking)
     top-margin = 3.0

--- a/ftp/MozartWA/mozart_abendruhe/mozart_abendruhe.ly
+++ b/ftp/MozartWA/mozart_abendruhe/mozart_abendruhe.ly
@@ -25,7 +25,6 @@
     between-system-space = #0.3
     after-title-space = #0.1
     ragged-last-bottom = ##f %% stretch and center systems of last page
-    #(ly:set-option 'point-and-click #f) %% for smaller PDFs
 }
 
 \layout {

--- a/ftp/NaujalisJ/O7/naujalis-caligaverunt/naujalis-caligaverunt.ly
+++ b/ftp/NaujalisJ/O7/naujalis-caligaverunt/naujalis-caligaverunt.ly
@@ -1,6 +1,5 @@
 \version "2.11.22"
 #(set-global-staff-size 18)
-%#(ly:set-option 'point-and-click #f)
 
 \paper {
 	%#(set-paper-size "letter")

--- a/ftp/NaujalisJ/O7/naujalis-popule-meus/naujalis-popule-meus.ly
+++ b/ftp/NaujalisJ/O7/naujalis-popule-meus/naujalis-popule-meus.ly
@@ -1,6 +1,5 @@
 \version "2.11.22"
 #(set-global-staff-size 18)
-%#(ly:set-option 'point-and-click #f)
 
 \paper {
 	%#(set-paper-size "letter")

--- a/ftp/NaujalisJ/O7/naujalis-vexilla-regis/naujalis-vexilla-regis.ly
+++ b/ftp/NaujalisJ/O7/naujalis-vexilla-regis/naujalis-vexilla-regis.ly
@@ -1,6 +1,5 @@
 \version "2.11.22"
 #(set-global-staff-size 18)
-%#(ly:set-option 'point-and-click #f)
 
 \paper {
 	%#(set-paper-size "letter")

--- a/ftp/RameauJP/HippolyteEtAricie/HippolyteEtAricie-lys/common/layout.ily
+++ b/ftp/RameauJP/HippolyteEtAricie/HippolyteEtAricie-lys/common/layout.ily
@@ -21,7 +21,6 @@
 
 #(set-default-paper-size (symbol->string (*paper-size*)))
 
-#(ly:set-option 'point-and-click #f)
 
 \paper {
   %% Page breaking

--- a/ftp/RameauJP/lesFetesDeRamire/lesFetesDeRamire-lys/common/common.ily
+++ b/ftp/RameauJP/lesFetesDeRamire/lesFetesDeRamire-lys/common/common.ily
@@ -1,6 +1,5 @@
 \include "italiano.ly"
 \version "2.11.27"
-#(ly:set-option 'point-and-click #f)
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Page layout

--- a/ftp/RegerM/O135a/reger_grosser_gott_wir_loben_dich/reger_grosser_gott_wir_loben_dich.ly
+++ b/ftp/RegerM/O135a/reger_grosser_gott_wir_loben_dich/reger_grosser_gott_wir_loben_dich.ly
@@ -33,7 +33,6 @@ tempoMark = #(define-music-function (parser location markp) (string?)
     after-title-space = #0.1
     between-title-space = #0.0
     ragged-last-bottom = ##f %% stretch and center systems of last page
-    #(ly:set-option 'point-and-click #f) %% for smaller PDFs
 }
 
 \layout {

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Alto.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Alto.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking) 	
     top-margin = 5\mm

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Basson1.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Basson1.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking) 	
     top-margin = 5\mm

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Basson2.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Basson2.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking) 	
     top-margin = 5\mm

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Clarinette1.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Clarinette1.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking) 	
     top-margin = 5\mm

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Clarinette2.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Clarinette2.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking) 	
     top-margin = 5\mm

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Contrebasse.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Contrebasse.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking) 	
     top-margin = 5\mm

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Cor1.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Cor1.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking) 	
     top-margin = 5\mm

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Cor2.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Cor2.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking) 	
     top-margin = 5\mm

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Flute1.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Flute1.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking) 	
     top-margin = 5\mm

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Flute2.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Flute2.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking) 	
     top-margin = 5\mm

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/GrosseCaisse.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/GrosseCaisse.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking) 	
     top-margin = 5\mm

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Hautbois1.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Hautbois1.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking) 	
     top-margin = 5\mm

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Hautbois2.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Hautbois2.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking) 	
     top-margin = 5\mm

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Piccolo.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Piccolo.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking) 	
     top-margin = 5\mm

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Score.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Score.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"   
                   
 #(set-global-staff-size 14)  
-#(ly:set-option 'point-and-click #f)
 \paper{ 
 		#(define page-breaking ly:minimal-breaking)
     top-margin = 5\mm

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/ScoreFrancais.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/ScoreFrancais.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"   
                   
 #(set-global-staff-size 14)  
-#(ly:set-option 'point-and-click #f)
 \paper{ 
 		#(define page-breaking ly:minimal-breaking)
     top-margin = 5\mm

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Tambour.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Tambour.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking) 	
     top-margin = 5\mm

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Timbales.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Timbales.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking) 	
     top-margin = 5\mm

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Trombone1.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Trombone1.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking) 	
     top-margin = 5\mm

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Trombone2.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Trombone2.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking) 	
     top-margin = 5\mm

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Trombone3.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Trombone3.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking) 	
     top-margin = 5\mm

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Trompette1.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Trompette1.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking) 	
     top-margin = 5\mm

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Trompette2.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Trompette2.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking) 	
     top-margin = 5\mm

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Violon1.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Violon1.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking) 	
     top-margin = 5\mm

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Violon2.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Violon2.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking) 	
     top-margin = 5\mm

--- a/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Violoncelle.ly
+++ b/ftp/RossiniG/Eduardo_e_Cristina/Eduardo_e_Cristina-lys/Violoncelle.ly
@@ -3,7 +3,6 @@
 \include "Global.lyp"                     
 
 #(set-global-staff-size 20)  
-#(ly:set-option 'point-and-click #f)
 
 \paper{ #(define page-breaking ly:page-turn-breaking) 	
     top-margin = 5\mm

--- a/ftp/RoyerJNP/PremierLivre/PremierLivre-lys/common/layout.ily
+++ b/ftp/RoyerJNP/PremierLivre/PremierLivre-lys/common/layout.ily
@@ -20,7 +20,6 @@
 
 #(set-default-paper-size (symbol->string (*paper-size*)))
 
-#(ly:set-option 'point-and-click #f)
 
 \paper {
   %% Margins, line width

--- a/ftp/SardainL/petitefille/petitefille-lys/petitefille.ly
+++ b/ftp/SardainL/petitefille/petitefille-lys/petitefille.ly
@@ -1,5 +1,4 @@
 \version "2.10.0"
-#(ly:set-option 'point-and-click #f)
 \include "catalan.ly"
 
 \include "1.ly"

--- a/ftp/SchubertF/D120/SchubertF-D120-TrostInThraenen/SchubertF-D120-TrostInThraenen.ly
+++ b/ftp/SchubertF/D120/SchubertF-D120-TrostInThraenen/SchubertF-D120-TrostInThraenen.ly
@@ -24,7 +24,6 @@ line-width = 186\mm
   " " { \italic "♫  Franz Schubert: Trost in Thränen (D.120)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup =  \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Trost in Thränen (D.120)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D162/SchubertF-D162_NaeheDesGeliebten/SchubertF-D162_NaeheDesGeliebten.ly
+++ b/ftp/SchubertF/D162/SchubertF-D162_NaeheDesGeliebten/SchubertF-D162_NaeheDesGeliebten.ly
@@ -23,7 +23,6 @@
   " " { \italic "♫  Franz Schubert: Nähe des Geliebten (D162)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup = \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Nähe des Geliebten (D162)  ♫" } " " }
- #(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D163/SchubertF-D163-D165_SaengersMorgenlied/SchubertF-D163-D165_SaengersMorgenlied.ly
+++ b/ftp/SchubertF/D163/SchubertF-D163-D165_SaengersMorgenlied/SchubertF-D163-D165_SaengersMorgenlied.ly
@@ -23,7 +23,6 @@
   " " { \italic "♫  Franz Schubert: Sängers Morgenlied (D163 & D165)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup = \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Sängers Morgenlied (D163 & D165)  ♫" } " " }
- #(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D210/SchubertF-D210-DieLiebe/SchubertF-D210-DieLiebe.ly
+++ b/ftp/SchubertF/D210/SchubertF-D210-DieLiebe/SchubertF-D210-DieLiebe.ly
@@ -26,7 +26,6 @@ line-width = 186\mm
   " " { \italic "♫  Franz Schubert: Die Liebe (D.210)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup =  \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Die Liebe (D.210)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D257/SchubertF-D257-Heidenroeslein/SchubertF-D257-Heidenroeslein.ly
+++ b/ftp/SchubertF/D257/SchubertF-D257-Heidenroeslein/SchubertF-D257-Heidenroeslein.ly
@@ -23,7 +23,6 @@ line-width = 186\mm
   " " { \italic "♫  Franz Schubert: Heidenröslein (D.257)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup =  \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Heidenröslein (D.257)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D259/SchubertF-D259-AnDenMond/SchubertF-D259-AnDenMond.ly
+++ b/ftp/SchubertF/D259/SchubertF-D259-AnDenMond/SchubertF-D259-AnDenMond.ly
@@ -24,7 +24,6 @@ line-width = 186\mm
   " " { \italic "♫  Franz Schubert: An den Mond (D.259)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup =  \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: An den Mond (D.259)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D296/SchubertF-D296-AnDenMond/SchubertF-D296-AnDenMond.ly
+++ b/ftp/SchubertF/D296/SchubertF-D296-AnDenMond/SchubertF-D296-AnDenMond.ly
@@ -26,7 +26,6 @@ after-title-space = 60\mm
   " " { \italic "♫  Franz Schubert: An den Mond (D.296)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup =  \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: An den Mond (D.296)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D328/Erlkoenig/Erlkoenig.ly
+++ b/ftp/SchubertF/D328/Erlkoenig/Erlkoenig.ly
@@ -101,7 +101,6 @@ noletNormal = {
 % SUPPRESSION DU PointAndClick
 PDFSimple =
 #(define-music-function (parser location) ()
-   (ly:set-option 'point-and-click #f)
    (make-music 'SequentialMusic 'void #t))
 \PDFSimple
 

--- a/ftp/SchubertF/D328/Erlkoenig_alt/Erlkoenig_alt-lys/Erlkoenig_alt.ly
+++ b/ftp/SchubertF/D328/Erlkoenig_alt/Erlkoenig_alt-lys/Erlkoenig_alt.ly
@@ -117,7 +117,6 @@ noletNormal = {
 % SUPPRESSION DU PointAndClick
 PDFSimple =
 #(define-music-function (parser location) ()
-   (ly:set-option 'point-and-click #f)
    (make-music 'SequentialMusic 'void #t))
 \PDFSimple
 

--- a/ftp/SchubertF/D493/SchubertF-D493_DerWanderer/SchubertF-D493_DerWanderer.ly
+++ b/ftp/SchubertF/D493/SchubertF-D493_DerWanderer/SchubertF-D493_DerWanderer.ly
@@ -23,7 +23,6 @@ line-width = 186\mm
   " " { \italic "♫  Franz Schubert: Der Wanderer (D.493)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup =  \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Der Wanderer (D.493)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D531/SchubertF-D531_DerTodUndDasMaedchen/SchubertF-D531_DerTodUndDasMaedchen.ly
+++ b/ftp/SchubertF/D531/SchubertF-D531_DerTodUndDasMaedchen/SchubertF-D531_DerTodUndDasMaedchen.ly
@@ -22,7 +22,6 @@ line-width = 186\mm
   " " { \italic "♫  Franz Schubert: Der Tod und das Mädchen (D.531)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup =  \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Der Tod und das Mädchen (D.531)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D547/AnDieMusik/AnDieMusik.ly
+++ b/ftp/SchubertF/D547/AnDieMusik/AnDieMusik.ly
@@ -57,7 +57,6 @@ cresD = { \set crescendoText = \markup { \italic "   cresc." } \set crescendoSpa
 % SUPPRESSION DU PointAndClick
 PDFSimple =
 #(define-music-function (parser location) ()
-   (ly:set-option 'point-and-click #f)
    (make-music 'SequentialMusic 'void #t))
 \PDFSimple
 

--- a/ftp/SchubertF/D686B/SchubertF-D686B-Fruehlingsglaube/SchubertF-D686B-Fruehlingsglaube.ly
+++ b/ftp/SchubertF/D686B/SchubertF-D686B-Fruehlingsglaube/SchubertF-D686B-Fruehlingsglaube.ly
@@ -24,7 +24,6 @@ between-system-padding = 8\mm
   " " { \italic "♫  Franz Schubert: Frühlingsglaube (D.686B)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup =  \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Frühlingsglaube (D.686B)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D691/SchubertF-D691_DieVoegel/SchubertF-D691_DieVoegel.ly
+++ b/ftp/SchubertF/D691/SchubertF-D691_DieVoegel/SchubertF-D691_DieVoegel.ly
@@ -23,7 +23,6 @@ line-width = 186\mm
   " " { \italic "♫  Franz Schubert: Die Vögel (D.691)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup =  \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Die Vögel (D.691)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D703/SchubertF-D703-Quartettsatz/SchubertF-D703-Quartettsatz.ly
+++ b/ftp/SchubertF/D703/SchubertF-D703-Quartettsatz/SchubertF-D703-Quartettsatz.ly
@@ -18,7 +18,6 @@
   " " { \italic "♫  Franz Schubert: Streichquartett No. 12 “Quartettsatz” in c-moll (D 703)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup = \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Streichquartett No. 12 “Quartettsatz” in c-moll (D 703)  ♫" } " " }
- #(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D706/SchubertF-D706-Psalm23/SchubertF-D706-Psalm23.ly
+++ b/ftp/SchubertF/D706/SchubertF-D706-Psalm23/SchubertF-D706-Psalm23.ly
@@ -20,7 +20,6 @@
   " " { \italic "♫  Franz Schubert: Psalm 23 (D 706)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup = \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Psalm 23 (D 706)  ♫" } " " }
- #(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D717/SchubertF-D717-Suleika-2/SchubertF-D717-Suleika-2.ly
+++ b/ftp/SchubertF/D717/SchubertF-D717-Suleika-2/SchubertF-D717-Suleika-2.ly
@@ -26,7 +26,6 @@ line-width = 186\mm
   " " { \italic "♫  Franz Schubert: Suleika 2 (D.717)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup =  \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Suleika 2 (D.717)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D720/SchubertF-D720-Suleika-1/SchubertF-D720-Suleika-1.ly
+++ b/ftp/SchubertF/D720/SchubertF-D720-Suleika-1/SchubertF-D720-Suleika-1.ly
@@ -25,7 +25,6 @@ oddHeaderMarkup  = \markup \fill-line {
  " " { \italic "♫  Franz Schubert: Suleika 1 (D.720)  ♫" }  \fromproperty #'page:page-number-string }
 evenHeaderMarkup =  \markup \fill-line {
  \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Suleika 1 (D.720)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D733/SchubertF-D733-1-TroisMarches/SchubertF-D733-1-TroisMarches.ly
+++ b/ftp/SchubertF/D733/SchubertF-D733-1-TroisMarches/SchubertF-D733-1-TroisMarches.ly
@@ -24,7 +24,6 @@ oddHeaderMarkup  = \markup \fontsize #2 \fill-line {
   " " { \italic "♫  Franz Schubert: Trois Marches militaires (D.733-1)  ♫" }  \fromproperty #'page:page-number-string }
 evenHeaderMarkup = \markup \fontsize #2 \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Trois Marches militaires (D.733-1)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D733/SchubertF-D733-2-TroisMarches/SchubertF-D733-2-TroisMarches.ly
+++ b/ftp/SchubertF/D733/SchubertF-D733-2-TroisMarches/SchubertF-D733-2-TroisMarches.ly
@@ -25,7 +25,6 @@ oddHeaderMarkup  = \markup \fontsize #2 \fill-line {
   " " { \italic "♫  Franz Schubert: Trois Marches militaires (D.733-2)  ♫" }  \fromproperty #'page:page-number-string }
 evenHeaderMarkup = \markup \fontsize #2 \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Trois Marches militaires (D.733-2)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 

--- a/ftp/SchubertF/D733/SchubertF-D733-3-TroisMarches/SchubertF-D733-3-TroisMarches.ly
+++ b/ftp/SchubertF/D733/SchubertF-D733-3-TroisMarches/SchubertF-D733-3-TroisMarches.ly
@@ -25,7 +25,6 @@ oddHeaderMarkup  = \markup \fontsize #2 \fill-line {
   " " { \italic "♫  Franz Schubert: Trois Marches militaires (D.733-3)  ♫" }  \fromproperty #'page:page-number-string }
 evenHeaderMarkup = \markup \fontsize #2 \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Trois Marches militaires (D.733-3)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D743/SchubertF-D743-SeligeWelt/SchubertF-D743-SeligeWelt.ly
+++ b/ftp/SchubertF/D743/SchubertF-D743-SeligeWelt/SchubertF-D743-SeligeWelt.ly
@@ -25,7 +25,6 @@ between-system-padding = 10\mm
   " " { \italic "♫  Franz Schubert: Selige Welt (D.743)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup =  \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Selige Welt (D.743)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D744/SchubertF-D744-Schwanengesang/SchubertF-D744-Schwanengesang.ly
+++ b/ftp/SchubertF/D744/SchubertF-D744-Schwanengesang/SchubertF-D744-Schwanengesang.ly
@@ -26,7 +26,6 @@ between-system-padding = 10\mm
   " " { \italic "♫  Franz Schubert: Schwanengesang (D.744)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup =  \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Schwanengesang (D.744)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D751/SchubertF-D751-DieLiebeHatGelogen/SchubertF-D751-DieLiebeHatGelogen.ly
+++ b/ftp/SchubertF/D751/SchubertF-D751-DieLiebeHatGelogen/SchubertF-D751-DieLiebeHatGelogen.ly
@@ -23,7 +23,6 @@ line-width = 186\mm
   " " { \italic "♫  Franz Schubert: Die Liebe hat gelogen (D.751)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup =  \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Die Liebe hat gelogen (D.751)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D764/SchubertF-D764-DerMusensohn/SchubertF-D764-DerMusensohn.ly
+++ b/ftp/SchubertF/D764/SchubertF-D764-DerMusensohn/SchubertF-D764-DerMusensohn.ly
@@ -23,7 +23,6 @@ line-width = 186\mm
   " " { \italic "♫  Franz Schubert: Der Musensohn (D.764)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup =  \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Der Musensohn (D.764)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D774/SchubertF-D774_AufDemWasserZuSingen/SchubertF-D774_AufDemWasserZuSingen.ly
+++ b/ftp/SchubertF/D774/SchubertF-D774_AufDemWasserZuSingen/SchubertF-D774_AufDemWasserZuSingen.ly
@@ -21,7 +21,6 @@
   " " { \italic "♫  Franz Schubert: Auf dem Wasser zu singen (D 774)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup = \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Auf dem Wasser zu singen (D 774)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D776/SchubertF-D776_DuBistDieRuh/SchubertF-D776_DuBistDieRuh.ly
+++ b/ftp/SchubertF/D776/SchubertF-D776_DuBistDieRuh/SchubertF-D776_DuBistDieRuh.ly
@@ -21,7 +21,6 @@
   " " { \italic "♫  Franz Schubert: Du bist die Ruh (D 776)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup = \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Du bist die Ruh (D 776)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D777/SchubertF-D777-LachenUndWeinen/SchubertF-D777-LachenUndWeinen.ly
+++ b/ftp/SchubertF/D777/SchubertF-D777-LachenUndWeinen/SchubertF-D777-LachenUndWeinen.ly
@@ -23,7 +23,6 @@ line-width = 186\mm
   " " { \italic "♫  Franz Schubert: Lachen und Weinen (D.777)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup =  \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Lachen und Weinen (D.777)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D827/SchubertF-D827_NachtUndTraeume/SchubertF-D827_NachtUndTraeume.ly
+++ b/ftp/SchubertF/D827/SchubertF-D827_NachtUndTraeume/SchubertF-D827_NachtUndTraeume.ly
@@ -23,7 +23,6 @@ line-width = 186\mm
   " " { \italic "♫  Franz Schubert: Nacht und Träume (D.827)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup =  \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Nacht und Träume (D.827)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D828/SchubertF-D828_DieJungeNonne/SchubertF-D828_DieJungeNonne.ly
+++ b/ftp/SchubertF/D828/SchubertF-D828_DieJungeNonne/SchubertF-D828_DieJungeNonne.ly
@@ -23,7 +23,6 @@ line-width = 186\mm
   " " { \italic "♫  Franz Schubert: Die junge Nonne (D.828)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup =  \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Die junge Nonne (D.828)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D839/SchubertF-D839_AveMaria/SchubertF-D839_AveMaria.ly
+++ b/ftp/SchubertF/D839/SchubertF-D839_AveMaria/SchubertF-D839_AveMaria.ly
@@ -22,7 +22,6 @@
   " " { \italic "♫  Franz Schubert: Ave Maria (D 839)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup =  \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Ave Maria (D 839)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D881B/SchubertF-D881B-Fischerweise/SchubertF-D881B-Fischerweise.ly
+++ b/ftp/SchubertF/D881B/SchubertF-D881B-Fischerweise/SchubertF-D881B-Fischerweise.ly
@@ -24,7 +24,6 @@ between-system-padding = 7\mm
   " " { \italic "♫  Franz Schubert: Fischerweise (D.881B)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup =  \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Fischerweise (D.881B)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D882/SchubertF-D882_ImFruehling/SchubertF-D882_ImFruehling.ly
+++ b/ftp/SchubertF/D882/SchubertF-D882_ImFruehling/SchubertF-D882_ImFruehling.ly
@@ -23,7 +23,6 @@ line-width = 186\mm
   " " { \italic "♫  Franz Schubert: Im Frühling (D.882)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup =  \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Im Frühling (D.882)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D899/SchubertF-D899-1-Impromptu/SchubertF-D899-1-Impromptu.ly
+++ b/ftp/SchubertF/D899/SchubertF-D899-1-Impromptu/SchubertF-D899-1-Impromptu.ly
@@ -20,7 +20,6 @@
   " " { \italic "♫  Franz Schubert: Impromptu in c-moll (D 899-1)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup = \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Impromptu in c-moll (D 899-1)  ♫" } " " }
- #(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D899/SchubertF-D899-2-Impromptu/SchubertF-D899-2-Impromptu.ly
+++ b/ftp/SchubertF/D899/SchubertF-D899-2-Impromptu/SchubertF-D899-2-Impromptu.ly
@@ -22,7 +22,6 @@ oddHeaderMarkup  = \markup \fill-line {
   " " { \italic "♫  Franz Schubert: Impromptu in Es-dur (D.899-2)  ♫" }  \fromproperty #'page:page-number-string }
 evenHeaderMarkup = \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Impromptu in Es-dur (D.899-2)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 

--- a/ftp/SchubertF/D899/SchubertF-D899-3-Impromptu/SchubertF-D899-3-Impromptu.ly
+++ b/ftp/SchubertF/D899/SchubertF-D899-3-Impromptu/SchubertF-D899-3-Impromptu.ly
@@ -23,7 +23,6 @@
   " " { \italic "♫  Franz Schubert: Impromptu in Ges-dur (D 899-3)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup = \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Impromptu in Ges-dur (D 899-3)  ♫" } " " }
- #(ly:set-option 'point-and-click #f)
 }
 
 

--- a/ftp/SchubertF/D899/SchubertF-D899-4-Impromptu/SchubertF-D899-4-Impromptu.ly
+++ b/ftp/SchubertF/D899/SchubertF-D899-4-Impromptu/SchubertF-D899-4-Impromptu.ly
@@ -22,7 +22,6 @@ oddHeaderMarkup  = \markup \fill-line {
   " " { \italic "♫  Franz Schubert: Impromptu in As-dur (D.899-4)  ♫" }  \fromproperty #'page:page-number-string }
 evenHeaderMarkup = \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Impromptu in As-dur (D.899-4)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 

--- a/ftp/SchubertF/D935/SchubertF-D935-1-Impromptu/SchubertF-D935-1-Impromptu.ly
+++ b/ftp/SchubertF/D935/SchubertF-D935-1-Impromptu/SchubertF-D935-1-Impromptu.ly
@@ -20,7 +20,6 @@
   " " { \italic "♫  Franz Schubert: Impromptu in f-moll (D935-1)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup = \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Impromptu in f-moll (D935-1)  ♫" } " " }
- #(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D935/SchubertF-D935-2-Impromptu/SchubertF-D935-2-Impromptu.ly
+++ b/ftp/SchubertF/D935/SchubertF-D935-2-Impromptu/SchubertF-D935-2-Impromptu.ly
@@ -20,7 +20,6 @@
   " " { \italic "♫  Franz Schubert: Impromptu in As-dur (D 935-2)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup = \markup \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Impromptu in As-dur (D 935-2)  ♫" } " " }
- #(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D962/SchubertF-D962-TantumErgo/SchubertF-D962-TantumErgo.ly
+++ b/ftp/SchubertF/D962/SchubertF-D962-TantumErgo/SchubertF-D962-TantumErgo.ly
@@ -25,7 +25,6 @@ indent = 5\mm
   " " { \italic "♫  Franz Schubert: Tantum ergo in Es-Dur (D.962)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup = \markup \fontsize #3 \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Tantum ergo in Es-Dur (D.962)  ♫" } " " }
- #(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D965/SchubertF-D965-DerHirtAufDemFelsen/SchubertF-D965-DerHirtAufDemFelsen-lys/SchubertF-D965-DerHirtAufDemFelsen.ly
+++ b/ftp/SchubertF/D965/SchubertF-D965-DerHirtAufDemFelsen/SchubertF-D965-DerHirtAufDemFelsen-lys/SchubertF-D965-DerHirtAufDemFelsen.ly
@@ -25,7 +25,6 @@ oddHeaderMarkup  = \markup \fontsize #1 \fill-line {
  " " { \italic "♫  Franz Schubert: Der Hirt auf dem Felsen (D.965)  ♫" }  \fromproperty #'page:page-number-string }
 evenHeaderMarkup = \markup \fontsize #1 \fill-line {
  \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Der Hirt auf dem Felsen (D.965)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D983/SchubertF-D983A_Liebe/SchubertF-D983A_Liebe.ly
+++ b/ftp/SchubertF/D983/SchubertF-D983A_Liebe/SchubertF-D983A_Liebe.ly
@@ -24,7 +24,6 @@ line-width = 186\mm
   " " { \italic "♫  Franz Schubert: Liebe (D.983A)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup =  \markup \fontsize #2 \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Liebe (D.983A)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D983/SchubertF-D983B_ZumRundetanz/SchubertF-D983B_ZumRundetanz.ly
+++ b/ftp/SchubertF/D983/SchubertF-D983B_ZumRundetanz/SchubertF-D983B_ZumRundetanz.ly
@@ -24,7 +24,6 @@ line-width = 186\mm
   " " { \italic "♫  Franz Schubert: Zum Rundetanz (D.983A)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup =  \markup \fontsize #2 \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Zum Rundetanz (D.983A)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D983/SchubertF-D983C_DieNacht/SchubertF-D983C_DieNacht.ly
+++ b/ftp/SchubertF/D983/SchubertF-D983C_DieNacht/SchubertF-D983C_DieNacht.ly
@@ -24,7 +24,6 @@ line-width = 186\mm
   " " { \italic "♫  Franz Schubert: Die Nacht (D.983C)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup =  \markup \fontsize #2 \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Die Nacht (D.983C)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/SchubertF/D983/SchubertF-D983_Juenglingswonne/SchubertF-D983_Juenglingswonne.ly
+++ b/ftp/SchubertF/D983/SchubertF-D983_Juenglingswonne/SchubertF-D983_Juenglingswonne.ly
@@ -24,7 +24,6 @@ line-width = 186\mm
   " " { \italic "♫  Franz Schubert: Jünglingswonne (D.983)  ♫" }  \fromproperty #'page:page-number-string }
  evenHeaderMarkup =  \markup \fontsize #2 \fill-line {
   \fromproperty #'page:page-number-string { \italic "♫  Franz Schubert: Jünglingswonne (D.983)  ♫" } " " }
-#(ly:set-option 'point-and-click #f)
 }
 
 \header {

--- a/ftp/ScriabinA/O11/Scriabin_prelude_op11no1/Scriabin_prelude_op11no1.ly
+++ b/ftp/ScriabinA/O11/Scriabin_prelude_op11no1/Scriabin_prelude_op11no1.ly
@@ -32,7 +32,7 @@
   ragged-bottom = ##f
   ragged-last-bottom = ##f
 }
-\pointAndClickOff
+
 
 % Definitions to override page-breaking 
 myExplicitBreak = {

--- a/ftp/SidwellA/little-toy-lost/little-toy-lost.ly
+++ b/ftp/SidwellA/little-toy-lost/little-toy-lost.ly
@@ -1,7 +1,6 @@
 \version "2.9.18"
 \include "english.ly"
 
-#(ly:set-option 'point-and-click #f)
 
 \header
 {

--- a/ftp/SidwellA/miniature-2/miniature-2.ly
+++ b/ftp/SidwellA/miniature-2/miniature-2.ly
@@ -8,7 +8,6 @@
 % changes, I'd love to hear them!  My current email address can always be found
 % at my website (http://entai.co.uk).
 
-#(ly:set-option 'point-and-click #f)
 
 \header
 {

--- a/ftp/SittH/O32/Hans_Sitt-100_Etudes_Op32-Book1/Hans_Sitt-100_Etudes_Op32-Book1-lys/defs.ly
+++ b/ftp/SittH/O32/Hans_Sitt-100_Etudes_Op32-Book1/Hans_Sitt-100_Etudes_Op32-Book1-lys/defs.ly
@@ -1,7 +1,6 @@
 % -*- coding: utf-8 -*-
 \version "2.12.3"
 
-#( ly:set-option 'point-and-click #f )
 #(use-modules (srfi srfi-39))
 #(define *use-letter-paper* (make-parameter (ly:get-option 'letter)))
 

--- a/ftp/SousaJP/sousa_washington_post/sousa_washington_post.ly
+++ b/ftp/SousaJP/sousa_washington_post/sousa_washington_post.ly
@@ -5,7 +5,6 @@
 \paper {
   ragged-bottom=##f
   ragged-last-bottom=##f
-#(ly:set-option 'point-and-click #f)
 } 
 
 

--- a/ftp/TarregaF/adelita-duo/adelita-duo.ly
+++ b/ftp/TarregaF/adelita-duo/adelita-duo.ly
@@ -52,8 +52,6 @@
   evenFooterMarkup = \oddFooterMarkup
 }
 
-% suppress local file system path in pdf
-#(ly:set-option 'point-and-click #f)
 
 % guitar neck position indicators
 pI    = ^\markup { "I" }

--- a/ftp/TarregaF/adelita/adelita.ly
+++ b/ftp/TarregaF/adelita/adelita.ly
@@ -1,6 +1,5 @@
 \version "2.8.0"
 
-#(ly:set-option 'point-and-click #f)
 #(set-global-staff-size 20)
 
 moveFingering = #(define-music-function (parser location shift) (pair?)

--- a/ftp/TarregaF/lagrima-duo/lagrima-duo.ly
+++ b/ftp/TarregaF/lagrima-duo/lagrima-duo.ly
@@ -52,8 +52,6 @@
   evenFooterMarkup = \oddFooterMarkup
 }
 
-% suppress local file system path in pdf
-#(ly:set-option 'point-and-click #f)
 
 % guitar neck position indicators
 pI    = ^\markup { "I" }

--- a/ftp/TarregaF/recuerdos/recuerdos-lys/recuerdos-a4.ly
+++ b/ftp/TarregaF/recuerdos/recuerdos-lys/recuerdos-a4.ly
@@ -1,6 +1,5 @@
 \version "2.8.0"
 
-#(ly:set-option 'point-and-click #f)
 %set to 19.5 - at 20, page breaking goes weird with letter
 #(set-global-staff-size 19.5)
 #(set-default-paper-size "a4")

--- a/ftp/TarregaF/recuerdos/recuerdos-lys/recuerdos-let.ly
+++ b/ftp/TarregaF/recuerdos/recuerdos-lys/recuerdos-let.ly
@@ -1,6 +1,5 @@
 \version "2.8.0"
 
-#(ly:set-option 'point-and-click #f)
 %set to 19.5 - at 20, page breaking goes weird with letter
 #(set-global-staff-size 19.5)
 #(set-default-paper-size "letter")

--- a/ftp/TchaikovskyPI/O37/Tschaikowsky-op37.1/Tschaikowsky-op37.1.ly
+++ b/ftp/TchaikovskyPI/O37/Tschaikowsky-op37.1/Tschaikowsky-op37.1.ly
@@ -1,5 +1,4 @@
 \version "2.11.0"
-#(ly:set-option 'point-and-click #f)
 \header {
   filename = "Tschaikowsky-op37,1.ly"
   title = \markup {

--- a/ftp/TchaikovskyPI/O37/Tschaikowsky-op37.2/Tschaikowsky-op37.2.ly
+++ b/ftp/TchaikovskyPI/O37/Tschaikowsky-op37.2/Tschaikowsky-op37.2.ly
@@ -1,5 +1,4 @@
 \version "2.10.0"
-%#(ly:set-option 'point-and-click #f)
 \header {
   filename = "Tschaikowsky-op37,2.ly"
   title = \markup {

--- a/ftp/Traditional/SingIvy/SingIvy.ly
+++ b/ftp/Traditional/SingIvy/SingIvy.ly
@@ -1,4 +1,3 @@
-#(ly:set-option 'point-and-click #f)
 
 \version "2.8.3"
 

--- a/ftp/Traditional/oatsandbeans/oatsandbeans.ly
+++ b/ftp/Traditional/oatsandbeans/oatsandbeans.ly
@@ -1,4 +1,3 @@
-#(ly:set-option 'point-and-click #f)
 \version "2.10.0"
 \header {
     title = "Oats and Beans"

--- a/ftp/Traditional/wateroftyne/wateroftyne.ly
+++ b/ftp/Traditional/wateroftyne/wateroftyne.ly
@@ -1,4 +1,3 @@
-#(ly:set-option 'point-and-click #f)
 \version "2.10.0"
 \header {
     title = "The Water of Tyne"

--- a/ftp/VeliumovA/veliumov-great-doxology/veliumov-great-doxology.ly
+++ b/ftp/VeliumovA/veliumov-great-doxology/veliumov-great-doxology.ly
@@ -38,7 +38,6 @@ Text translation:
 %}
 
 #(set-global-staff-size 20)
-#(ly:set-option 'point-and-click #f)
 
 dtDown = { \once\override DynamicText #'extra-offset = #'(0 . -1) }
 hpLeftDown = { \once\override Hairpin #'extra-offset = #'(-3 . -1.5) }


### PR DESCRIPTION
This is the first of two pull requests to close issue #994 

I left all the commented `%\pointAndClickOff` on purpose.

@glenl I think there's only one piece where point and click is set on explicitely. Here's the grep on this branch:

```
$ git grep "'point-and-click" ftp/*
ftp/TchaikovskyPI/O37/Tschaikowsky-op37.8/Tschaikowsky-op37.8.ly:2:%#(ly:set-option 'point-and-click #t)
```
