### PR TITLE
Mozart, W.A. -- Divertimento in D, KV 136

### DIFF
--- a/ftp/MozartWA/KV136/book.ily
+++ b/ftp/MozartWA/KV136/book.ily
@@ -1,0 +1,5 @@
+\version "2.24.1"
+
+\book {
+  #(whenscore (set-global-staff-size 14))
+}

--- a/ftp/MozartWA/KV136/definitions.ily
+++ b/ftp/MozartWA/KV136/definitions.ily
@@ -1,0 +1,5 @@
+\version "2.24.1"
+
+#(define-syntax-rule (whenscore stmt stmt* ...)
+  (if (and (defined? 'score-type) (string=? score-type "score"))
+   (begin stmt stmt* ...)))

--- a/ftp/MozartWA/KV136/header.ily
+++ b/ftp/MozartWA/KV136/header.ily
@@ -1,0 +1,56 @@
+\version "2.24.1"
+
+\header {
+  date = "1772"
+  style = "Classical"
+  source = "Mozarts Werke; Breitkopf und Härtel, 1882"
+  composer = "W.A. Mozart"
+  opus = "KV 136"
+  title = "Divertimento in D"
+  subtitle = "I"
+
+  maintainer = "YTG123"
+  maintainerEmail = "ytg1234 (at) pm (dot) me"
+  license = "Creative Commons Attribution-ShareAlike 4.0 International"
+
+  properEmail = "ytg1234@pm.me"
+
+  mutopiatitle = "Divertimento in D"
+  mutopiaopus = "KV 136"
+  mutopiacomposer = "MozartWA"
+  mutopiainstrument = "Orchestra: Violins, Viola, Cello"
+
+  footer = "Mutopia-2023/04/02"
+  
+  copyright =  \markup {
+	\override #'(baseline-skip . 0 ) \right-column {
+	  \sans \bold \with-url #"https://www.mutopiaproject.org" {
+		\abs-fontsize #9  "Mutopia " \concat {
+		  \abs-fontsize #12 \with-color #white \char ##x01C0 \abs-fontsize #9 "Project "
+		}
+	  }
+	}
+	\override #'(baseline-skip . 0 ) \center-column {
+	  \abs-fontsize #11.9 \with-color #grey \bold {
+		\char ##x01C0 \char ##x01C0
+	  }
+	}
+	\override #'(baseline-skip . 0 ) \column {
+	  \abs-fontsize #8 \sans \concat {
+		" Typeset using " \with-url #"https://lilypond.org" "LilyPond"
+		" by " \with-url #(string-append "mailto:" properEmail) \maintainer " " \char ##x2014 " "
+		\footer
+	  }
+	  \concat {
+		\concat {
+		  \abs-fontsize #8 \sans {
+			" Licensed under "
+			\with-url #"https://creativecommons.org/licenses/by-sa/4.0/" "CC BY-SA 4.0"
+			" by the typesetter " \char ##x2014 " free to distribute, modify, and perform"
+		  }
+		} \abs-fontsize #13 \with-color #white \char ##x01C0
+	  }
+	}
+  }
+ tagline = ##f
+}

--- a/ftp/MozartWA/KV136/kv-136-I/kv-136-I-lys/MozartWA-KV136-I-Part-cello.ly
+++ b/ftp/MozartWA/KV136/kv-136-I/kv-136-I-lys/MozartWA-KV136-I-Part-cello.ly
@@ -1,0 +1,16 @@
+\version "2.24.1"
+\language nederlands
+
+\include "../../master.ily"
+\include "./cello.ily"
+
+\header {
+  instrument = "Basso"
+}
+
+\score {
+  \new Staff = "cello" {
+	\accidentalStyle modern
+	\new Voice \cello
+  }
+}

--- a/ftp/MozartWA/KV136/kv-136-I/kv-136-I-lys/MozartWA-KV136-I-Part-viola.ly
+++ b/ftp/MozartWA/KV136/kv-136-I/kv-136-I-lys/MozartWA-KV136-I-Part-viola.ly
@@ -1,0 +1,16 @@
+\version "2.24.1"
+\language nederlands
+
+\include "../../master.ily"
+\include "./viola.ily"
+
+\header {
+  instrument = "Viola"
+}
+
+\score {
+  \new Staff = "viola" {
+	\accidentalStyle modern
+	\new Voice \viola
+  }
+}

