### PR TITLE
Alkan Op45 Salut Cendre du Pauvre

### DIFF
--- a/ftp/AlkanCV/O45/salut cendre du pauvre/C-V-Alkan-Salut-cendre-du-pauvre.ly
+++ b/ftp/AlkanCV/O45/salut cendre du pauvre/C-V-Alkan-Salut-cendre-du-pauvre.ly
@@ -15,7 +15,7 @@
     maintainer = "Anonymous"
     opus = "Op. 45"
 }
-\paper { page-count = #6 }\layout { \context { \Staff \RemoveEmptyStaves } }\layout { \context {	\Score	\consists "Span_arpeggio_engraver" } }\score { << 
+\paper { page-count = #6 }\layout { \context { \Staff \RemoveEmptyStaves } }\layout { \context { \Score \consists "Span_arpeggio_engraver" } }\score { << 
 \new PianoStaff <<
 << \new Staff = "treble" \with {
 \consists "Span_arpeggio_engraver"
@@ -24,33 +24,33 @@
 \clef bass
 \key bf \major
 \time 4/4
-\tempo "Adagio sostenuto" 4 = 69<g, bf,>2\arpeggio\mf <a, c>2\arpeggio |
+\tempo "Adagio sostenuto" 4 = 69<g, bf,>2\arpeggio <a, c>2\arpeggio |
 <bf, df>2\arpeggio <a, c>4.\arpeggio \clef treble 
 <<
 { f8-(\p^\markup{\italic{dolce cantabile}} |
-f'2~\< f'8 g'8\! ef'8 c'8-) |
+f'2~^\< f'8 g'8\! ef'8 c'8-) |
 bf2-( a4.-) c8-( |
-c'2~\< c'8 d'8\! bf8 g8-) |
-f2.-(_\markup{\italic{dim.}} e4-) }
+c'2~^\< c'8 d'8\! bf8 g8-) |
+f2.-(^\markup{\italic{dim.}} e4-) }
 \\
 { \omit r8 |
-r4 c'4_\markup{\dynamic{pp} \italic{e legatissimo}} <bf d'>4 g4 |
+r4 c'4 <bf d'>4 g4 |
 f4( e4 f4 ds4) |
 r4 e4 <f a>4 d4 |
 c4( b,4 bf,2) }
 >>
 |
-\clef bass <d, f,>2\arpeggio\mf <e, g,>2\arpeggio |
+\clef bass <d, f,>2\arpeggio <e, g,>2\arpeggio |
 <f, af,>2\arpeggio <e, g,>4.\arpeggio \clef treble 
 <<
 { af8-(\p^\markup{\italic{dolce}} |
-af'2~\< af'8 bf'8\! gf'8 ef'8-) |
+af'2~^\< af'8 bf'8\! gf'8 ef'8-) |
 df'2-( c'4.-) e8-( |
-e'4.\< e'8 e'8 fs'8\! d'8 b8 |
+e'4.^\< e'8 e'8 fs'8\! d'8 b8 |
 a2~ a8 gs8_\markup{\italic{ten.}} cs'8 b8-) }
 \\
 { \omit r8 |
-r4 ef'4\pp <df' f'>4 bf4 |
+r4 ef'4 <df' f'>4 bf4 |
 af4\( g4 af4( gs4)\) |
 r4 <e c'>4 <e cs'>4 fs4 |
 e4 fs4 d2 }
@@ -63,53 +63,53 @@ e'2. fs'8 gs'8 |
 a'2 b'4. fs'8 |
 a'2( gs'4 g'4) |
 fs'2.( \clef "treble" b'8 d''8) |
-d''4(\> e'2)-(\!\< a'8 cs''8)\! |
-cs''4(\> d'2)-(\! cs'8 e'8) |
+d''4(^\> e'2)-(\!^\< a'8 cs''8)\! |
+cs''4(^\> d'2)-(\! cs'8 e'8) |
 cs'2( b4 c'4) |
-cs'2.(_\markup{\italic{cresc. poco a poco}} es'8 fs'8) |
+cs'2.( es'8 fs'8) |
 \clef "treble" gs'2.( as'8 bs'8) |
-cs''2\< es''4.\rfz ds''8 |
-cs''2(\> bs'4 b'4)\p |
+cs''2 es''4. ds''8 |
+cs''2( bs'4 b'4) |
 b'2.( e''8 g''8) |
 g''4( g'2 c''8) e''8 |
-e''4 e'2 a'8 c''8 |
+e''4 e'2^\< a'8 c''8\! |
 c'2 c'4. c'8 |
 \clef "bass" c'4 f'4 ef'4 df'4 |
 g4( a4 bf4 <bf d'>8 <a c'>8) |
 bf2( a4) }
 \\
-{ \omit TupletNumber \tuplet 3/2 {<cs e>8^\markup{\italic{sempre sostenuto}}_\markup{\italic{poco cresc.}} <cs e>8 <cs e>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<cs e>8 <cs e>8 <cs e>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<cs e>8 <cs e>8 <cs e>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<e a>8 <e a>8 <e a>8} %{ end triplets %} |
+{ \omit TupletNumber \tuplet 3/2 {<cs e>8^\markup{\italic{sempre sostenuto}} <cs e>8 <cs e>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<cs e>8 <cs e>8 <cs e>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<cs e>8 <cs e>8 <cs e>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<e a>8 <e a>8 <e a>8} %{ end triplets %} |
 \omit TupletNumber \tuplet 3/2 {<e b>8 <e b>8 <e b>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<e gs b>8 <e gs b>8 <e gs b>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<e gs b>8 <e gs b>8 <e gs b>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<b e'>8 <b e'>8 <b e'>8} %{ end triplets %} |
-\omit TupletNumber \tuplet 3/2 {<a cs'>8\< <a cs'>8 <a cs'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<a cs'>8 <a cs'>8 <a cs'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<b d' fs'>8\!\> <b d' fs'>8 <b d' fs'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<b d'>8 <b d'>8 <b d'>8\!} %{ end triplets %} |
+\omit TupletNumber \tuplet 3/2 {<a cs'>8 <a cs'>8 <a cs'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<a cs'>8 <a cs'>8 <a cs'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<b d' fs'>8 <b d' fs'>8 <b d' fs'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<b d'>8 <b d'>8 <b d'>8} %{ end triplets %} |
 \omit TupletNumber \tuplet 3/2 {<cs' e'>8 <cs' e'>8 <cs' e'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<a cs' e'>8 <a cs' e'>8 <a cs' e'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<gs b e'>8 <gs b e'>8 <gs b e'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<g b e'>8 <g b e'>8 <g b e'>8} %{ end triplets %} |
-\omit TupletNumber \tuplet 3/2 {<fs as cs'>8\< <fs as cs'>8 <fs as cs'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<fs as cs'>8 <fs as cs'>8 <fs as cs'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<fs b d'>8 <fs b d'>8 <fs b d'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<d' fs'>8 <d' fs'>8\! <d' fs'>8} %{ end triplets %} |
+\omit TupletNumber \tuplet 3/2 {<fs as cs'>8 <fs as cs'>8 <fs as cs'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<fs as cs'>8 <fs as cs'>8 <fs as cs'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<fs b d'>8 <fs b d'>8 <fs b d'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<d' fs'>8 <d' fs'>8 <d' fs'>8} %{ end triplets %} |
 \omit TupletNumber \tuplet 3/2 {<d' e'>8 <d' e'>8 <d' e'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<e gs b>8 <e gs b>8 <e gs b>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<e a cs'>8 <e a cs'>8 <e a cs'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<cs' e'>8 <cs' e'>8 <cs' e'>8} %{ end triplets %} |
-\omit TupletNumber \tuplet 3/2 {<d' a'>8 <d' a'>8 <d' a'>8} %{ end triplets %} \clef "bass" \omit TupletNumber \tuplet 3/2 {<e b>8 <e b>8_\markup{\italic{dim.}} <e b>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<e b>8 <e b>8 <e b>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<e a>8 <e a>8 <e a>8} %{ end triplets %} |
-\omit TupletNumber \tuplet 3/2 {<e a>8\> <e a>8 <e a>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<fs a>8 <fs a>8 <fs a>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {gs8\! gs8 gs8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<fs gs>8\p <fs gs>8 <fs gs>8} %{ end triplets %} |
+\omit TupletNumber \tuplet 3/2 {<d' a'>8 <d' a'>8 <d' a'>8} %{ end triplets %} \clef "bass" \omit TupletNumber \tuplet 3/2 {<e b>8 <e b>8 <e b>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<e b>8 <e b>8 <e b>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<e a>8 <e a>8 <e a>8} %{ end triplets %} |
+\omit TupletNumber \tuplet 3/2 {<e a>8 <e a>8 <e a>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<fs a>8 <fs a>8 <fs a>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {gs8 gs8 gs8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<fs gs>8 <fs gs>8 <fs gs>8} %{ end triplets %} |
 \omit TupletNumber \tuplet 3/2 {<es gs>8 <es gs>8 <es gs>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<es gs>8 <es gs>8 <es gs>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<es gs>8 <es gs>8 <es gs>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<es gs cs'>8 <es gs cs'>8 <es gs cs'>8} %{ end triplets %} |
 \omit TupletNumber \tuplet 3/2 {<gs ds'>8 <gs ds'>8 <gs ds'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<gs bs ds'>8 <gs bs ds'>8 <gs bs ds'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<gs bs ds'>8 <gs bs ds'>8 <gs bs ds'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<bs ds' gs'>8 <bs ds' gs'>8 <bs ds' gs'>8} %{ end triplets %} |
 \omit TupletNumber \tuplet 3/2 {<ds' as'>8 <ds' as'>8 <ds' as'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<ds' fss' as'>8 <ds' fss' as'>8 <ds' fss' as'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<fss' as' cs''>8 <fss' as' cs''>8 <fss' as' cs''>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<ds' as' cs''>8 <ds' as' cs''>8 <ds' as' cs''>8} %{ end triplets %} |
 \omit TupletNumber \tuplet 3/2 {<ds' fss' as'>8 <ds' fss' as'>8 <ds' fss' as'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<ds' fss' as'>8 <ds' fss' as'>8 <ds' fss' as'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<ds' gs'>8 <ds' gs'>8 <ds' gs'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<ds' gs'>8 <ds' gs'>8 <ds' gs'>8} %{ end triplets %} |
-\omit TupletNumber \tuplet 3/2 {<ds' fs'>8 <ds' fs'>8 <ds' fs'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<ds' a'>8 <ds' a'>8 <ds' a'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<e' g'>8 <e' g'>8 <e' g'>8\<} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<g' b'>8 <g' b'>8 <g' b'>8\!} %{ end triplets %} |
-\omit TupletNumber \tuplet 3/2 {<g' b' d''>8\> <g' b' d''>8 <g' b' d''>8\!} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<b f'>8 <b f'>8 <b f'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<c' e'>8 <c' e'>8 <c' e'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<e' g'>8 <e' g'>8 <e' g'>8} %{ end triplets %} |
-\omit TupletNumber \tuplet 3/2 {<e' gs'>8\> <e' gs'>8 <e' gs'>8\!} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<gs d'>8\< <gs d'>8 <gs d'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<a c'>8 <a c'>8 <a c'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<c' e'>8 <c' e'>8 <c' e'>8\!} %{ end triplets %} |
-\omit TupletNumber \tuplet 3/2 {<f a>8\p^\markup{\italic{dolce}} <f a>8 <f a>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<f a>8 <f a>8 <f a>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<e g>8 <e g>8 <e g>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<g bf>8 <g bf>8 <g bf>8} %{ end triplets %} |
-\omit TupletNumber \tuplet 3/2 {<f a>8 <f a>8 <f a>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<f c'>8\> <f c'>8 <f c'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<f c'>8 <f c'>8 <f c'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<f bf>8 <f bf>8 <f bf>8\!} %{ end triplets %} |
-\omit TupletNumber \tuplet 3/2 {f8\< f8 f8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<f g>8 <f g>8 <f g>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<e g>8 <e g>8 <e g>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {e8\!\> e8 e8\!} %{ end triplets %} |
+\omit TupletNumber \tuplet 3/2 {<ds' fs'>8 <ds' fs'>8 <ds' fs'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<ds' a'>8 <ds' a'>8 <ds' a'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<e' g'>8 <e' g'>8 <e' g'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<g' b'>8 <g' b'>8 <g' b'>8} %{ end triplets %} |
+\omit TupletNumber \tuplet 3/2 {<g' b' d''>8 <g' b' d''>8 <g' b' d''>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<b f'>8 <b f'>8 <b f'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<c' e'>8 <c' e'>8 <c' e'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<e' g'>8 <e' g'>8 <e' g'>8} %{ end triplets %} |
+\omit TupletNumber \tuplet 3/2 {<e' gs'>8 <e' gs'>8 <e' gs'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<gs d'>8 <gs d'>8 <gs d'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<a c'>8 <a c'>8 <a c'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<c' e'>8 <c' e'>8 <c' e'>8} %{ end triplets %} |
+\omit TupletNumber \tuplet 3/2 {<f a>8^\markup{\italic{dolce}} <f a>8 <f a>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<f a>8 <f a>8 <f a>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<e g>8 <e g>8 <e g>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<g bf>8 <g bf>8 <g bf>8} %{ end triplets %} |
+\omit TupletNumber \tuplet 3/2 {<f a>8 <f a>8 <f a>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<f c'>8 <f c'>8 <f c'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<f c'>8 <f c'>8 <f c'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<f bf>8 <f bf>8 <f bf>8} %{ end triplets %} |
+\omit TupletNumber \tuplet 3/2 {f8 f8 f8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<f g>8 <f g>8 <f g>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<e g>8 <e g>8 <e g>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {e8 e8 e8} %{ end triplets %} |
 \omit TupletNumber \tuplet 3/2 {<e g>8 <e g>8 <e g>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<e g>8 <e g>8 <e g>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {f8 f8 f8} %{ end triplets %} }
 >>
- \override Rest.transparent = ##f r8\p^\markup{\italic{dolce}} f8-( |
+ \override Rest.transparent = ##f r8^\markup{\italic{dolce}} f8-( |
 f'2.-) r8 f8-( |
 f'2.-) r8 f8-( |
 f'4.-) f8-( f'4.-) 
 <<
 { f8-( |
-f'2~\p\< f'8 g'8\! ef'8 c'8-) |
+f'2~^\< f'8 g'8\! ef'8 c'8-) |
 bf2~-( bf8 a8 g8 a8-) }
 \\
 {  \override Rest.transparent = ##t r8 |
 r4 \omit TupletNumber \tuplet 3/2 {af8 af8 af8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {g8 g8 g8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {g8 g8 g8} %{ end triplets %} |
-\omit TupletNumber \tuplet 3/2 {f8 f8 f8_\markup{\italic{smorz.}}} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {e8 e8 e8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {ef8 ef8 ef8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {c8 c8 c8} %{ end triplets %} }
+\omit TupletNumber \tuplet 3/2 {f8 f8 f8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {e8 e8 e8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {ef8 ef8 ef8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {c8 c8 c8} %{ end triplets %} }
 >>
 |
 r2 r4 \tuplet 3/2 {<bf, df gf>8\p\< <df gf bf>8 <ff gf df'>8\!} %{ end triplets %} |
@@ -160,36 +160,36 @@ r2 r4 \tuplet 3/2 {<bf, df gf>8\p\< <df gf bf>8 <ff gf df'>8\!} %{ end triplets 
 >>
 \omit TupletNumber \tuplet 3/2 {\clef "treble" <gs b d' es'>8\< <b d' es' gs'>8 <d' es' gs' b'>8\!} %{ end triplets %} |
 <d' fs' a' d''>4-(\f\> <a d' fs' a'>8.-) <fs a d' fs'>16\! <fs a d' fs'>4 <e a e'>8 <d a d'>8 |
-\clef "bass" <ds a bs>8.-(_\markup{\italic{sempre cresc. e sempre} Ped.} <e cs'>16 <ds a bs>2-) \tuplet 3/2 {<ds a bs>8 <a bs ds'>8 <bs ds' a'>8} %{ end triplets %} |
+\clef "bass" \grace s8<ds a bs>8.-( <e cs'>16 <ds a bs>2-) \tuplet 3/2 {<ds a bs>8 <a bs ds'>8 <bs ds' a'>8} %{ end triplets %} |
 \clef "treble" <ds' a' bs'>8.-( <e' cs''>16-) <ds' a' bs'>2 \tuplet 3/2 {<ds' a' bs'>8 <a' bs' ds''>8 <bs' ds'' a''>8} %{ end triplets %} |
-<ds'' a'' bs''>8.-(\f <e'' cs'''>16-) 
+<ds'' a'' bs''>8.-( <e'' cs'''>16-) 
 <<
 { <ds'' bs''>4~ <ds'' bs''>8( <e'' cs'''>8) }
 \\
 { a''2 }
 >>
 <ds'' a'' bs''>4~ |
-<ds'' a'' bs''>8-(\< <e'' cs'''>8) <ds'' a'' bs''>8-( <e'' cs'''>8-) <ds'' a'' bs''>8-( <e'' cs'''>8-) <ds'' a'' bs''>8-( <e'' cs'''>8-)\! |
-<ds'' a'' bs''>8(\ff <d'' gs'' b''>8_\markup{\italic{sempre} Ped.} <cs'' g'' as''>8 <c'' fs'' a''>8 <b' f'' gs''>8 <as' e'' g''>8 <a' ds'' fs''>8 <gs' d'' es''>8) |
-<fs'' bs'' ds'''>8(_\markup{\italic{Poco accel.}} <f'' b'' d'''>8 <e'' as'' cs'''>8 <ds'' a'' c'''>8 <d'' gs'' b''>8 <cs'' g'' as''>8 <c'' fs'' a''>8 <b' es'' gs''>8) |
-<a'' bs'' ds''' fs'''>8_\markup{\dynamic{sf}}_\markup{\dynamic{rfz} \italic{molto}} <fs'' a'' bs'' ds'''>8 <ds'' fs'' a'' bs''>8 <bs' ds'' fs'' a''>8 <a' bs' ds'' fs''>8 <fs' a' bs' ds''>8 <ds' fs' a' bs'>8 <bs ds' fs' a'>8 |
+<ds'' a'' bs''>8-( <e'' cs'''>8) <ds'' a'' bs''>8-( <e'' cs'''>8-) <ds'' a'' bs''>8-( <e'' cs'''>8-) <ds'' a'' bs''>8-( <e'' cs'''>8-) |
+<ds'' a'' bs''>8( <d'' gs'' b''>8 <cs'' g'' as''>8 <c'' fs'' a''>8 <b' f'' gs''>8 <as' e'' g''>8 <a' ds'' fs''>8 <gs' d'' es''>8) |
+<fs'' bs'' ds'''>8( <f'' b'' d'''>8 <e'' as'' cs'''>8 <ds'' a'' c'''>8 <d'' gs'' b''>8 <cs'' g'' as''>8 <c'' fs'' a''>8 <b' es'' gs''>8) |
+<a'' bs'' ds''' fs'''>8_\markup{\dynamic{sf}} <fs'' a'' bs'' ds'''>8 <ds'' fs'' a'' bs''>8 <bs' ds'' fs'' a''>8 <a' bs' ds'' fs''>8 <fs' a' bs' ds''>8 <ds' fs' a' bs'>8 <bs ds' fs' a'>8 |
 <as cs' e' g'>4-^ <gs b d' f'>4-^ <fs a c' ef'>4-^ <es gs b d'>4-^ |
-\clef "bass" \grace s8 <ef fs a c'>2_\markup{\italic{dim. poco a poco, ma sempre pedale}} <d es gs b>2 |
+\clef "bass" \grace s8 <ef fs a c'>2 <d es gs b>2 |
 <as, cs fs>1 |
 <bf, df gf>2 <bf, df gf>2 |
-<bf, df f>1_\markup{\italic{poco rall. \bold{p}}} |
+<bf, df f>1 |
 
 <<
 { e1^\markup{\italic{ten.}} }
 \\
-{ df2-(\> c4 bf,4-)\! }
+{ df2-( c4 bf,4-) }
 >>
 |
 \set Score.connectArpeggios = ##f \set Staff.connectArpeggios = ##t
-\tempo "A tempo"r2.\omit \sustainOn r8\sustainOff \clef "treble" 
+\tempo "A tempo"r2. r8 \clef "treble" 
 <<
 { f''8-(^\pp |
-f'''2~ f'''8 g'''8 ef'''8 c'''8-) |
+f'''2~^\< f'''8 g'''8\! ef'''8 c'''8-) |
 bf''2-(\arpeggio a''4-) }
 \\
 { \omit r8 |
@@ -203,7 +203,7 @@ f'2.\arpeggio }
 r4 |
 r4 r8 
 <<
-{ c''8-( c'''2~\< |
+{ c''8-( c'''2~^\< |
 c'''8 d'''8\! bf''8 g''8-) f''2-(\arpeggio |
 e''4-) }
 \\
@@ -217,9 +217,9 @@ e''4-) }
 >>
 r2 r8 
 <<
-{ a'8(^\p |
+{ a'8( |
 a''2.) \omit r8 bf'8( |
-bf''2.) \omit r8 b'8(_\markup{\italic{poco cresc.}} |
+bf''2.) \omit r8 b'8( |
 b''2.) }
 \\
 { \omit r8 |
@@ -230,13 +230,13 @@ r4 \omit r4 e''4. }
 { \omit r8 |
 \omit r4 \stemDown \slurDown\stemDown <e'' g''>4(\pp fs''4 f''8) \omit r8 |
 \omit r4 <f'' af''>4( g''4 gf''8) \omit r8 |
-\omit r4 <fs'' a''>4( gs''4_\markup{\italic{poco rinf}} g''8)\stemNeutral \slurNeutral }
+\omit r4 <fs'' a''>4( gs''4 g''8)\stemNeutral \slurNeutral }
 >>
 
 <<
 { <c' c''>8(\( |
 <c'' c'''>2)-~\< <c'' c'''>8 <ef'' ef'''>8\! <d'' d'''>8 <bf' bf''>8\) |
-<g' g''>8\(_\markup{\italic{dim}} <ef' ef''>8 <c' c''>8 <d' d''>8 ef''4\arpeggio <ef'' g''>8\arpeggio\> <d'' f''>8\) |
+<g' g''>8\(_\markup{\italic{dim.}} <ef' ef''>8 <c' c''>8 <d' d''>8 ef''4\arpeggio <ef'' g''>8\arpeggio\> <d'' f''>8\) |
 <c'' ef''>4( <bf' d''>8)\! }
 \\
 { \omit r8 |
@@ -247,15 +247,15 @@ f'4. }
 { \omit r8 |
 \omit r1 |
 \omit r2 \stemDown c''8\stemNeutral  \stemDown bf'8\stemNeutral  \omit r4 |
-\omit r4. }
+\omit r4 \omit r8 }
 >>
-r8 r4 r8 f8-(_\markup{\italic{dolce}} |
-f'2~\< f'8 g'8\! ef'8 c'8-) |
-ef'4( d'8) r8 r4 r8 f8(\< |
-f'4)\! r8 f8-(\< f'8 g'8\! ef'8 c'8-) |
-ef'4( d'8) r8 r4 r8 bf8(_\markup{\italic{poco cresc.}} |
-bf'2~\< bf'8 c''8\! af'8 fs'8) |
-g'8( af'8 f'8 d'8 ef'8 c'8_\markup{\italic{dim.}} af8 fs8) |
+r8 r4 r8 f8-(^\markup{\italic{dolce}} |
+f'2~^\< f'8 g'8\! ef'8 c'8-) |
+ef'4( d'8) r8 r4 r8 f8(^\< |
+f'4)\! r8 f8-(^\< f'8 g'8\! ef'8 c'8-) |
+ef'4( d'8) r8 r4 r8 bf8( |
+bf'2~^\< bf'8 c''8\! af'8 fs'8) |
+g'8( af'8 f'8 d'8 ef'8 c'8 af8 fs8) |
 g8( a8 bf8 <ef ef'>8) 
 <<
 { <bf d'>4(_\markup{\italic{ten.}} <a c'>8. bf16) }
@@ -263,27 +263,27 @@ g8( a8 bf8 <ef ef'>8)
 { f2 }
 >>
 \bar "||" %{ bar %}
-\omit TupletNumber \tuplet 3/2 {<f bf d' f'>8\pp^\markup{\italic{sostenuto sempre}} <f bf d' f'>8 <f bf d' f'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<f bf d' f'>8 <f bf d' f'>8 <f bf d' f'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<f bf d' f'>8 <f bf d' f'>8 <f bf d' f'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<f bf d' f'>8 <f bf d' f'>8 <f bf d' f'>8} %{ end triplets %} |
+\omit TupletNumber \tuplet 3/2 {<f bf d' f'>8^\markup{\italic{sostenuto sempre}} <f bf d' f'>8 <f bf d' f'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<f bf d' f'>8 <f bf d' f'>8 <f bf d' f'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<f bf d' f'>8 <f bf d' f'>8 <f bf d' f'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<f bf d' f'>8 <f bf d' f'>8 <f bf d' f'>8} %{ end triplets %} |
 \omit TupletNumber \tuplet 3/2 {<bf c' f'>8 <bf c' f'>8 <bf c' f'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<bf c' f'>8 <bf c' f'>8 <bf c' f'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<a c' f'>8 <a c' f'>8 <a c' f'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<c' f'>8 <c' f'>8 <c' f'>8} %{ end triplets %} |
 \omit TupletNumber \tuplet 3/2 {<g d' f'>8 <g d' f'>8 <g d' f'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<g d' f'>8 <g d' f'>8 <g d' f'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<g bf e'>8 <g bf e'>8 <g bf e'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<g bf e'>8 <g bf e'>8 <g bf e'>8} %{ end triplets %} |
 \omit TupletNumber \tuplet 3/2 {<f c' f'>8 <f c' f'>8 <f c' f'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<f c' f'>8 <f c' f'>8 <f c' f'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<f c' f'>8 <f c' f'>8 <f c' f'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<f c' f'>8 <f c' f'>8 <f c' f'>8} %{ end triplets %} |
 \omit TupletNumber \tuplet 3/2 {<f b d' f'>8 <f b d' f'>8 <f b d' f'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<f b d' f'>8 <f b d' f'>8 <f b d' f'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<f c' ef' f'>8 <f c' ef' f'>8 <f c' ef' f'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<f f'>8 <f f'>8 <f f'>8} %{ end triplets %} |
 \omit TupletNumber \tuplet 3/2 {<f a c' f'>8 <f a c' f'>8 <f a c' f'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<a c' ef' f'>8 <a c' ef' f'>8 <a c' ef' f'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<bf d' f'>8 <bf d' f'>8 <bf d' f'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<f f'>8 <f f'>8 <f f'>8} %{ end triplets %} |
 \omit TupletNumber \tuplet 3/2 {<bf d' f'>8 <bf d' f'>8 <bf d' f'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<f bf d' f'>8 <f bf d' f'>8 <f bf d' f'>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<f bf d' f'>8 <f bf d' f'>8 <f bf d' f'>8} %{ end triplets %} \tuplet 3/2 {<f a c' f'>8 <f a c' f'>8 <f a ef' f'>8} %{ end triplets %} |
-\clef bass \set Score.connectArpeggios = ##t <g, bf,>2-(\arpeggio\p\< <a, c>2\arpeggio |
-<bf, df>2\arpeggio\> <a, c>2-)\arpeggio\! |
-<c ef>2-(\arpeggio\> <bf, df>2-)\arpeggio\! |
-<ef gf>2-(\arpeggio\> <df f>2-)\arpeggio\! |
-<f af>4-(\arpeggio\> <ef g>4-)\arpeggio\! <bf, d>4-(\arpeggio_\markup{\italic{cresc - - - - - - - - - - - - - - poco - - - - - - - - a - - - - - - poco}} <bf, ef>4-)\arpeggio |
-<g bf>4-(\arpeggio\> <f a>4-)\arpeggio\! <c e>4-(\arpeggio <c f>4-)\arpeggio |
-<a c'>4-(\arpeggio\> <g bf>4-)\arpeggio\! <d fs>4-(\arpeggio <d g>4-)\arpeggio |
-<b d'>4-(\arpeggio\> <a c'>4-)\arpeggio\! <ef gs>4-(\arpeggio <ef a>4-)\arpeggio |
+\clef bass \set Score.connectArpeggios = ##t <g, bf,>2-(\arpeggio <a, c>2\arpeggio |
+<bf, df>2\arpeggio <a, c>2-)\arpeggio |
+<c ef>2-(\arpeggio <bf, df>2-)\arpeggio |
+<ef gf>2-(\arpeggio <df f>2-)\arpeggio |
+<f af>4-(\arpeggio <ef g>4-)\arpeggio <bf, d>4-(\arpeggio <bf, ef>4-)\arpeggio |
+<g bf>4-(\arpeggio <f a>4-)\arpeggio <c e>4-(\arpeggio <c f>4-)\arpeggio |
+<a c'>4-(\arpeggio <g bf>4-)\arpeggio <d fs>4-(\arpeggio <d g>4-)\arpeggio |
+<b d'>4-(\arpeggio <a c'>4-)\arpeggio <ef gs>4-(\arpeggio <ef a>4-)\arpeggio |
 <ef f c' ef'>4\arpeggio^\markup{\italic{sostenuto}} <d f bf d'>4\arpeggio <g a c' ef' g'>4\arpeggio <f bf d' f'>4\arpeggio |
-\clef "treble" <a c' ef' f' a'>4\arpeggio <f bf d' f' bf'>4\arpeggio <ef' f' c'' ef''>4\arpeggio^\markup{\italic{sempre cresc}} <d' f' bf' d''>4\arpeggio |
+\clef "treble" <a c' ef' f' a'>4\arpeggio <f bf d' f' bf'>4\arpeggio <ef' f' c'' ef''>4\arpeggio^\markup{\italic{sempre cresc.}} <d' f' bf' d''>4\arpeggio |
 <g' a' c'' ef'' g''>4\arpeggio <f' bf' d'' f''>4\arpeggio <a' c'' ef'' f'' a''>4\arpeggio <f' bf' d'' f'' bf''>4\arpeggio |
-<ef'' f'' c''' ef'''>4\arpeggio <d'' f'' bf'' d'''>4\arpeggio <ef'' a'' c''' ef'''>4\arpeggio\f <ef'' a'' c''' ef''' e'''>4\arpeggio |
-<ef'' a'' c''' ef''' f'''>4\arpeggio^\markup{\italic{poco accel.}} <ef'' a'' c''' ef''' e'''>4\arpeggio_\markup{\italic{sempre cresc.}} <ef'' a'' c''' ef''' f'''>4\arpeggio <ef'' a'' c''' ef''' fs'''>4\arpeggio |
-<ef'' a'' c''' ef''' f'''>4\arpeggio <ef'' a'' c''' ef''' fs'''>4\arpeggio <ef'' a'' c''' ef''' g'''>4\arpeggio\< <ef'' a'' c''' ef''' fs'''>4\arpeggio |
+<ef'' f'' c''' ef'''>4\arpeggio <d'' f'' bf'' d'''>4\arpeggio <ef'' a'' c''' ef'''>4\arpeggio <ef'' a'' c''' ef''' e'''>4\arpeggio |
+<ef'' a'' c''' ef''' f'''>4\arpeggio^\markup{\italic{poco accel.}} <ef'' a'' c''' ef''' e'''>4\arpeggio <ef'' a'' c''' ef''' f'''>4\arpeggio <ef'' a'' c''' ef''' fs'''>4\arpeggio |
+<ef'' a'' c''' ef''' f'''>4\arpeggio <ef'' a'' c''' ef''' fs'''>4\arpeggio <ef'' a'' c''' ef''' g'''>4\arpeggio <ef'' a'' c''' ef''' fs'''>4\arpeggio |
 <ef'' a'' c''' ef''' g'''>4\arpeggio <ef'' a'' c''' ef''' gs'''>4\arpeggio a'''2~\startTrillSpan\sf |
 a'''1~ |
 \afterGrace a'''1_\markup{\italic{poco ritard}} { g'''16\stopTrillSpan a'''16 }  |
@@ -293,18 +293,134 @@ a'''1~ |
 
 <<
 { \set Staff.connectArpeggios = ##f <bf'' d''' f''' bf'''>1\arpeggio |
-<f'' bf'' d''' f'''>1_\markup{\italic{smorzando}} |
+<f'' bf'' d''' f'''>1 |
 <d'' f'' bf'' d'''>1 |
 \omit r1 }
 \\
-{ r4 r8 f8(\< f'2)\! |
+{ r4 r8 f8(^\< f'2)\! |
 r4 r8 d'8(\< d''2)\! |
 r4 r8 bf'8-(\< bf''2-~-)\! |
 bf''1 }
 >>
 |
-\clef bass \set Score.connectArpeggios = ##t <d f bf d'>2\ppp <d f bf d'>2 |
+\clef bass \set Score.connectArpeggios = ##t <d f bf d'>2 <d f bf d'>2 |
 <d f bf d'>1\arpeggio\fermata |
+} >>
+<< \new Dynamics {\key bf \major
+\time 4/4
+r1\mf |
+r2 r4. r8 |
+r4 r2._\markup{\dynamic{pp} \italic{e legatissimo}} |
+r1 |
+r1 |
+r1 |
+r1\mf |
+r2 r4. r8 |
+r4 r2.\pp |
+r1 |
+r1 |
+r1 |
+r1_\markup{\italic{poco cresc.}} |
+r1 |
+r2\< r2\> |
+r1\! |
+r1\< |
+r1\! |
+r4 r2._\markup{\italic{dim.}} |
+r2.\> r4\p |
+r1_\markup{\italic{cresc. poco a poco}} |
+r1 |
+r2\< r2\rfz |
+r2.\>_\markup{\italic{dim.}} r4\p |
+r2 \tuplet 3/2 {r8 r8 r8\<} %{ end triplets %} r4 |
+r4\> r2.\! |
+r4\> r2.\< |
+r1\p |
+r4 r2.\> |
+r2.\< r4\> |
+r2.\! r4\p |
+r1 |
+r2 r2_\markup{\italic{poco cresc.}} |
+r1 |
+r1\p |
+\tuplet 3/2 {r8 r8 r8_\markup{\italic{smorz.}}} %{ end triplets %} r2. |
+r1 |
+r1 |
+r1 |
+r1 |
+r1 |
+r1 |
+r1 |
+r1 |
+r1 |
+r1 |
+r1 |
+r1 |
+r1_\markup{\italic{sempre cresc. e sempre} Ped.} |
+r1 |
+r1\f |
+r2..\< r8\! |
+r8\ff r8_\markup{\italic{sempre } Ped.} r2. |
+r1_\markup{\italic{poco accel.}} |
+r1_\markup{\dynamic{rfz} \italic{molto}} |
+r1 |
+r1_\markup{\italic{dim. poco a poco, ma sempre pedale}} |
+r1 |
+r1 |
+r1_\markup{\italic{poco rall.} \dynamic{p}} |
+r2..\> r8\! |
+r2.\omit \sustainOn r4\sustainOff |
+r1 |
+r1 |
+r1 |
+r1 |
+r2.. r8\p |
+r1 |
+r2.. r8_\markup{\italic{poco cresc.}} |
+r2.. r8_\markup{\italic{poco rinf.}} |
+r1 |
+r1 |
+r1 |
+r1 |
+r1 |
+r1 |
+r2.. r8_\markup{\italic{poco cresc.}} |
+r1 |
+r2 r8 r4._\markup{\italic{dim.}} |
+r1 |
+r1\pp |
+r1 |
+r1 |
+r1 |
+r1 |
+r1 |
+r1 |
+r1\p\< |
+r1\> |
+r1\> |
+r1\> |
+r4\> r2.\! |
+r4\> r2.\! |
+r4\> r2.\! |
+r4\> r2.\! |
+r1 |
+r1 |
+r1 |
+r2 r2\f |
+r4 r2.^\markup{\italic{sempre cresc.}} |
+r2 r2\< |
+r2 r2\ff |
+r1^\markup{\italic{dim. poco a poco}} |
+r2..\> r8\! |
+r1 |
+r1 |
+r1 |
+r1 |
+r1^\markup{\italic{smorz.}} |
+r1 |
+r1 |
+r1\ppp |
+r1 |
 } >>
 << \new Staff = "bass" \with {
 \consists "Span_arpeggio_engraver"
@@ -326,7 +442,7 @@ r4 a,4 bf,4 <ef, ef>4 |
 r4 g,4 a,4 <bf,, bf,>4 |
 
 <<
-{ a,4( af,4 g,2) }
+{ a,4(^\markup{\italic{dim.}} af,4 g,2) }
 \\
 { c,2. c,4 }
 >>
@@ -354,7 +470,7 @@ e,2. e,4 }
 \omit TupletNumber \tuplet 3/2 {<e, gs,>8 <e, gs,>8 <e, gs,>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<e, d>8 <e, d>8 <e, d>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<e, cs>8 <e, cs>8 <e, cs>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<e, a,>8 <e, a,>8 <e, a,>8} %{ end triplets %} |
 \omit TupletNumber \tuplet 3/2 {<e, fs,>8 <e, fs,>8 <e, fs,>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<gs,, e, gs,>8 <gs,, e, gs,>8 <gs,, e, gs,>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<a,, e, a,>8 <a,, e, a,>8 <a,, e, a,>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<cs, e, cs>8 <cs, e, cs>8 <cs, e, cs>8} %{ end triplets %} |
 \omit TupletNumber \tuplet 3/2 {e,8 e,8 e,8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<e, ds>8 <e, ds>8 <e, ds>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<e, e>8 <e, e>8 <e, e>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<d, d>8 <d, d>8 <d, d>8} %{ end triplets %} |
-\omit TupletNumber \tuplet 3/2 {<cs, gs, cs>8 <cs, gs, cs>8 <cs, gs, cs>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<gs, gs>8 <gs, gs>8 <gs, gs>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<es, gs, es>8 <es, gs, es>8 <es, gs, es>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<cs, gs, cs>8 <cs, gs, cs>8 <cs, gs, cs>8} %{ end triplets %} |
+\omit TupletNumber \tuplet 3/2 {<cs, gs, cs>8\sustainOn <cs, gs, cs>8 <cs, gs, cs>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<gs, gs>8 <gs, gs>8 <gs, gs>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<es, gs, es>8 <es, gs, es>8 <es, gs, es>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<cs, gs, cs>8 <cs, gs, cs>8 <cs, gs, cs>8} %{ end triplets %} |
 \omit TupletNumber \tuplet 3/2 {<bs,, gs, bs,>8 <bs,, gs, bs,>8 <bs,, gs, bs,>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<ds, gs, ds>8 <ds, gs, ds>8 <ds, gs, ds>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<bs,, gs, bs,>8 <bs,, gs, bs,>8 <bs,, gs, bs,>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<gs,, gs,>8 <gs,, gs,>8 <gs,, gs,>8} %{ end triplets %} |
 \omit TupletNumber \tuplet 3/2 {<fss,, ds, fss,>8 <fss,, ds, fss,>8 <fss,, ds, fss,>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<as,, ds, as,>8 <as,, ds, as,>8 <as,, ds, as,>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<ds,, ds,>8 <ds,, ds,>8 <ds,, ds,>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<fss,, ds, fss,>8 <fss,, ds, fss,>8 <fss,, ds, fss,>8} %{ end triplets %} |
 \omit TupletNumber \tuplet 3/2 {<gs,, ds, gs,>8 <gs,, ds, gs,>8 <gs,, ds, gs,>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<ds, ds>8 <ds, ds>8 <ds, ds>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<gs, ds gs>8 <gs, ds gs>8 <gs, ds gs>8} %{ end triplets %} \omit TupletNumber \tuplet 3/2 {<gs b>8 <gs b>8 <gs b>8} %{ end triplets %} |
@@ -368,7 +484,7 @@ e,2. e,4 }
 <<
 { <c ef>4-( |
 <bf, d>4 <gs, b,>4 <a, c>4-) <d f>4-( |
-<c ef>4 <a, cs>4 <bf, d>4-)^\markup{\italic{poco cresc.}} <ef g>4-( |
+<c ef>4 <a, cs>4 <bf, d>4-) <ef g>4-( |
 <c ef>4 <a, f>4 <bf, d>4 <g, ef>4 |
 <a, c>4-) }
 \\
@@ -425,8 +541,8 @@ f,2.\arpeggio }
 r4 |
 r4 r8 
 <<
-{ c8-( c'2~ |
-c'8 d'8 bf8 g8-) f2-(\arpeggio |
+{ c8-( c'2~^\< |
+c'8 d'8\! bf8 g8-) f2-(\arpeggio |
 e4-) }
 \\
 { \omit r8 r4 \omit r4 |
@@ -439,7 +555,7 @@ e4-) }
 >>
 r2 r8 
 <<
-{ a,8(^\p |
+{ a,8( |
 a2.) \omit r8 bf,8( |
 bf2.) \omit r8 b,8( |
 b2.) }
@@ -484,7 +600,7 @@ bf,8\(\< |
 bf8 c'8\! af8 fs8 g8 af8 f8 d8\) |
 
 <<
-{ ef8\( c8 d8 g,8 f,4 ef4\) }
+{ ef8\( c8 d8 g,8 f,4_\markup{\italic{ten.}} ef4\) }
 \\
 { \omit r2 f,2 }
 >>
@@ -500,7 +616,7 @@ f8.(\> ef16 d2 ef8 c8)\! |
 <bf,, e, g,>2\arpeggio <f,, c, f,>2)\arpeggio |
 <a,, c, gf,>2(\arpeggio <bf,, df, f,>2)\arpeggio |
 <c, ef, af,>2(\arpeggio <df, f, af,>2)\arpeggio |
-<d, f, bf,>4(\arpeggio <ef, g, bf,>4)\arpeggio <af,, bf,, f,>4(\arpeggio <g,, bf,, ef,>4)\arpeggio |
+<d, f, bf,>4(\arpeggio <ef, g, bf,>4)\arpeggio <af,, bf,, f,>4(\arpeggio^\markup{\italic{cresc. - - - - - - - - - - - - - - poco - - - - - - - - a - - - - - - poco}} <g,, bf,, ef,>4)\arpeggio |
 <e, g, c>4(\arpeggio <f, a, c>4)\arpeggio <bf,, c, g,>4(\arpeggio <a,, c, f,>4)\arpeggio |
 <fs, a, d>4(\arpeggio <g, bf, d>4)\arpeggio <c, d, a,>4(\arpeggio <bf,, d, g,>4)\arpeggio |
 <gs, b, ef>4(\arpeggio <a, c ef>4)\arpeggio <d, ef, b,>4(\arpeggio <c, ef, a,>4)\arpeggio |
@@ -510,9 +626,9 @@ f8.(\> ef16 d2 ef8 c8)\! |
 <a c' ef' f' a'>4\arpeggio\sustainOn\sustainOff  <bf d' f' bf'>4\arpeggio\sustainOn\sustainOff  <f a c' ef' a'>4\arpeggio_\markup{Ped. \italic{sempre}}\sustainOff  <f a c' ef' a'>4\arpeggio |
 <f a c' ef' a'>4\arpeggio <f a c' ef' a'>4\arpeggio <f a c' ef' a'>4\arpeggio <f a c' ef' a'>4\arpeggio |
 <f, a, c ef a>4\arpeggio <f a c' ef' a'>4\arpeggio <f a c' ef' a'>4\arpeggio <f, a, c ef a>4\arpeggio |
-<f, a, c ef a>4\arpeggio <f a c' ef' a'>4\arpeggio <f' a' c'' ef'' a''>4\arpeggio <f a c' ef' a'>4\arpeggio^\ff |
-<f, a, c ef a>4\arpeggio^\markup{\italic{dim poco a poco}} <f a c' ef' a'>4\arpeggio <f, a, c ef a>4\arpeggio <f,, a,, c, ef, a,>4\arpeggio |
-<f, a, c ef a>4\arpeggio_\markup{Ped. \italic{sempre}}^\> <f, ef g>4\arpeggio \set Staff.pedalSustainStyle = #'text <f, d f>4\arpeggio\omit \sustainOn  <f, c ef>4\arpeggio\!\sustainOff \break
+<f, a, c ef a>4\arpeggio <f a c' ef' a'>4\arpeggio \clef "treble" <f' a' c'' ef'' a''>4\arpeggio^\sf <f a c' ef' a'>4\arpeggio |
+\clef "bass" <f, a, c ef a>4\arpeggio <f a c' ef' a'>4\arpeggio <f, a, c ef a>4\arpeggio <f,, a,, c, ef, a,>4\arpeggio |
+<f, a, c ef a>4\arpeggio_\markup{Ped. \italic{sempre}} <f, ef g>4\arpeggio \set Staff.pedalSustainStyle = #'text <f, d f>4\arpeggio\omit \sustainOn  <f, c ef>4\arpeggio\sustainOff \break
 |
 <bf,, d, f, bf,>4\arpeggio_\markup{Ped. \italic{sempre}} <d, f, bf, d>4\arpeggio <f, bf, d f>4\arpeggio <bf, d f bf>4\arpeggio |
 <d f bf d'>4\arpeggio <f bf d'>4\arpeggio <bf d'>4\arpeggio <f bf d'>4\arpeggio |


### PR DESCRIPTION
This is the sheet music for Alkan's Op. 45 paraphrase, "Salut, cendre du pauvre!". It is broadly based on this imslp source, however I made a number of changes, including:

1. I change key a few times, whereas the source just inserts vast numbers of accidentals.
2. I use a hybrid staff for the right hand as it often spans traditional treble and bass staves.
3. Throughout I modernize some of the notation (e.g. using modern pedal notation in some parts where it works better than the sources alternative format).

Note that the file does compile to midi, but produces a warning when doing so. This stems from the pieces unusual pedal notation.

Cheers,
Tom