### PR TITLE
New movement: Mozart KV 488, Andante, all instruments

### DIFF
--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/bassoon.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/bassoon.ily
@@ -1,2 +1,128 @@
 bassoon = \relative c {
+  \barNumberCheck #1
+  \solo
+  R2.*11
+
+  \barNumberCheck #12
+  \tutti
+  <<
+    {
+      R2. |
+      r4 r8 b'4.~^\p |
+      b8( a gis fis gis a) |
+      d,4. d'4.~ |
+      d8( cis b a gis fis) |
+      dis'4.( d4.) |
+      g8 fis e d4. |
+      cis8( b) a~( a b) gis |
+    } \\
+    {
+      fis,2.~ \p |
+      fis4.( gis) \p |
+      a2. |
+      b2. |
+      cis4. fis,4. \f |
+      bis4.( b4.) |
+      ais4.( b8) b'( a!) |
+      gis!8( eis) fis~ fis gis eis |
+    } \\
+  >>
+
+  \barNumberCheck #20
+  \solo
+  << fis4 \\ fis4 >> r8 r4 r8 |
+  R2.*11 |
+
+  \barNumberCheck #32
+  R2. |
+  <<
+    {
+      b4.( c4.) |
+      b4
+    } \\
+    {
+      gis4.( \p a4.) |
+      gis4
+    }
+  >>
+  r8 r4 r8 |
+
+  \barNumberCheck #35
+  \tutti
+  R2.*2 |
+  <<
+    {
+      r16( a b cis! d b cis16 gis a cis d dis) |
+      \barNumberCheck #38
+      e16( dis e dis e cis << { s16 \solo } b8) >>
+    } \\
+    {
+      r4 r8 r8 r16 a( b bis) |
+      \barNumberCheck #38
+      cis16( bis cis bis cis a << { s16 \solo } gis8) >>
+    } \\
+  >>
+  r8 r8 |
+  <<
+    {
+      a4 a8 a4 a8 |
+      gis8-. gis-. gis-. gis8
+    } \\
+    {
+      a,4 a8 a4 a8 |
+      gis8-. gis-. gis-. gis8
+    } \\
+  >> r8 r8 |
+  R2. |
+  R2. |
+  r8
+  <<
+    { gis'8( a) e8 } \\
+    { gis,8( a) e8 } \\
+  >>
+  r8 r8 |
+  <<
+    { a'8( cis gis) a8 } \\
+    { a,8( cis e) a8 } \\
+  >>
+  r8 r8 |
+  R2. |
+  <<
+    {
+      r4 r8 \tuplet 3/2 8 { r16 b a gis fis e d cis b } |
+      r4 r8 \tuplet 3/2 8 { r16 cis' b a gis fis e d cis } |
+    } \\
+    { R2.*2 | } \\
+  >> |
+  R2. |
+  <<
+    {
+      cis'2.( |
+      b2.) |
+    } \\
+    {
+      a2.~ |
+      a4. gis4. |
+    } \\
+  >> |
+
+  \barNumberCheck #51
+  <<
+    {
+      \barNumberCheck #51
+      a8[ \tutti r8 a]( b8[) r b]( |
+      cis8[) r cis]( cis,8[) r cis] |
+      \barNumberCheck #53
+      \solo
+      fis4 r8 r4 r8 |
+    } \\
+    {
+      \barNumberCheck #51
+      a8 \tutti r r r4 r8 |
+      R2. |
+      \barNumberCheck #53
+      \solo
+      R2. |
+    } \\
+  >> |
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/bassoon.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/bassoon.ily
@@ -125,4 +125,95 @@ bassoon = \relative c {
       R2. |
     } \\
   >> |
+
+  \barNumberCheck #54
+  R2.*10 |
+  <<
+    {
+      d2.~ |
+      d8
+    } \\
+    {
+      d,2.( \p |
+      b8)
+    } \\
+  >>
+  r8 r8 r4 r8 |
+  R2. |
+  R2. |
+
+  \barNumberCheck #68
+  \tutti
+  <<
+    {
+      R2. |
+      r4 r8 b'4.~^\p |
+      b8( a gis fis gis a) |
+      d,4. d'4.~ |
+      d8( cis b a8 gis fis) |
+      dis'4.( d4.) |
+      g8( fis e) d4. |
+      cis8( b) a~( a b) gis |
+    } \\
+    {
+      fis,2.~ \p |
+      fis4. gis4. |
+      a2. |
+      b2. |
+      cis4. fis,4. \f |
+      bis4.( b4.) |
+      ais4.( b8) b'8( a!) |
+      gis8( eis) fis~ fis8 gis eis |
+    } \\
+  >>
+
+  \barNumberCheck #76
+  \solo
+  << fis4 \\ fis4 >> r8 r4 r8 |
+  R2.*3 |
+  <<
+    {
+      r4 r8 r16 cis \p fis a cis cis, |
+      r4 r8 r16 cis eis gis cis cis, |
+      r4 r8 r16 cis fis a! cis cis, |
+      r4 r8 r16 cis eis gis cis cis, |
+      fis4 r8 r4 r8 |
+    } \\
+    { R2.*5 | } \\
+  >> |
+  R2.*3 |
+  <<
+    {
+      fis'2.~ \p |
+      fis2. |
+      d2. |
+      fis4.( eis4.) |
+      fis8
+    } \\
+    {
+      cis2.( |
+      d2.) |
+      b2. |
+      cis2. |
+      a8
+    } \\
+  >>
+  r8 r8 r4 r8 |
+  R2.*3 |
+  <<
+    {
+      r4 r8 a4.~ |
+      a8( gis fis eis fis gis) |
+    } \\
+    {
+      R2. |
+      R2. |
+    } \\
+  >> |
+  << { fis8-. a-. } \\ { fis8-. fis8-. } >> r8
+  << { fis'8-. \pp fis-. } \\ { fis,8-. fis8-. } >> r8 |
+  << { fis'8-. fis-. } \\ { fis,8-. fis8-. } >> r8 r4 r8 |
+  \bar "|."
+
+  \barNumberCheck #100
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/cello.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/cello.ily
@@ -1,2 +1,60 @@
 cello = \relative c {
+  \barNumberCheck #1
+  \solo
+  R2.*11 |
+
+  \barNumberCheck #12
+  \tutti
+  fis8 \p r r fis8 r r |
+  fis8 r r gis8 r r |
+  a8 r r a,8 r r |
+  b8 r r b'8 r r |
+  cis8 r r fis,8 \f r r |
+  bis,8 r r b8 r r |
+  ais4. b8( g' fis) |
+  eis8( cis fis) d8( b cis) |
+
+  \barNumberCheck #20
+  \solo
+  fis,4 r8 r4 r8 |
+  R2.*4 |
+  gis'2. \p |
+  a4.( cis,4.) |
+  d4.( dis4.) |
+  e8 r r e8 r r |
+  e8 r r e8 r r |
+  e8 r r e8 r r |
+  f8 \f r r f8 \p r r |
+  e2.~ |
+  e2.~ |
+  e4 r8 r4 r8 |
+
+  \barNumberCheck #35
+  \tutti
+  a4 a8 a4 a8 |
+  gis4 gis8 gis4 e8 |
+  a4 r8 r4 r8 |
+
+  \barNumberCheck #38
+  e8 e e << { s16 \solo } e8 >> r r |
+  R2. |
+  r4 r8 r8 r e8( \p |
+  fis8) r r d8 r r |
+  e4.( a,8) r r |
+  R2. |
+  R2. |
+  r8 d( e) a,8 r r |
+  r8 gis( a) e'8 r r |
+  a,8( cis e) fis8 r r |
+  d4.( dis4.) |
+  e4 r8 e4 r8 |
+  e4 r8 e4 r8 |
+
+  \barNumberCheck #51
+  a,8 \tutti r r b8 r r |
+  cis8 r r cis8 r r |
+
+  \barNumberCheck #53
+  \solo
+  fis4 r8 r4 r8 |
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/cello.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/cello.ily
@@ -57,4 +57,54 @@ cello = \relative c {
   \barNumberCheck #53
   \solo
   fis4 r8 r4 r8 |
+  R2.*14 |
+
+  \barNumberCheck #68
+  \tutti
+  fis8 \p r r fis8 r r |
+  fis8 r r gis8 r r |
+  a8 r r a,8 r r |
+  b8 r r b'8 r r |
+  cis8 r r fis,8 \f r r |
+  bis,8 r r b8 r r |
+  ais4.( b8)( g' fis) |
+  eis8( cis fis) d8( b cis) |
+
+  \barNumberCheck #76
+  \solo
+  fis,8 r r fis'8 \p r r |
+  fis8 r r gis8 r r |
+  a8 r r a8 r r |
+  b8 r r b,8 r r |
+  cis2.~ |
+  cis2.~ |
+  cis2.~ |
+  cis2. |
+
+  \barNumberCheck #84
+  \set Staff.midiInstrument = "pizzicato strings"
+  fis8-\pizz a cis a8 fis cis |
+  d8 fis a fis8 d a |
+  b8 d cis b8 a gis |
+  cis8 fis a cis,8 eis gis |
+  fis8 a cis a8 fis cis |
+  d8 fis a fis8 d a |
+  b8 d g b8 g b, |
+  % Note: In the original score, this gis has a courtesy accidental,
+  % even though the corresponding gis in bar 87 does not. We reproduce
+  % this despite the inconsistency.
+  cis8 fis a cis,8 eis gis! |
+
+  \barNumberCheck #92
+  fis8 r r \set Staff.midiInstrument = "cello" a,8-\arco r r |
+  b8 r r cis8 r r |
+  a8 r r d8 r r |
+  b8 r r cis8 r r |
+  a8 r r bis8 r r |
+  cis8 r r cis8 r r |
+  fis8 r r fis8 \pp r r |
+  fis8 r r r4 r8 |
+  \bar "|."
+
+  \barNumberCheck #100
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/clarinet.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/clarinet.ily
@@ -1,2 +1,106 @@
 clarinet = \relative c'' {
+  % Note that ``\transposition a'' is in effect.
+
+  \barNumberCheck #1
+  \solo
+  R2.*11
+
+  \barNumberCheck #12
+  \tutti
+  <<
+    {
+      r4 r8 c'4.~ \p |
+      c8( b a gis8 a b) |
+      e,4. r4 r8 |
+    } \\
+    { R2.*3 | } \\
+  >> |
+  R2. |
+  r4 r8
+  <<
+    {
+      c'4.~ \f |
+      c8 b a gis8 a b |
+      bes8( a g!) f4. |
+      e8( d) c~( c8 d) b |
+      \barNumberCheck #20
+      \solo
+      a4
+    } \\
+    {
+      e'4. |
+      fis4.( f4.) |
+      e4.~ e8 d( c) |
+      b!8( gis) a~ a8 b gis |
+      \barNumberCheck #20
+      \solo
+      a4
+    } \\
+  >>
+  r8 r4 r8 |
+  R2.*11 |
+
+  <<
+    {
+      d4.( \p ees4.) |
+      d8
+    } \\
+    {
+      b4.( c4.) |
+      b8
+    } \\
+  >> r8 r8 r4 r8 |
+  R2. |
+
+  \barNumberCheck #35
+  \tutti
+  <<
+    {
+      e!4. c4 d32( c b c) |
+      d8 d d d8 r r |
+      r16 e( f g a b c16 d e) e,( f fis) |
+      \barNumberCheck #38
+      g16( fis g fis g e << { s16 \solo} d8) >>
+    } \\
+    {
+      \tuplet 3/2 8 {
+        g,,16 c e g e c g c e g,16 c e g e c g c e |
+        g,16 b d g d b g b d g,16 b d g d b g b d |
+      }
+      c8 r r r8 r16 c'( d dis) |
+      \barNumberCheck #38
+      e16( dis e dis e c << { s16 \solo } b8) >>
+    } \\
+  >> r8 r8 |
+
+  <g' e>4. <e c>4 <f! d>32( <e c> <d b> <e c>) |
+  <f d>8-. q-. q-. q8-. r r |
+  R2. |
+  R2. |
+  <f d>4( <e c>8) <d b>8 r r |
+  <g e>4( <f d>8) <e c>8 r r |
+  R2.*6 |
+
+  \barNumberCheck #51
+  <<
+    {
+      \barNumberCheck #51
+      s8 \tutti s s s4 s8 |
+      s2. |
+      \barNumberCheck #53
+      \solo
+    }
+    {
+      e4.( d4.) |
+      c4. b4( d8) |
+      c4
+    } \\
+    {
+      c4.~ c8 b4~ |
+      b8 a4~ a8 gis b |
+      a4
+    } \\
+  >> r8 r4 r8 |
+
+  \barNumberCheck #54
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/clarinet.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/clarinet.ily
@@ -103,4 +103,93 @@ clarinet = \relative c'' {
   >> r8 r4 r8 |
 
   \barNumberCheck #54
+  R2.*10 |
+  <<
+    {
+      f'2.~ \p |
+      f8
+    } \\
+    {
+      a,2.( |
+      bes8)
+    } \\
+  >> r8 r8 r4 r8 |
+  R2. |
+  R2. |
+
+  \barNumberCheck #68
+  \tutti
+  <<
+    {
+      r4 r8 c'4.~^\p |
+      c8( (b a gis a b) |
+      e,4. r4 r8 |
+    } \\
+    {
+      R2. |
+      R2. |
+      R2. |
+    } \\
+  >> |
+  R2. |
+  r4 r8
+  <<
+    {
+      c'4.~ \f |
+      c8( (b a gis a b) |
+      bes8 a g f4. |
+      e8( d) c~( c8 d) b |
+    } \\
+    {
+      e4. |
+      fis4. f4. |
+      e4.~ e8( d c) |
+      b8( gis) a~( a8 b) gis |
+    } \\
+  >> |
+
+  \barNumberCheck #76
+  \solo
+  << a4 \\ a4 >> r8 r4 r8 |
+  R2.*3 |
+  <<
+    {
+      r4 r8 c'4.~ |
+      c4. b4.~ |
+      b4. a4.~ |
+      a4.( gis4.) |
+      a4
+    } \\
+    {
+      e2. \p |
+      dis4.( d4. |
+      cis4. c4.) |
+      b2. |
+      a4
+    } \\
+  >> r8 r4 r8 |
+  R2.*3 |
+
+  <a' e>2.( \p |
+  <a f>2.) |
+  <bes bes,>2. |
+  <a c,>4.( <gis b,!>4.) |
+  <a a,>8 r r r4 r8 |
+  R2. |
+
+  <<
+    {
+      r4 r8 c,4.~ |
+      c8( b a gis8 a b) |
+      e,4. c'4.~ |
+      c8( b a gis8 a b) |
+    } \\
+    { R2.*4 | } \\
+  >> |
+  << { a8[-. e']-. } \\ { a,[-. c]-. } >> r
+  << { a'8[-. \pp a]-. } \\ { c,[-. c]-. } >> r |
+  << { c'8[-. c]-. } \\ { e,[-. e]-. } >> r r4 r8 |
+  \bar "|."
+
+  \barNumberCheck #100
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/flute.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/flute.ily
@@ -1,2 +1,44 @@
 flute = \relative c''' {
+  \barNumberCheck #1
+  \solo
+  R2.*11 |
+
+  \barNumberCheck #12
+  \tutti
+  R2. |
+  R2. |
+  r4 r8 cis4.~ \p |
+  cis8( b a gis8 a b) |
+  eis,4. cis'4. \f |
+  dis4.( d4.) |
+  cis4.~ cis8 b4~ |
+  b8( cis) a~( a8 b) gis |
+
+  \barNumberCheck #20
+  \solo
+  fis4 r8 r4 r8 |
+  R2.*14 |
+
+  \barNumberCheck #35
+  \tutti
+  e4. \p cis!4 d32( cis b cis) |
+  d8 d d d8 r r |
+  r4 r8 r8 r16 cis'( d dis) |
+
+  \barNumberCheck #38
+  e16( dis e dis e cis << { s16 \solo } b8) >> r r |
+  e4. cis4 d32( cis b cis) |
+  d8-. d-. d-. d8 r r |
+  R2.*5 |
+  r4 r8 \tuplet 3/2 8 { r16 d cis b a gis fis e d } |
+  r4 r8 \tuplet 3/2 8 { r16 e' d cis b a gis fis e } |
+  R2.*3 |
+
+  \barNumberCheck #51
+  r8 \tutti cis( cis') r8 d,( d') |
+  r16. cis,32 cis'8( fis,) r16. b,32 b'8( eis,) |
+
+  \barNumberCheck #53
+  \solo
+  fis4 r8 r4 r8 |
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/flute.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/flute.ily
@@ -41,4 +41,50 @@ flute = \relative c''' {
   \barNumberCheck #53
   \solo
   fis4 r8 r4 r8 |
+  R2.*10 |
+  fis2.( \p |
+  g8) r r r4 r8 |
+  R2. |
+  R2. |
+
+  \barNumberCheck #68
+  \tutti
+  R2. |
+  R2. |
+  r4 r8 cis4.~ \p |
+  cis8( b a gis a b) |
+  eis,4. cis'4. \f |
+  dis4.( d4.) |
+  cis4.~ cis8 b4~ |
+  b8( cis) a~( a8 b) gis |
+
+  \barNumberCheck #76
+  \solo
+  fis4 r8 r4 r8 |
+  R2.*3 |
+  r4 r8 fis4.~ \p |
+  fis4. eis4( d8) |
+  cis2. |
+  b8( cis d~ d8 cis b) |
+
+  \barNumberCheck #84
+  a4 r8 r4 r8 |
+  R2.*3 |
+  a'2.~ \p |
+  a2. |
+  d4.( b4. |
+  a4. gis!4.) |
+
+  \barNumberCheck #92
+  fis8 r r a4.~ |
+  a8( gis fis eis8 fis gis) |
+  cis,4. a'4.~ |
+  a8( gis fis eis8 fis gis) |
+  cis,4. a'4.~ |
+  a8( gis fis eis8 fis gis) |
+  fis8-. fis-. r cis'8-. \pp cis-. r |
+  fis8-. fis-. r r4 r8 |
+  \bar "|."
+
+  \barNumberCheck #100
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/horn.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/horn.ily
@@ -1,2 +1,48 @@
 horn = \relative c'' {
+  % Note that ``\transposition a'' is in effect.
+
+  \barNumberCheck #1
+  \solo
+  R2.*11
+
+  \barNumberCheck #12
+  \tutti
+  R2.*7 |
+  << { e,4. \f } \\ e4. >> r8 r << e8 \\ e8 >> |
+
+  \barNumberCheck #20
+  \solo
+  << e4 \\ e4 >> r8 r4 r8 |
+  R2.*7 |
+  <g g,>2.~ \p |
+  q2.~ |
+  q2. |
+  R2. |
+  q2.~ |
+  q2.~ |
+  q4 r8 r4 r8 |
+
+  \barNumberCheck #35
+  \tutti
+  R2.*3 |
+
+  \barNumberCheck #38
+  << { s4 s8 s16 \solo } R2. >> |
+  q2.~ |
+  q8 q-. q-. q8 r r |
+  R2. |
+  << g4. \\ g4. >> <c c,>8( <e e, > <c c,>) |
+  <g g,>2.~ |
+  q4. <c c,>8 r r |
+  R2.*4 |
+  <g g,>2.~ |
+  q2. |
+
+  \barNumberCheck #51
+  << { s8 \tutti } c,4 \\ c4 >> r8 r4 r8 |
+  << e2. \\ e2. >> |
+
+  \barNumberCheck #53
+  \solo
+  << e4 \\ e4 >> r8 r4 r8 |
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/horn.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/horn.ily
@@ -45,4 +45,61 @@ horn = \relative c'' {
   \barNumberCheck #53
   \solo
   << e4 \\ e4 >> r8 r4 r8 |
+  R2.*10 |
+  <<
+    {
+      c'2.( \p |
+      d8) r r r4 r8 |
+    } \\
+    {
+      c,2. |
+      R2. |
+    } \\
+  >> |
+  R2. |
+  R2. |
+
+  \barNumberCheck #68
+  \tutti
+  R2.*7
+  e4.-\both \f r4 e8 |
+
+  \barNumberCheck #76
+  \solo
+  e2.~ \p |
+  e2.~ |
+  e2. |
+  R2. |
+  e2.~ |
+  e2.~ |
+  e2.~ |
+  e2.~ |
+  e4 r8 r4 r8 |
+  R2.*3 |
+
+  <<
+    {
+      c'2.~ \p |
+      c2. |
+      d2. |
+      e2.~ |
+      e8
+    } \\
+    {
+      e,2.( |
+      c2.) |
+      R2. |
+      e2.~ |
+      e8
+    } \\
+  >>
+  r8 r8 r4 r8 |
+  R2.*4 |
+  << e2. \\ e2. >> |
+  << { e8[-. e]-. } \\ { e8[-. e]-. } >> r8
+  << { e8[-. \pp e]-. } \\ { c8[-. c]-. } >> r8 |
+  << { c'8[-. c]-. } \\ { e,8[-. e]-. } \\ >> r8 r4 r8 |
+  \bar "|."
+
+  \barNumberCheck #100
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/piano.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/piano.ily
@@ -99,6 +99,25 @@ pianoTreble = \relative c' {
   \barNumberCheck #68
   \tutti
   fis4 r8 r4 r8 |
+  R2.*7 |
+
+  \barNumberCheck #76
+  \solo
+  r4 r8 \grace a32 a'4. |
+  b16( a) a( gis) gis( fis) fis( eis) eis( fis) fis( gis) |
+  cis,4. cis'4.~ |
+  % This is notated as a ``delayed turn'' between gis8 and a8 in the
+  % original score, but it is not clear how to typeset that such that it
+  % both appears correctly in print and plays correctly on MIDI.
+  % Instead, we simply expand the turn to a sequence of 64th-notes.
+  cis16( d32 cis b8 a gis16 a64 gis fis gis a8 b) |
+  eis,4 cis8 a'4. |
+  dis4. gis,4 r8 |
+  cis4. fis,4 r8 |
+  b8.[( cis32 d] cis[ b a gis] fis16 eis b'8 eis, |
+
+  \barNumberCheck #84
+  fis4) r8 r4 r8 |
 }
 
 pianoBass = \relative c {
@@ -197,4 +216,20 @@ pianoBass = \relative c {
   \barNumberCheck #68
   \tutti
   <fis a>4 r8 r4 r8 |
+  R2.*7 |
+
+  \barNumberCheck #76
+  \solo
+  fis16^\legato a cis a cis a fis16 a cis a cis a |
+  fis16 a cis a cis a gis b cis b cis b |
+  a16 b eis b eis b a16 cis fis cis fis cis |
+  b16 d fis d fis d b16 d gis d gis d |
+
+  r16 cis,( eis gis cis cis, cis'4) r8 |
+  r16 cis,,16( dis fis cis' cis, cis'4) r8 |
+  r16 cis16( fis ais cis cis, cis'4) r8 |
+  r16 cis,,16( fis gis cis cis, cis'4) r8 |
+
+  \barNumberCheck #84
+  fis4 r8 r4 r8 |
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/piano.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/piano.ily
@@ -19,6 +19,33 @@ pianoTreble = \relative c' {
   \barNumberCheck #12
   \tutti
   fis4 r8 r4 r8 |
+  R2.*7 |
+
+  \barNumberCheck #20
+  \solo
+  % Note: In the source score, the slurs in bars 20 and 24 start 3/32
+  % into the measure (on the cis32), while the slur in bar 22 starts
+  % exactly on beat 2 (on the d32). We reproduce this notation here
+  % despite the inconsistency.
+  r8 r16. cis'32( \noBeam d cis bis cis a'8. gis16 fis8) |
+  eis8(-. e-. dis-. d-. cis-. cis-.) |
+  cis8[ r16. cis32] d( cis bis cis a'8. gis16 fis8) |
+  fis16( eis) eis-. e-. dis-. d-. d( cis) cis-. cis-. cis-. cis-. |
+  cis8[ r16. cis32]( d cis bis cis a'8. gis16 fis8) |
+  fis16( e!) e8 e e8( fis d) |
+  cis8[ r e] e8. d16 cis8 |
+  b8( d fis a8)[ r cis,] |
+  e8.( cis16 b8) r16 e,( gis b e b |
+  d8 c) r r16 e,( a c e c |
+  ais8 b) r r8 e, e'' |
+  e4( dis8) r8 r16 a,( c a |
+  e'4) r8 r r16 a( c a |
+  e'4) r8 r r16 a,,( c a) |
+  e'8(-. e-. e-.) dis16( e fis! e d b) |
+
+  \barNumberCheck #35
+  \tutti
+  a4 r8 r4 r8 |
 }
 
 pianoBass = \relative c {
@@ -42,4 +69,27 @@ pianoBass = \relative c {
   \barNumberCheck #12
   \tutti
   <fis a>4 r8 r4 r8 |
+  R2.*7 |
+
+  \barNumberCheck #20
+  \solo
+  fis,8 r <fis' a>8 q4 q8 |
+  <gis b>4 <fis a>8 <eis gis>4 q8 |
+  <fis a>4 q8 q4 q8 |
+  <gis b>4 <fis a>8 <eis gis>4 q8 |
+  <fis a>4 q8 q4 q8 |
+  <gis b>4 q8 q4 q8 |
+  a4 a8 <a cis,>4 q8 |
+  <d, fis>4 q8 <dis fis>4 q8 |
+  <e a>4 <e gis>8 q4 q8 |
+  <e a>4 q8 q4 q8 |
+  <e gis>4 q8 q4 q8 |
+  <f a>4 q8 q4 q8 |
+  e8( gis b e, a c |
+  e,8 gis b e, a c |
+  e,4) r8 r4 r8 |
+
+  \barNumberCheck #35
+  \tutti
+  R2. |
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/piano.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/piano.ily
@@ -46,6 +46,34 @@ pianoTreble = \relative c' {
   \barNumberCheck #35
   \tutti
   a4 r8 r4 r8 |
+  R2. |
+  R2. |
+
+  \barNumberCheck #38
+  r4 r8 r16 \solo ais( b cis d! dis |
+  e4.) cis4 d!32( cis b cis |
+  d8) d d d8 r r |
+  r8 cis( a') r16 b,16( cis d e fis) |
+  a,4( cis16 b a4) r8 |
+
+  r4 r8 r32 b'32([ d cis] b[ a gis fis] e[ d cis b]) |
+  r4 r8 r32 cis'32([ e d] cis[ b a gis] fis[ e d cis] |
+  b8 d gis, a16) a( gis a b cis |
+  e16 dis) d8( cis b8) r r |
+
+  <<
+    { e8~( e16 fis64 e d! e fis16 d cis8) } \\
+    { cis4 b8 a } \\
+  >>
+  r8 r8 |
+  b4( fis'8) fis8.( gis32 a gis16) fis-. |
+  e8
+  \shape #'((0 . -0.5) (2 . 2) (0 . 1) (0 . 0)) Slur
+  e'4~( e16 cis a e cis a) |
+  \afterGrace { b2. \startTrillSpan } { a32 \stopTrillSpan b } |
+
+  \barNumberCheck #51
+  << { s8 \tutti } a4 >> r8 r4 r8 |
 }
 
 pianoBass = \relative c {
@@ -91,5 +119,32 @@ pianoBass = \relative c {
 
   \barNumberCheck #35
   \tutti
+  R2.*3 |
+
+  \barNumberCheck #38
   R2. |
+  \tuplet 3/2 8 {
+    % Alternately, each triplet (of which six per measure) can be
+    % manually beamed together (e.g., `e[ cis a]`). This is done in the
+    % original score, but I think that it's harder to read.
+    e16( a cis e cis a e a cis e,16 a cis e cis a e a cis |
+    e,16 gis b e b gis e gis b e,16 gis b e b gis e gis b) |
+  }
+  <a fis>4 r8 <b fis d>4 r8 |
+  <<
+    { cis4( d8) cis4 } \\
+    { e,4. a4 } \\
+  >> r8 |
+
+  R2. |
+  r4 r8 r8 r <fis a> |
+  <d fis>4 <e d'>8 <a cis>4 r8 |
+  r8 << e'8 { gis,8( a) } >> <gis e>8 r8 r8 |
+  <a, cis>8( <cis e> <e gis>) <fis a>8 r r |
+  d4 r8 dis4 r8 |
+  e4 r8 e4 r8 |
+  e4 r8 e4 r8 |
+
+  \barNumberCheck #51
+  a,8 \tutti r r r4 r8 |
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/piano.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/piano.ily
@@ -1,5 +1,45 @@
 pianoTreble = \relative c' {
+  \barNumberCheck #1
+  \solo
+
+  cis'8. d16 cis8 cis8( fis a) |
+  a8( b,) gis'-. r8 b,4~( |
+  b16 a) fis'4~ fis8( gis, d') |
+  fis,4( eis32 fis gis fis eis8) r r |
+
+  d'8. e16 d8 \grace { d32( e) } fis8. e16 d8 |
+  bis4.( cis8) r r |
+  cis16( b!) ais( b) ais( b) a'!( gis) fis( eis) d( cis) |
+  b4( ais8) a8 r r |
+
+  g8. a16 g8 g4 g8 |
+  g8-. b-. d-. g-. b-. d-. |
+  fis,,8. gis!16 fis8 <fis a>4( <eis gis>8) |
+
+  \barNumberCheck #12
+  \tutti
+  fis4 r8 r4 r8 |
 }
 
 pianoBass = \relative c {
+  \barNumberCheck #1
+  \solo
+
+  <fis a>4 q8 q4 <fis cis'>8 |
+  <fis d'>4. eis,8 r <eis' cis'>8 |
+  <fis cis'>4 <a, cis>8 << { d4 b'8 } \\ b,4. >> |
+  <cis a'>4.( <cis gis'>8) r r |
+
+  <fis a>4 q8 <gis b>4 q8 |
+  <a e'>4 q8 <fis a>4 q8 |
+  <dis a'>4 q8 <eis gis>4 q8 |
+  <fis cis'>4 q8 <d! fis>4 <d fis>8 |
+
+  <g d b>4 q8 q4 q8 |
+  q4 r8 r4 r8 |
+  <a cis,>4 q8 <cis cis,>4 <b cis,>8 |
+
+  \barNumberCheck #12
+  \tutti
+  <fis a>4 r8 r4 r8 |
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/piano.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/piano.ily
@@ -118,6 +118,25 @@ pianoTreble = \relative c' {
 
   \barNumberCheck #84
   fis4) r8 r4 r8 |
+  fis4. a,4. |
+  gis4.~ gis4 d''8 |
+  cis4. eis,4. |
+  fis4 r8 r4 r8 |
+  fis4. a,,4. |
+  g4.~ g4 d'''8 |
+  cis4. eis,4. |
+
+  fis4 r8 r4 r8 |
+  r4 r8 r16 cis16( cis') cis-. cis-. cis-. |
+  cis8.( a16 fis8) r4 r8 |
+  r4 r8 r16 cis16( cis') cis-. cis-. cis-. |
+  cis8.( a16 fis8) r4 r8 |
+  r16 cis16( cis') cis-. cis-. cis-. cis-. cis-. cis-. cis-. cis-. cis-. |
+  fis,8 r <a cis,>( <fis a,>8) r <a cis,>( |
+  <fis a,>8) r r r4 r8 |
+  \bar "|."
+
+  \barNumberCheck #100
 }
 
 pianoBass = \relative c {
@@ -232,4 +251,23 @@ pianoBass = \relative c {
 
   \barNumberCheck #84
   fis4 r8 r4 r8 |
+  d4 r8 r4 r8 |
+  b4 r8 r4 r8 |
+  cis4 r8 r4 r8 |
+  fis4 r8 r4 r8 |
+  d4 r8 r4 r8 |
+  b4 r8 r4 r8 |
+  cis4 r8 r4 r8 |
+
+  fis4 r8 r4 r8 |
+  r4 r8 cis4 r8 |
+  a4 r8 r4 r8 |
+  r4 r8 cis4 r8 |
+  a4 r8 bis4 r8 |
+  cis4 r8 cis4 r8 |
+  fis8 r r fis8 r r |
+  fis8 r r r4 r8 |
+  \bar "|."
+
+  \barNumberCheck #100
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/piano.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/piano.ily
@@ -74,6 +74,31 @@ pianoTreble = \relative c' {
 
   \barNumberCheck #51
   << { s8 \tutti } a4 >> r8 r4 r8 |
+  R2. |
+
+  \barNumberCheck #53
+  \solo
+  cis8. d16 cis8 cis8( fis a) |
+  a8( b,) gis'-. r8 b,4~( |
+  b16 a) fis'4~ fis8 gis,( d') |
+  fis,4( eis32 fis gis fis eis8) r r |
+
+  d'8. e16 d8 \grace { d32 e } fis8. e16 d8 |
+  bis4.( cis8) r r |
+  cis16( b!) ais( b) ais( b) a'!( gis) fis( eis) d( cis) |
+  b4( ais8 a8) r r |
+
+  g8. a16 g8 g4 g8 |
+  g8-. b-. d-. g-. b-. d-. |
+  fis,,8.( gis!16 fis8) <fis a>4( <eis gis>8) |
+  fis2. |
+  g8. a16 g8 g g, g |
+  g4. d'''4 g,,8 |
+  fis8. gis!16 fis8 <fis a>4 <eis gis>8 |
+
+  \barNumberCheck #68
+  \tutti
+  fis4 r8 r4 r8 |
 }
 
 pianoBass = \relative c {
@@ -147,4 +172,29 @@ pianoBass = \relative c {
 
   \barNumberCheck #51
   a,8 \tutti r r r4 r8 |
+  R2. |
+
+  \barNumberCheck #53
+  \solo
+  <fis' a>4 q8 q4 <fis cis'>8 |
+  <fis d'>4. eis,8 r <eis' cis'> |
+  <fis cis'>4 <a, cis>8 << { d4 b'8 } \\ b,4. >> |
+  <cis a'>4.( <cis gis'>8) r r |
+
+  <fis a>4 q8 <gis b>4 q8 |
+  <a e'>4 q8 <fis a>4 q8 |
+  <dis a'>4 q8 <eis gis>4 q8 |
+  <fis cis'>4 q8 <d! fis>4 <d fis>8 |
+
+  <g d b>4 q8 q4 q8 |
+  q4 r8 r4 r8 |
+  <cis, a'>4 q8 <cis cis'>4 <cis b'>8 |
+  <d a'>2. |
+  <b d>4 q8 q4 q8 |
+  q4 r8 r4 r8 |
+  <cis a'>4 q8 <cis cis'>4 <cis b'>8 |
+
+  \barNumberCheck #68
+  \tutti
+  <fis a>4 r8 r4 r8 |
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/viola.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/viola.ily
@@ -1,2 +1,57 @@
 viola = \relative c' {
+  \barNumberCheck #1
+  \solo
+  R2.*11 |
+
+  \barNumberCheck #12
+  \tutti
+  cis,2.~ \p |
+  cis2.~ |
+  cis2. |
+  fis4. gis4.~ |
+  gis4. fis4. \f |
+  bis4.( b4.) |
+  ais4. b8( g fis) |
+  eis8( cis fis) d'( b cis) |
+
+  \barNumberCheck #20
+  \solo
+  fis,4 r8 r4 r8 |
+  R2.*4 |
+  e'2.~ \p |
+  e2. |
+  fis2. |
+  e8 r r e8 r r |
+  e8 r r e8 r r |
+  e8 r r e8 r r |
+  c4.( \fp a4.) |
+  b4 r8 r4 r8 |
+  R2. |
+  R2. |
+
+  \barNumberCheck #35
+  \tutti
+  R2.*3 |
+
+  \barNumberCheck #38
+  << { s4 s8 s16 \solo } R2.*2 >> |
+  r4 r8 r8 r b( \p |
+  a8) r r d8 r r |
+  r8 cis( b) a8 r r |
+  R2. |
+  R2. |
+  r8 fis'( e) e8 r r |
+  e,2.~ |
+  e4( gis8) a r r |
+  b4.( c4.) |
+  cis!8 e e e8 e e |
+  e8 e e <e d>8 q q |
+
+  \barNumberCheck #51
+  << { s8 \tutti } <e cis>4 >> r8 r4 r8 |
+  R2. |
+
+  \barNumberCheck #53
+  \solo
+  R2. |
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/viola.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/viola.ily
@@ -53,5 +53,53 @@ viola = \relative c' {
 
   \barNumberCheck #53
   \solo
-  R2. |
+  R2.*15 |
+
+  \barNumberCheck #68
+  \tutti
+  cis,2.~ \p |
+  cis2.~ |
+  cis2. |
+  fis4. gis4.~ |
+  gis4. fis4. \f |
+  bis4.( b4.) |
+  ais4. b8( g fis) |
+  eis8( cis fis) d'( b cis) |
+
+  \barNumberCheck #76
+  \solo
+  fis,4 r8 r4 r8 |
+  cis'4.( \p eis~) |
+  eis4.( fis4.) |
+  fis,4. b4. |
+  cis4 r8 r4 r8 |
+  R2.*3 |
+
+  \barNumberCheck #84
+  \set Staff.midiInstrument = "pizzicato strings"
+  fis8-\pizz a cis a8 fis cis |
+  d8 fis a fis8 d a |
+  b8 d cis b8 a gis |
+  cis8 fis a cis,8 eis gis |
+  fis8 a cis a8 fis cis |
+  d8 fis a fis8 d a |
+  b8 d g b8 g b, |
+  % Note: In the original score, this gis has a courtesy accidental,
+  % even though the corresponding gis in bar 87 does not. We reproduce
+  % this despite the inconsistency.
+  cis8 fis a cis,8 eis gis! |
+
+  \barNumberCheck #92
+  fis4 r8 r4 r8 |
+  \set Staff.midiInstrument = "viola"
+  b4.-\arco gis,4.~ |
+  gis8( fis) fis-. r4 r8 |
+  b'4. gis,4.~ |
+  gis8( fis) fis-. r4 r8 |
+  cis'4.( b4.) |
+  a8 r r fis'8 \pp r r |
+  a8 r r r4 r8 |
+  \bar "|."
+
+  \barNumberCheck #100
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/violin-i.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/violin-i.ily
@@ -50,4 +50,24 @@ violinI = \relative c'' {
 
   \barNumberCheck #51
   << { s8 \tutti } a4 >> r8 r4 r8 |
+  R2. |
+
+  \barNumberCheck #53
+  \solo
+  R2.*15 |
+
+  \barNumberCheck #68
+  \tutti
+  r4 r8 a4.~ \p |
+  a8( gis fis eis8 fis gis) |
+  cis,4. cis'4.~ |
+  cis8( b a gis a b) |
+  eis,4. a'4.~ \f |
+  a8( gis fis eis8 fis gis) |
+  cis,4.~ cis8 b4~ |
+  b8( cis) a~( a8 b) gis |
+
+  \barNumberCheck #76
+  \solo
+  fis4 r8 r4 r8 |
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/violin-i.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/violin-i.ily
@@ -1,2 +1,20 @@
 violinI = \relative c'' {
+  \barNumberCheck #1
+  \solo
+  R2.*11 |
+
+  \barNumberCheck #12
+  \tutti
+  r4 r8 a4.~ \p |
+  a8( gis fis eis fis gis) |
+  cis,4. cis'4.~ |
+  cis8( b a gis a b) |
+  eis,4. a'4.~ \f |
+  a8( gis fis eis fis gis) |
+  cis,4.~ cis8 b4~ |
+  b8( cis) a~( a8 b) gis |
+
+  \barNumberCheck #20
+  \solo
+  fis4 r8 r4 r8 |
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/violin-i.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/violin-i.ily
@@ -70,4 +70,11 @@ violinI = \relative c'' {
   \barNumberCheck #76
   \solo
   fis4 r8 r4 r8 |
+  cis'4.( \p b4.~) |
+  b8 a( gis fis gis a) |
+  d,4. d'4. |
+  gis,4 r8 r4 r8 |
+  R2.*3 |
+
+  \barNumberCheck #84
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/violin-i.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/violin-i.ily
@@ -77,4 +77,31 @@ violinI = \relative c'' {
   R2.*3 |
 
   \barNumberCheck #84
+  % These next eight measures shared across violins.
+  \set Staff.midiInstrument = "pizzicato strings"
+  r16-\pizz fis r a r cis r a r fis r cis |
+  r16 d r fis r a r fis r d r a |
+  r16 b r d r cis r b r a r gis |
+  r16 cis r fis r a r cis, r eis r gis |
+  r16 fis r a r cis r a r fis r cis |
+  r16 d r fis r a r fis r d r a |
+  r16 b r d r g r b r g r b, |
+  % Note: In the original score, this gis has a courtesy accidental,
+  % even though the corresponding gis in bar 87 does not. We reproduce
+  % this despite the inconsistency.
+  r16 cis r fis r a r cis, r eis r gis! |
+
+  \barNumberCheck #92
+  \set Staff.midiInstrument = "violin"
+  r16 a,(-\arco cis fis cis a) r16 cis( fis a fis cis) |
+  r16 d( fis gis fis d) r16 cis( eis gis eis cis) |
+  r16 cis( fis a fis cis) r16 d( fis a fis d) |
+  r16 d( fis gis fis d) r16 cis( eis gis eis cis) |
+  r16 cis( fis a fis cis) r16 dis( fis a fis dis) |
+  r16 cis( fis a fis cis) r16 cis( eis gis eis cis) |
+  cis8 r r cis'8 \pp r r |
+  fis8 r r r4 r8 |
+  \bar "|."
+
+  \barNumberCheck #100
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/violin-i.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/violin-i.ily
@@ -17,4 +17,37 @@ violinI = \relative c'' {
   \barNumberCheck #20
   \solo
   fis4 r8 r4 r8 |
+  R2.*4 |
+  d'2. \p |
+  cis2. |
+  b4.( cis4.) |
+  cis4( b8) r4 r8 |
+  r8 a( c) e8 r r |
+  r8 gis,( b) e8 r r |
+  e4( \f dis8) \p c4( a8) |
+  gis4 r8 r4 r8 |
+  R2. |
+  R2. |
+
+  \barNumberCheck #35
+  \tutti
+  R2.*3 |
+
+  \barNumberCheck #38
+  << { s4 s8 s16 \solo } R2. >> |
+  R2. |
+  r4 r8 r r d'( \p |
+  cis8) r r b r r |
+  r8 e( gis,) a8 r r |
+  R2. |
+  R2. |
+  r8 fis'16( d) d( b) a8 r r |
+  d,4( cis8) b8 r r |
+  e4( d8) cis8 r r |
+  r16 fis( a fis a fis) r16 fis( a fis a fis) |
+  e8 cis' cis cis8 cis cis |
+  b8 b b b8 b b |
+
+  \barNumberCheck #51
+  << { s8 \tutti } a4 >> r8 r4 r8 |
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/violin-ii.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/violin-ii.ily
@@ -17,4 +17,37 @@ violinII = \relative c'' {
   \barNumberCheck #20
   \solo
   a4 r8 r4 r8 |
+  R2.*4 |
+  b'2. \p |
+  a2.~ |
+  a2. |
+  a4( gis8) r4 r8 |
+  r8 c,8( a') c8 r r |
+  r8 b,( gis') gis8 r r |
+  a4.( \fp dis,4.) |
+  e4 r8 r4 r8 |
+  R2. |
+  R2. |
+
+  \barNumberCheck #35
+  \tutti
+  R2.*3 |
+
+  \barNumberCheck #38
+  << { s4 s8 s16 \solo } R2. >> |
+  R2. |
+  r4 r8 r r gis( \p |
+  a8) r r fis8 r r |
+  r8 e( d) cis8 r r |
+  R2. |
+  R2. |
+  r8 d'16( b) b( gis) a8 r r |
+  b,4( a8) gis8 r r |
+  cis4( b8) a8 r r |
+  r16 a( fis' a, fis' a,) r16 a( fis' a, fis' a,) |
+  a8 a' a a8 a a |
+  a8 a a gis8 gis gis |
+
+  \barNumberCheck #51
+  << { s8 \tutti } a4 >> r8 r4 r8 |
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/violin-ii.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/violin-ii.ily
@@ -77,4 +77,31 @@ violinII = \relative c'' {
   R2.*3 |
 
   \barNumberCheck #84
+  % These next eight measures shared across violins.
+  \set Staff.midiInstrument = "pizzicato strings"
+  r16-\pizz fis r a r cis r a r fis r cis |
+  r16 d r fis r a r fis r d r a |
+  r16 b r d r cis r b r a r gis |
+  r16 cis r fis r a r cis, r eis r gis |
+  r16 fis r a r cis r a r fis r cis |
+  r16 d r fis r a r fis r d r a |
+  r16 b r d r g r b r g r b, |
+  % Note: In the original score, this gis has a courtesy accidental,
+  % even though the corresponding gis in bar 87 does not. We reproduce
+  % this despite the inconsistency.
+  r16 cis r fis r a r cis, r eis r gis! |
+
+  \barNumberCheck #92
+  fis4 r8 r4 r8 |
+  \set Staff.midiInstrument = "violin"
+  d'4.-\arco b,4.~ |
+  b8( a) a-. r4 r8 |
+  d'4. b,4.~ |
+  b8( a) a-. r4 r8 |
+  a'4.( gis4.) |
+  fis8 r r a8 \pp r r |
+  cis8 r r r4 r8 |
+  \bar "|."
+
+  \barNumberCheck #100
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/violin-ii.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/violin-ii.ily
@@ -50,4 +50,24 @@ violinII = \relative c'' {
 
   \barNumberCheck #51
   << { s8 \tutti } a4 >> r8 r4 r8 |
+  R2. |
+
+  \barNumberCheck #53
+  \solo
+  R2.*15 |
+
+  \barNumberCheck #68
+  \tutti
+  r16 a,( \p cis fis cis a) r16 a( cis fis cis a) |
+  r16 a( cis fis cis a) r16 b( cis eis cis b) |
+  r16 b( cis eis cis b) r16 a( cis fis cis a) |
+  r16 d( fis b fis d) r16 b( d fis d b) |
+  r16 b( cis gis' cis, b) r16 a( \f cis fis cis a) |
+  r16 dis( fis gis fis dis) r16 gis( b d! b gis) |
+  r16 cis,( e fis e cis) r16 b( d g! d b) |
+  r16 cis( eis gis! fis cis) r16 fis( d fis eis b) |
+
+  \barNumberCheck #76
+  \solo
+  a4 r8 r4 r8 |
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/violin-ii.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/violin-ii.ily
@@ -70,4 +70,11 @@ violinII = \relative c'' {
   \barNumberCheck #76
   \solo
   a4 r8 r4 r8 |
+  a'4.( \p gis4.~) |
+  gis8 cis,( b a b cis) |
+  b4. gis'4. |
+  eis4 r8 r4 r8 |
+  R2.*3 |
+
+  \barNumberCheck #84
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/violin-ii.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/02_andante/violin-ii.ily
@@ -1,2 +1,20 @@
 violinII = \relative c'' {
+  \barNumberCheck #1
+  \solo
+  R2.*11 |
+
+  \barNumberCheck #12
+  \tutti
+  r16 a,( \p cis fis cis a) r16 a( cis fis cis a) |
+  r16 a( cis fis cis a) r16 b( cis eis cis b) |
+  r16 b( cis eis cis b) r16 a( cis fis cis a) |
+  r16 d( fis b fis d) r16 b( d fis d b) |
+  r16 b( cis gis' cis, b) r16 a( \f cis fis cis a) |
+  r16 dis( fis gis fis dis) r16 gis( b d! b gis) |
+  r16 cis,( e fis e cis) r16 b( d g d b) |
+  r16 cis( eis gis! fis cis) r16 fis( d fis eis b) |
+
+  \barNumberCheck #20
+  \solo
+  a4 r8 r4 r8 |
 }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/assert_consistent_marks.sh
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/assert_consistent_marks.sh
@@ -55,6 +55,7 @@ check_movement() {
 
 main() {
     check_movement 01_allegro
+    check_movement 02_andante
     exit "${failed}"
 }
 

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/common/definitions.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/common/definitions.ily
@@ -26,6 +26,9 @@ legato = \markup { \italic legato }
 dolce = \markup { \italic dolce }
 cadenza = \markup { \italic Cadenza }
 
+pizz = \markup { pizz. }
+arco = \markup { arco }
+
 % Voicing marking for bassoon and horn, indicating that the (monophonic)
 % notation should be played by both members.
 both = \markup { a. 2. }

--- a/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/common/variables.ily
+++ b/ftp/MozartWA/KV488/Mozart-KV488/Mozart-KV488-lys/common/variables.ily
@@ -32,7 +32,7 @@ combinedPublicationName = "Conductor’s Score"
 
 %% Movement-specific variables
 thisTempoMovI = "Allegro"
-thisTempoMovII = "Andante (under construction)"
+thisTempoMovII = "Andante"
 thisTempoMovIII = "Presto (under construction)"
 
 thisIdentifierMovI = "I"


### PR DESCRIPTION
This pull request includes the second movement of Mozart’s Piano
Concerto № 23 in A Major (KV 488/KV488/K488), for all instruments.

This is a follow-up to #1003, which included the first movement. As
before, the source is a manuscript of Breitkopf and Härtel from 1879,
available on IMSLP: https://imslp.org/wiki/Special:ReverseLookup/25720
The PDF version of the source has the following SHA-256 hash:

```
dd642c79649d00758dfa65c3dbc605d940edb1d14b2f53312282acb7a8a0fe9a
```

I’ve hand-checked each measure of the final score against the source,
and also listened to the rendered MIDI output.

Maintainers: please `merge --no-ff` this branch as-is; please _do not_
squash the history. Feel free to push any administrative commits (ID
changes, etc.) on top of the existing history; I’ve granted maintainer
permission to push to `wchargin/kv488-andante`.