--- a/ftp/MozartWA/KV136/kv-136-I/kv-136-I-lys/MozartWA-KV136-I-Part-violin1.ly
+++ b/ftp/MozartWA/KV136/kv-136-I/kv-136-I-lys/MozartWA-KV136-I-Part-violin1.ly
@@ -1,0 +1,17 @@
+\version "2.24.1"
+\language nederlands
+
+\include "../../master.ily"
+\include "./violin1.ily"
+
+\header {
+  instrument = "Violino I"
+}
+
+\score {
+  \new Staff = "violin1" {
+	\accidentalStyle modern
+	\new Voice \violinI
+  }
+  \layout {}
+}

--- a/ftp/MozartWA/KV136/kv-136-I/kv-136-I-lys/MozartWA-KV136-I-Part-violin2.ly
+++ b/ftp/MozartWA/KV136/kv-136-I/kv-136-I-lys/MozartWA-KV136-I-Part-violin2.ly
@@ -1,0 +1,16 @@
+\version "2.24.1"
+\language nederlands
+
+\include "../../master.ily"
+\include "./violin2.ily"
+
+\header {
+  instrument = "Violino II"
+}
+
+\score {
+  \new Staff = "violin2" {
+	\accidentalStyle modern
+	\new Voice \violinII
+  }
+}

--- a/ftp/MozartWA/KV136/kv-136-I/kv-136-I-lys/MozartWA-KV136-I-midi.ly
+++ b/ftp/MozartWA/KV136/kv-136-I/kv-136-I-lys/MozartWA-KV136-I-midi.ly
@@ -1,0 +1,29 @@
+\version "2.24.1"
+\language nederlands
+
+\include "../../master.ily"
+\include "articulate.ly"
+\include "./common.ily"
+\include "./violin1.ily"
+\include "./violin2.ily"
+\include "./viola.ily"
+\include "./cello.ily"
+
+\score {
+  <<
+	\new Staff = "violin1" \with { midiInstrument = "violin" } {
+	  \new Voice \articulate { \midiTempo \unfoldRepeats \violinI }
+	}
+	\new Staff = "violin2" \with { midiInstrument = "violin" } {
+	  \new Voice \articulate { \midiTempo \unfoldRepeats \violinII }
+	}
+	\new Staff = "viola" \with { midiInstrument = "viola" } {
+	  \new Voice \articulate { \midiTempo \unfoldRepeats \viola }
+	}
+	\new Staff = "cello" \with { midiInstrument = "cello" } {
+	  \new Voice \articulate { \midiTempo \unfoldRepeats \cello }
+	}
+  >>
+
+  \midi {}
+}

--- a/ftp/MozartWA/KV136/kv-136-I/kv-136-I-lys/MozartWA-KV136-I-score.ly
+++ b/ftp/MozartWA/KV136/kv-136-I/kv-136-I-lys/MozartWA-KV136-I-score.ly
@@ -1,0 +1,49 @@
+\version "2.24.1"
+\language nederlands
+
+score-type = #"score"
+
+\include "articulate.ly"
+\include "../../master.ily"
+\include "./common.ily"
+\include "./violin1.ily"
+\include "./violin2.ily"
+\include "./viola.ily"
+\include "./cello.ily"
+
+\header {
+  instrument = "Partitura"
+}
+
+\paper {
+  system-separator-markup = \slashSeparator
+}
+
+\score {
+  \new StaffGroup <<
+	\accidentalStyle StaffGroup.modern
+	\new Staff = "violin1" \with {
+	  instrumentName = "Violino I"
+	  shortInstrumentName = "Vln. I"
+	}
+	{ \new Voice \violinI }
+	\new Staff = "violin2" \with {
+	  instrumentName = "Violino II"
+	  shortInstrumentName = "Vln. II"
+	}
+	{ \new Voice \violinII }
+	\new Staff = "viola" \with {
+	  instrumentName = "Viola"
+	  shortInstrumentName = "Vla."
+	}
+	{ \new Voice \viola }
+	\new Staff = "cello" \with {
+	  instrumentName = "Basso"
+	  shortInstrumentName = "Vlc."
+	}
+	<<
+	  \new Voice \cello
+	  \new Voice \breaks
+	>>
+  >>
+}

--- a/ftp/MozartWA/KV136/kv-136-I/kv-136-I-lys/cello.ily
+++ b/ftp/MozartWA/KV136/kv-136-I/kv-136-I-lys/cello.ily
@@ -1,0 +1,102 @@
+\version "2.24.1"
+\language nederlands
+
+\include "./common.ily"
+
+cello = \relative d {
+  \common
+  \clef bass
+  \repeat volta 2 {
+	\once \override Staff.Parentheses.font-size = 2
+	d8\parenthesize \f \repeat unfold 31 { d8 } |
+	\barNumberCheck #5
+	a8 8 8 8 8 8 8 8 |
+	d8 8 8 8 8 8 e e |
+	fis8 8 8 8 8 8 8 8 |
+	g8 8 8 8 8 8 8 8 |
+	a8 8 8 8 8 8 8 8 |
+	a,8 8 8 8 8 8 8 8 |
+	d4 r8 a8 d4 r8 a'8 |
+	d,4 r8 a8 d4 r8 a'8 |
+
+	\repeat unfold 16 { d,8 } |
+	\repeat unfold 15 { e } gis |
+	a8 8 8 8 cis8 8 8 8 |
+	b8 8 8 8 gis8 8 8 8 |
+	a8 8 8 8 cis8 8 8 8 |
+	b8 8 8 8 e,8 8 8 8 |
+	a,4 r4 r2 |
+	r2 r8 a'8 a, b\turn |
+	cis8 8 8 8 8 8 8 8 |
+	d8 8 8 8 8 8 8 8 |
+	e8 8 8 8 8 8 8 8 |
+	d8 8 8 8 8 8 8 8 |
+	cis8 8 8 8 4 r4 |
+	d8 8 8 8 4 r4 |
+	e8 8 8 8 4 r4 |
+	fis4 r4 r2 |
+	r4 e( d cis) |
+	d8 8 8 8 8 8 8 8 |
+	e8 8 8 8 8 8 8 8 |
+	\repeat unfold 20 { a,8 } a4-. r4 |
+  } \repeat volta 2 {
+	c8 8 8 8 8 8 8 8 |
+	\repeat unfold 32 { b8 } |
+	e e fis8 8 g g, g gis |
+	a8 8 8 8 8 8 8 8 |
+	8 8 8 8 g'8 8 8 8 |
+	fis8 8 8 8 8 8 8 8 |
+	b,8 8 8 8 8 8 8 8 |
+	fis'8 8 8 8 8 8 8 8 |
+	b8 8 8 8 gis8 8 8 8 |
+	a8 8 8 8 fis8 8 8 8 |
+	g!8 8 8 8 8 8 gis8 8 |
+	a4 a,8. 16 4 r4 |
+
+	d4\p^"pizz." r d r |
+	g r g r |
+	a r a r |
+	bes r bes r |
+	f r f r |
+	g r g r |
+	g r g gis |
+	a r a r |
+	a, r a r |
+	a' r a r |
+	bes r bes, r |
+	a r4 r2 |
+	r8 a'8^"arco"( b! a g! fis g e) |
+
+	d8\f \repeat unfold 31 { d8 } |
+	a8 8 8 8 8 8 8 8 |
+	d8 8 8 8 8 8 e e |
+	fis8 8 8 8 8 8 8 8 |
+	g8 8 8 8 8 8 8 8 |
+	a8 8 8 8 8 8 8 8 |
+	a,8 8 8 8 8 8 8 8 |
+	d4 r8 a8 d4 r8 a'8 |
+	d,4 r8 a8 d4 r8 a'8 |
+
+	\repeat unfold 32 { d,8 } |
+	g g b b a a d, d |
+	g g a a g8 8 8 gis |
+	a a cis cis b b e, e |
+	a, a e' e cis cis a a |
+	d d fis fis e e a, a |
+	d d fis fis e e a, a |
+	b4 r4 r2 |
+	r2 r8 d8 d, e\turn |
+	fis fis'8 8 8 8 8 8 8 |
+	g8 8 8 8 g,8 8 8 8 |
+	a8 8 8 8 8 8 8 8 |
+	g8 8 8 8 g'8 8 8 8 |
+	fis8 8 8 8 4 r4 |
+	g8 8 8 8 4 r4 |
+	a8 8 8 8 4 r4 |
+	b4 r4 r2 |
+	r4 a,4( g fis) |
+	g8 8 8 8 g'8 8 8 8 |
+	a8 8 8 8 a,8 8 8 8 |
+	\stemDown \repeat unfold 20 { d8 } \stemNeutral d,4-. r4 |
+  }
+}

--- a/ftp/MozartWA/KV136/kv-136-I/kv-136-I-lys/common.ily
+++ b/ftp/MozartWA/KV136/kv-136-I/kv-136-I-lys/common.ily
@@ -1,0 +1,16 @@
+\version "2.24.1"
+\language nederlands
+
+common = {
+  \key d \major
+  \time 4/4
+  \tempo "Allegro"
+}
+
+breaks = {
+  s1*36 \break
+}
+
+midiTempo = {
+  \tempo 4 = 120
+}

--- a/ftp/MozartWA/KV136/kv-136-I/kv-136-I-lys/viola.ily
+++ b/ftp/MozartWA/KV136/kv-136-I/kv-136-I-lys/viola.ily
@@ -1,0 +1,116 @@
+\version "2.24.1"
+\language nederlands
+
+\include "./common.ily"
+
+viola = \relative d' {
+  \common
+  \clef alto
+  \repeat volta 2 {
+	\once \override Staff.Parentheses.font-size = 2
+	d8\parenthesize \f 8 8 8 8 8 8 8 |
+	8 8 8 8 a8 8 8 8 |
+	1~ |
+	8 fis'( a fis) d-. a( d fis) |
+	a,1 |
+	8 d4 fis4 8( e g) |
+	fis8 8 8 8 a8 8 8 8 |
+	g8 8 8 8 8 8( b e,) |
+	a a,8 8 8 8 8 8 8 |
+	8 8 8 8 8 8 8 8 |
+	4 r8 a'8 4 r8 e8 |
+	d4 r8 a'8 4 r8 g8 |
+
+	fis8 8 8 8 8 8 8 8 |
+	<a, fis'>8 q8 q8 q8 q8 d16 e fis8 8 |
+	b,8 8 8 8 8 8 8 8 |
+	<b gis'>8 q8 q8 q8 q8 e4 8~ |
+	8 4 4 4 8~ |
+	8 4 4 4 8 |
+	4 r4 r2 |
+	gis1 |
+	a4 r4 r2 |
+	r8 a8 a, b\turn cis e4 gis8 |
+	a4 r8 a4 e8( d cis) |
+	d8 8 8 8 8 8 8 8 |
+	e cis8 8 8 8 8 8 8 |
+	d8 8 8 8 8 8 b8 8 |
+	cis( e) e-. e-. e4 r4 |
+	a,8( fis') fis-. fis-. fis4 r4 |
+	a,8( cis) cis-. cis-. cis4 r4 |
+	d4 r4 r2 |
+	r4 cis( d cis) |
+	d8 4 4 4 fis8 |
+	e8 8 8 8 8 8 d d |
+	\repeat unfold 2 { cis-. cis( d b) cis-. e( fis d) | }
+	cis-. a16( gis a gis a gis) a4-. r4 |
+  } \repeat volta 2 {
+	c8 8 8 8 8 8 8 8 |
+	fis,8 8 8 8 a8 8 8 g! |
+	b1~ |
+	8 g'( b g) e4 r4 |
+	b1~ |
+	8 4 a g fis8 |
+	e8 8 8 8 8 8 8 8 |
+	e'8 8 8 8 8 8 8 8 |
+	fis,1~ |
+	8 d'( fis d) b4 r4 |
+	fis1~ |
+	8 fis'4 8 e2 |
+	8 4 8 d2 |
+	4 g,2 b8( e) |
+	e4 a8. 16 a,4 r4 |
+
+	r4 d,\p^"pizz." r d |
+	r g r g |
+	r a r a |
+	r bes r bes |
+	r f r f |
+	r g r g |
+	r g g gis |
+	a a r a |
+	r a r a |
+	r a r a |
+	bes r d r |
+	e r4 r2 | R1 |
+
+	d8\f^"arco" 8 8 8 8 8 8 8 |
+	8 8 8 8 a8 8 8 8 |
+	1~ |
+	8 fis'( a fis) d4 r |
+	a1 |
+	8 fis'4 4 8( e g) |
+	fis8 8 8 8 a8 8 8 8 |
+	b g4 4 8( b e,)
+	a,8 8 8 8 8 8 8 8 |
+	8 8 8 8 8 8 8 8 |
+	4 r8 a'8 4 r8 e8 |
+	d4 r8 a'8 4 r8 g8 |
+
+	fis8 8 8 8 <a, fis'>8 q8 q8 q8 |
+	q8 q8 q8 q8 q8 q8 q8 q8 |
+	d8 8 8 8 8 8 8 8 |
+	<fis a>8 q8 q8 q8 q8 d4 8~ |
+	8 4 4 4 8~ |
+	4 a'( g) e |
+	4 a( gis) b,8( gis) |
+	a4 g'( e) cis |
+	d2 cis4 e8( cis) |
+	d( fis a d,) cis4 e8( cis) |
+	d4 r4 r2 |
+	r8 d8 d, e\turn fis a4 cis8 |
+	d8 4 4 a'8( g fis) |
+	g8 8 8 8 g,8 8 8 8 |
+	a fis8 8 8 8 8 8 8 |
+	g8 8 8 8 b b a8 8 |
+	8( d) d-. d-. d4 r4 |
+	b8( d) d-. d-. d4 r4 |
+	d8( fis) fis-. fis-. fis4 r4 |
+	g r4 r2 |
+	r4 fis,( g fis) |
+	g8 g'4 4 4 8 |
+	a8 8 8 8 a,8 a g g |
+	\repeat unfold 2 { fis fis' g e fis d b g | }
+	fis8-. d'16( cis d cis d cis) d4-. r4 |
+  }
+}

--- a/ftp/MozartWA/KV136/kv-136-I/kv-136-I-lys/violin1.ily
+++ b/ftp/MozartWA/KV136/kv-136-I/kv-136-I-lys/violin1.ily
@@ -1,0 +1,106 @@
+\version "2.24.1"
+\language nederlands
+
+\include "./common.ily"
+
+violinI = \relative d'' {
+  \common
+  \clef treble
+  \repeat volta 2 {
+	\once \override Staff.Parentheses.font-size = 2
+	a'1\parenthesize \f |
+	\grace g16 fis2 \grace e16 d2 |
+	\repeat unfold 3 { cis16( d e d) } cis( d e cis) |
+	d4 r r8 a'( fis d) |
+	\repeat unfold 3 { e16(fis g fis) } e( fis g e) |
+	fis4 d4. e16 fis g a b cis |
+	d2 a4 fis |
+	fis16( g dis e) e4 r8 e( g b) |
+	\grace gis16 a2 \grace gis16 a4 \grace gis16 a4 |
+	\grace a16 g4 \grace fis16 g4. fis16 g a g fis e |
+	d! a fis a d a e' a, fis' d a' fis g e d cis |
+	d a fis a d a e' a, fis' d fis a g e d cis |
+	d4 r4 r2 | R1 |
+	\barNumberCheck #15
+	d'2. b8. gis16 |
+	d4 b8. gis16 e8 b'16 cis d8 d |
+	cis16 a b cis d e fis gis a b cis b a gis fis e |
+	d b cis d e fis gis a b a gis a gis fis e d |
+	cis4 e2.~ |
+	1~ |
+	4 r4 r8 a a, b\turn |
+	cis4 cis8 d e cis'16 a e8 d |
+	cis e a4. g8(fis eis) |
+	\grace eis16 fis2 \grace eis16 fis4 \grace eis16 fis4 |
+	ais,,1 |
+	b2 fis''4 gis |
+	\repeat unfold 3 { a2~ 16 gis-. fis-. e-. d-. cis-. b-. a-. | }
+	a'8-. gis16-. fis-. e-. d-. cis-. b-. a-. gis-. fis-. e-. d-. cis-. b-. a-. |
+	g!4( g' fis eis) |
+	fis a'2 \grace gis16 fis8 e16 d |
+	cis8 e \grace d16 cis8 b16 a b2\trill |
+	\repeat unfold 2 { a8 e'16( g!) fis( a) gis( b) a4 r4 | }
+	a,8-. a'16( b a b a b) a4-. r4
+  } \repeat volta 2 {
+	a1 |
+	\grace b16 a2 \grace g!16 fis4. e8 |
+	dis16( \repeat unfold 3 { e fis e dis } e fis dis |
+	e4) r4 r8 b'8( g e) |
+	fis16( \repeat unfold 3 { g a g fis } g a fis |
+	g4) r4 r2 |
+	g1 |
+	\grace fis16 e2 \grace d16 cis2 |
+	\stemDown ais16( \repeat unfold 3 { b cis b ais } b cis ais |
+	\stemNeutral b4) r4 r8 fis'8( d b) |
+	cis16( \repeat unfold 3 { d e d cis } d e cis |
+	d4) r4 e,16 fis gis a! b c d b |
+	c4 r4 d,16 e fis g a b c a |
+	b4 b'4. \grace a16 g8 \grace fis16 e8 \grace e16 d8 |
+	cis!4 <a a'>8. q16 q4 r4 |
+	a'1\p | bes | cis, |
+	d4 r4 r2 |
+	d2. a'8( f) |
+	e4 e r4 r8 bes'8 |
+	2.( d,4) |
+	cis \repeat unfold 2 { r8 a' \grace g16 f2\trill |
+	e4 } r8 a8 a a a a |
+	gis4( f e d) |
+	cis r4 r2 | R1 |
+	a'1\f |						% Have to copy it verbatim, because
+								% the slurs are different
+	\grace g16 fis2 \grace e16 d2 |
+	cis16( \repeat unfold 3 { d e d cis } d e cis) |
+	d4 r r8 a'( fis d) |
+	e16( \repeat unfold 3 { fis g fis e } fis g e) |
+	fis4 d4. e16 fis g a b cis |
+	d2 a4 fis |
+	fis16( g dis e) e4-. r8 e( g b) |
+	\grace gis16 a2 \grace gis16 a4 \grace gis16 a4 |
+	\grace a16 g4 \grace fis16 g4. fis16 g a g fis e |
+	d! a fis a d a e' a, fis' d a' fis g e d cis |
+	d a fis a d a e' a, fis' d fis a g e d cis |
+	d4 r4 r2 | R1 |
+	\barNumberCheck #79
+	<d, fis' a>2. a''8. fis16 |
+	c4 a8. fis16 d8 a''16 b c8 c |
+	b16-. a-. g( fis) g-. fis-. e( d) c fis a g fis e d c |
+	b d g fis g fis e dis e g b a g fis e d |
+	cis4 e2.~ |
+	4 a2.~ |
+	16 d, fis a d cis b a g fis e d cis e a g |
+	fis e d cis d a b fis g fis e d cis e a g |
+	fis4 r4 r8 d'8 d, e\turn |
+	fis d'4( cis8) d( fis16 d) a8( g) |
+	fis4 d''4. c8( b ais) |
+	\grace ais16 b2 \grace ais16 b4 \grace ais16 b4 |
+	dis,,1 |
+	e2 b''4 cis |
+	\repeat unfold 3 { d2~ 16 cis-. b-. a-. g-. fis-. e-. d-. | }
+	d'8-. cis16-. b-. a-. g-. fis-. e-. d-. cis-. b-. a-. g-. fis-. e-. d-. |
+	c2( b4 ais) |
+	b4 d''2 \grace cis16 b8 a16 g |
+	fis8 a \grace g16 fis8 e16 d e2\trill |
+	\repeat unfold 2 { d4 r4 r8 fis16( a) g( e) d( cis) | }
+	d8-. fis16( g fis g fis g) fis4-. r4 |
+  }
+}

--- a/ftp/MozartWA/KV136/kv-136-I/kv-136-I-lys/violin2.ily
+++ b/ftp/MozartWA/KV136/kv-136-I/kv-136-I-lys/violin2.ily
@@ -1,0 +1,117 @@
+\version "2.24.1"
+\language nederlands
+
+\include "./common.ily"
+
+violinII = \relative d' {
+  \common
+  \clef treble
+  \repeat volta 2 {
+	\once \override Staff.Parentheses.font-size = 2
+	fis8\parenthesize \f 8 8 8 8 8 8 8 |
+	a8 8 8 8 fis8 8 8 8 |
+	\repeat unfold 3 { e16( fis g fis) } e( fis g e) |
+	fis4 r4 r8 d8( fis a) |
+	\repeat unfold 3 { cis,16( d e d) } cis( d e cis) |
+	d8 a'4 4 4 8 |
+	8 8 8 8 d8 8 8 8 |
+	8 b4 4 8( e g) |
+	\grace eis16 fis2 \grace eis16 fis4 \grace eis16 fis4 |
+	\grace dis16 e4 \grace dis16 e4. d16 e fis e d cis |
+	d4 r8 cis8 d4 r8 g,8 |
+	fis4 r8 cis'8 d4 r4 |
+
+	d'2. a8. fis16 |
+	d4 a8. fis16 d8 fis'16 gis a8 a |
+	\grace b16 a8.\trill gis16 4 r2 |
+	r2 r8 gis,16 a b8 8 |
+	a4 r4 r2 |
+	R1 |
+	r16 a b cis d e fis gis a b cis b a gis fis e |
+	d b cis d e fis gis a b a gis a gis fis e d |
+	cis8 a' a, b\turn cis a' cis, d\turn |
+	e a4 gis8 a e( cis b) |
+	a cis4 e a,4 8 |
+	8 8 8 8 8 8 8 8 |
+	g8 8 8 8 8 8 8 8 |
+	fis8 8 8 8 b, b e e |
+	e( a) a-. a-. a4 r4 |
+	fis8( a) a-. a-. a4 r4 |
+	cis,8( a') a-. a-. a4 r4 |
+	a4 r4 r2 |
+	r8 a,4 4 4 8 |
+	8 fis'8 8 8 8 fis' \grace e16 d8 cis16 b |
+	a4 a2 gis4\trill |
+	\repeat unfold 2 { a4 r4 r8 cis16( e) \stemDown d( b) a( gis) \stemNeutral | }
+	a8-. cis16( d cis d cis d) cis4-. r4 |
+  } \repeat volta 2 {
+	e,8 8 8 8 8 8 8 8 |
+	dis8 8 8 8 8 8 8 e |
+	fis16( \repeat unfold 3 { g a g fis } g a fis |
+	g4) r4 r8 g'8( e b) |
+	dis16( \repeat unfold 3 { e fis e dis } e fis dis |
+	e8) g,4 fis e d8 |
+	cis8 8 8 8 8 8 8 8 |
+	8 8 8 8 ais8 8 8 8 |
+	cis16( \repeat unfold 3 { d e d cis } d e cis |
+	d4) r4 r8 d'8( b fis) |
+	ais,16( \repeat unfold 3 { b cis b ais } b cis ais |
+	b4) d'8.\trill( cis32 d) b'4 r4 |
+	r4 c,8.\trill( b32 c) a'4 r4 |
+	r8 d,4( dis8) e b4 8 |
+	e,4 <cis' e>8. q16 q4 r4 |
+
+	\stemUp d,16\p( cis d e f g f e d cis d e f e f d) |
+	e( bes' d c bes c bes a bes a g a g f e f) |
+	e( d cis d e f g f g a bes a c bes a g) |
+	f( e d cis d e d e f e d cis d e f g) |
+	a( g f e d e f g a g f e d f g a) |
+	bes( a g f e f g a bes c bes a g a bes g) |
+	e( f g f g a bes a g f e g f b d f,) |
+	e( d cis d e d e cis d e f g a f e d) |
+	cis( d e d cis b cis a d e f g a f e d) |
+	cis( \repeat unfold 3 { d e d cis } d e cis) \stemNeutral |
+	d2 gis |
+	a8-. a([ b a)] g( fis g e) |
+	fis-. fis([ g fis)] e( d e cis) |
+
+	d\f fis8 8 8 8 8 8 8 |
+	a8 8 8 8 fis8 8 8 8 |		% See violin1.ily
+	e16( \repeat unfold 3 { fis g fis e } fis g e) |
+	fis4 r4 r8 fis8( d a') |
+	cis,16( \repeat unfold 3 { d e d cis } d e cis) |
+	d8 a'4 4 4 8 |
+	8 8 8 8 d8 8 8 8 |
+	8 b4 4 8( e g) |
+	\grace eis16 fis2 \grace eis16 fis4 \grace eis16 fis4 |
+	\grace dis16 e4 \grace dis16 e4. d16 e fis e d cis |
+	d4 r8 cis8 d4 r8 g,8 |
+	fis4 r8 cis'8 d4 r4 |
+
+	d'2. a8. fis16 |
+	d4 a8. fis16 d8 d''8 8 8 |
+	d( c) c4 r2 |
+	r2 r8 fis,16 g a8 a |
+	g4 g,( fis) fis'( |
+	g) c,( b) b, |
+	a16 a' cis e a gis fis e d cis b a gis b e d |
+	cis b a b cis d e fis g fis e d cis b a g |
+	fis4 a'2.~ |
+	1~ |
+	8 d,8 d, e\turn fis d' fis, g\turn |
+	a fis4( g8) a-. a( fis e) |
+	d a'4 4 d d8 |
+	8 8 8 8 d,8 8 8 8 |
+	c8 8 8 8 8 8 8 8 |
+	b8 8 8 8 e8 8 8 8 |
+	d( a') a-. a-. a4 r4 |
+	d,8( b') b-. b-. b4 r4 |
+	fis8( d') d-. d-. d4 r4 |
+	d4 r4 r2 |
+	r8 d,4 4 4 8~ |
+	8 b'8 8 8 8 d \grace a'16 g8 fis16 e |
+	d4 2 cis4\trill |
+	\repeat unfold 2 { d8-. a16( c) b( d) cis( e) d4 r4 | }
+	d8-. d16( e d e d e) d4-. r4 |
+  }
+}

--- a/ftp/MozartWA/KV136/master.ily
+++ b/ftp/MozartWA/KV136/master.ily
@@ -1,0 +1,6 @@
+\version "2.24.1"
+
+\include "./definitions.ily"
+\include "./header.ily"
+\include "./paper.ily"
+\include "./book.ily"

--- a/ftp/MozartWA/KV136/paper.ily
+++ b/ftp/MozartWA/KV136/paper.ily
@@ -1,0 +1,29 @@
+\version "2.24.1"
+
+\pointAndClickOff
+\paper {
+  %% inner-margin = 12\mm
+  %% outer-margin = 9\mm
+  %% top-margin = 12.6\mm
+  %% bottom-margin = 8\mm
+  print-page-number = ##t
+  two-sided = ##t
+
+  %% indent = 20\mm
+  short-indent = 5\mm
+  horizontal-shift = 0.0
+
+  ragged-bottom = ##f
+  ragged-last = ##f
+  ragged-last-bottom = ##f
+  ragged-right = ##f
+
+  %% score-system-spacing = #'((basic-distance . 14) (minimum-distance . 8) (padding . 1) (stretchability . 80))
+  %% markup-system-spacing = #'((basic-distance . 8) (padding . 1.5) (stretchability . 15))
+  %% score-markup-spacing = #'((basic-distance . 12) (padding . 0.5) (stretchability . 40))
+  %% markup-markup-spacing = #'((basic-distance . 1) (padding . 0.5))
+  %% top-system-spacing = #'((basic-distance . 1) (minimum-distance . 0) (padding . 1))
+  %% top-markup-spacing = #'((basic-distance . 0) (minimum-distance . 0) (padding . 1))
+  %% system-system-spacing = #'((basic-distance . 12) (minimum-distance . 12) (padding . 2) (stretchability . 60))
+  %% last-bottom-spacing = #'((basic-distance . 11) (minimum-distance . 10) (padding . 1) (stretchability . 0))
+}


### PR DESCRIPTION
The initial submission is *incomplete*; I've only typeset the first movement.

Things to consider:
- Violin I part at bar 32 in the Breitkopf & Härtel edition is clearly a mistake. I've fixed it.
- I've replaced some trills with turns, as that is how this piece is usually performed. I'm unsure as to how to justify that; it's not from any particular edition. Should I keep it that way?
- I've added slurs to the violin II part at bars 48, 49.
- I've heard the violin I part at bar 22 be performed in a number of ways. I copied the way B&H has it.
- B&H doesn't have short instrument names. Should I remove them?
- I didn't bother to switch the MIDI instrument to pizzicato strings for the pizz sections. Hopefully that's not required.
- I have some common files located in the opus directory. Should I make a separate copy for each movement?