### PR TITLE
Changes to update the LilyPond version from 2.10.33 to 2.24.

### DIFF
--- a/ftp/ChopinFF/O66/chopin_fantaisie-impromptu/chopin_fantaisie-impromptu.ly
+++ b/ftp/ChopinFF/O66/chopin_fantaisie-impromptu/chopin_fantaisie-impromptu.ly
@@ -1,4 +1,4 @@
-\version "2.10.33"
+\version "2.24.0"
 
 \header {
   title = "Fantaisie-Impromptu"
@@ -13,7 +13,25 @@
   mutopiainstrument = "Piano"
 
  footer = "Mutopia-2009/09/05-1693"
- tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-align { \small \line { Sheet music from \with-url #"http://www.MutopiaProject.org" \line { \teeny www. \hspace #-1.0 MutopiaProject \hspace #-1.0 \teeny .org \hspace #0.5 } • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url #"http://www.LilyPond.org" \line { \teeny www. \hspace #-1.0 LilyPond \hspace #-1.0 \teeny .org } by \maintainer \hspace #-1.0 . \hspace #0.5 Reference: \footer } } \line { \teeny \line { This sheet music has been placed in the public domain by the typesetter, for details see: \hspace #-0.5 \with-url #"http://creativecommons.org/licenses/publicdomain" http://creativecommons.org/licenses/publicdomain } } } }
+ tagline = \markup { \override #'(box-padding . 1.0) \override #'(baseline-skip . 2.7) \box \center-column { \small \line { Sheet music from \with-url "http://www.MutopiaProject.org" \line { \teeny www. \hspace #-1.0 MutopiaProject \hspace #-1.0 \teeny .org \hspace #0.5 } • \hspace #0.5 \italic Free to download, with the \italic freedom to distribute, modify and perform. } \line { \small \line { Typeset using \with-url "http://www.LilyPond.org" \line { \teeny www. \hspace #-1.0 LilyPond \hspace #-1.0 \teeny .org } by \maintainer \hspace #-1.0 . \hspace #0.5 Reference: \footer } } \line { \teeny \line { This sheet music has been placed in the public domain by the typesetter, for details see: \hspace #-0.5 \with-url "http://creativecommons.org/licenses/publicdomain" http://creativecommons.org/licenses/publicdomain } } } }
+}
+
+\paper { 
+  max-systems-per-page = 5
+  
+  system-system-spacing =
+    #'((basic-distance . 8) 
+       (minimum-distance . 4)
+       (padding . 2)
+       (stretchability . 60)) % defaults: 12, 8, 1, 60
+
+  last-bottom-spacing = 
+    #'((basic-distance . 6)
+       (minimum-distance . 4)
+       (padding . 3)
+       (stretchability . 30)) % defaults 1, 0, 1, 30
+    
+  top-system-spacing.minimum-distance = 10
 }
 
 %%% NOTES %%%
@@ -35,14 +53,15 @@ partAright = \relative c'' {
   gis16\p( a gis fisis gis cis e dis cis dis cis bis cis e gis) |
   r16 gis,( a gis fisis gis cis e dis cis dis cis bis cis e gis) |
   r16 a,(\< cis dis fis a cis dis\! 
-  #(set-octavation 1) \once \override Staff.OttavaBracket #'padding = #2.0
-  b'\> a gis fis e dis fis cis)\! #(set-octavation 0) |
+  \override Staff.OttavaBracket.text = \markup \normal-text \italic "8va"
+  \ottava #1 \once \override Staff.OttavaBracket.padding = #2.0
+  b'\> a gis fis e dis fis cis)\! \ottava #0 |
   bis( dis a gis fis a e dis) fis( cis bis dis a gis b a~) |
   %bar 9&87
   a16\p gis( a gis fisis gis cis e dis cis dis cis bis cis e gis) |
-  \setTextCresc r\< gis,( ais gis fisis gis cis e dis cis dis cis bis cis e gis\!) |
-  \setHairpinCresc dis(\< e dis cisis dis b' ais gis fisis\!) e'(\> dis cis b ais gis fisis\!) |
-  \setTextDim ais(\> gis b cisis,) e( dis gis ais,) cis( b dis fisis,) ais( gis fisis gis\!) |
+  \crescTextCresc r\< gis,( ais gis fisis gis cis e dis cis dis cis bis cis e gis\!) |
+  \crescHairpin dis(\< e dis cisis dis b' ais gis fisis\!) e'(\> dis cis b ais gis fisis\!) |
+  \dimTextDim ais(\> gis b cisis,) e( dis gis ais,) cis( b dis fisis,) ais( gis fisis gis\!) |
   \break
   
   %bar 13&91
@@ -52,27 +71,27 @@ partAright = \relative c'' {
   eis,->( eis' b dis) fis,->( fis' b, dis) a->( a' b, e) gis,->( gis' b, e) |
   %bar 17&95
   gis,16(\p gis'-> bis, cis) fis,( fis'-> bis, cis) eis,( eis'-> bis cis) fis,( fis'-> bis, cis) |
-  \once \override DynamicLineSpanner #'staff-padding = #4
-  \setTextCresc cis,\<( cis'-> fis, a) dis,( dis'-> fis, a) e( e'-> gis, b) gis( gis'-> b, e) |
+  \once \override DynamicLineSpanner.staff-padding = #4
+  \crescTextCresc cis,\<( cis'-> fis, a) dis,( dis'-> fis, a) e( e'-> gis, b) gis( gis'-> b, e) |
   gis,( gis'-> bis, cis) fis,( fis'-> bis, cis) dis\!( dis'-> fis, a) cis,( cis'-> fis, a) |
   %bar 20&98
-  cis,\>( cis'-> dis, fis) bis,( bis'-> dis, fis\!) \setTextDim 
+  \dimHairpin cis,\>( cis'-> dis, fis) bis,( bis'-> dis, fis\!) \dimTextDim 
   bis,\>( bis'-> dis, fis) bis,( bis'-> dis, fis) |
   c( c'-> dis, fis) b,( b'-> dis, fis) b,( b'-> dis, fis) ais,( ais'-> dis, fis) |
   ais,( ais'-> dis, fis) \repeat unfold 3 {a,( a'-> dis, fis)} |
   c\!( c' dis, fis) b,( b' dis, fis) b,( b' dis, fis) ais,( ais' dis, fis) |
   ais,( ais' dis, fis) 
-  \once \override DynamicLineSpanner #'staff-padding = #4
-  a,_\markup{\italic "rit."}\>( a' dis, fis) a,( a' dis, fis) gis,( gis' dis fis\!) |
+  \once \override DynamicLineSpanner.staff-padding = #4
+  \dimHairpin a,_\markup{\italic "rit."}\>( a' dis, fis) a,( a' dis, fis) gis,( gis' dis fis\!) |
   \break
 
   %bar 25&103
-  \once \override TextScript #'staff-padding = #2.5
+  \once \override TextScript.staff-padding = #2.5
   r16^\markup{\italic "a tempo"} gis,\p( a gis fisis gis cis e dis cis dis cis bis cis e gis) |
   r16 gis,( a gis fisis gis cis e dis cis dis cis bis cis e gis) |
-  r16 a,(\< cis dis fis a cis dis\!
-  #(set-octavation 1) \once \override Staff.OttavaBracket #'padding = #2.0
-  b'\> a gis fis e dis fis cis)\! #(set-octavation 0) |
+  r16 \crescHairpin a,(\< cis dis fis a cis dis\!
+  \ottava #1 \once \override Staff.OttavaBracket.padding = #2.0
+  b'\> a gis fis e dis fis cis)\! \ottava #0 |
   bis( dis a gis fis a e dis) fis( cis bis dis a gis b a~) |
   %bar 29&107
   a gis( a gis fisis gis cis e dis cis dis cis bis cis e gis) |
@@ -86,14 +105,13 @@ partAright = \relative c'' {
   fis\< eis e dis d cis c b ais a gis g fis e dis cis\! |
   %avoid collision by increasing space between staves
   \overrideProperty
-  #"Score.NonMusicalPaperColumn"
-  #'line-break-system-details
+  Score.NonMusicalPaperColumn.line-break-system-details
   #'((fixed-alignment-extra-space . 3))
   \break
   %bar 37&115
-  gis8)-|\sf r 
-  #(set-octavation 1) \once \override Staff.OttavaBracket #'padding = #2.0
-  a'''16->(\ff gis e' e,) fis->( e cis' cis,) dis->( cis gis' gis,) #(set-octavation 0) |
+  gis8)-!\sf r 
+  \ottava #1 \once \override Staff.OttavaBracket.padding = #2.0
+  a'''16->(\ff gis e' e,) fis->( e cis' cis,) dis->( cis gis' gis,) \ottava #0 |
   a( gis e' e,) fis( e cis' cis,) dis( cis gis' gis,) a( gis e' e,) |
   fis( e cis' cis,) dis( cis gis' gis,) dis'( cis gis' gis,) dis'( cis a' a,) |
   dis( cis gis' gis,) dis'( cis fisis fisis,) dis'( cis gis' gis,) dis'( bis gis' gis,) |
@@ -109,7 +127,7 @@ partBright = \relative c'' {
   %bar 41
   r1^\markup{\huge \bold "Largo"}_\markup{\large \italic "pesante"} |
   \set decrescendoText = "poco dim."
-  \set decrescendoSpanner = #'dashed-line
+  \set decrescendoSpanner = #'text
   r1\> |
   \tempo 4 = 90
   aes2\!^\markup{\huge \bold \pad-markup #2.0 "Moderato cantabile"}_\markup{\large \italic "sotto voce"}( bes8\trill aes\< des ees |
@@ -118,7 +136,7 @@ partBright = \relative c'' {
   aes2) bes~->( |
   bes ces8\trill bes\< ees f) |
   ges4\!( f ees f) |
-  des2( \grace{c32[ des ees des]} f4.\> ees8\! |
+  des2( \grace{c32[ des ees des]} \dimHairpin f4.\> ees8\! |
   ees1->) |
   %bar 51
   aes,2^\markup{\italic "a tempo"}( bes8\trill aes\< des ees |
@@ -132,12 +150,12 @@ partBright = \relative c'' {
   %bar 59
   aes,2)\sf bes8.(\trill a16\< bes8. c16 |
   aes8)\! r8 c'4~(\sf 
-  \once \override DynamicLineSpanner #'staff-padding = #2
-  \times 4/7 {c8\> bes aes fes des bes8.)\! aes'16(} |
+  \once \override DynamicLineSpanner.staff-padding = #2
+  \tuplet 7/4 {c8\> bes aes fes des bes8.)\! aes'16(} |
   ees,2)-> \acciaccatura{c'8} bes8.(\> a16 bes8. ees16 |
   aes,4)\! r4 bes4(\pp 
-  \once \override DynamicLineSpanner #'staff-padding = #3
-  \times 2/3 {des8\> c bes\!)} |
+  \once \override DynamicLineSpanner.staff-padding = #3
+  \tuplet 3/2 {des8\> c bes\!)} |
   %bar 63
   aes2( bes8\trill aes\< des ees |
   f2) aes\!->( |
@@ -150,12 +168,12 @@ partBright = \relative c'' {
   %bar 71
   aes,2)\sf bes8.(\trill a16\< bes8. c16 |
   aes8)\f r8 c'4~(\sf 
-  \once \override DynamicLineSpanner #'staff-padding = #2
-  \times 4/7 {c8\> bes aes fes des bes8.)\! aes'16(} |
+  \once \override DynamicLineSpanner.staff-padding = #2
+  \tuplet 7/4 {c8\> bes aes fes des bes8.)\! aes'16(} |
   ees,2)-> \acciaccatura{c'8} bes8.(\> a16 bes8. ees16 |
   aes,4)\! r4 bes4(\pp 
-  \once \override DynamicLineSpanner #'staff-padding = #3
-  \times 2/3 {des8\> c bes\!)} |
+  \once \override DynamicLineSpanner.staff-padding = #3
+  \tuplet 3/2 {des8\> c bes\!)} |
   %bar 75
   aes2( bes8\trill aes\< des ees |
   f2) aes\!->( |
@@ -164,8 +182,8 @@ partBright = \relative c'' {
   bes ces8\trill bes\< ees f) |
   ges4\!( f ees f |
   des4.) g,32( aes bes aes f'4.\> ees8\!) |
-  \once \override TextSpanner #'edge-text = #'("riten." . "")
-  ees1\p\startTextSpan |
+  \once \override TextSpanner.bound-details.left.text = "riten."
+  \after 2... \stopTextSpan ees1\p\startTextSpan |
 }
 
 %% Part C %%
@@ -179,7 +197,7 @@ partCright = \relative c' {
   %bar 123
   dis'( cis gis'-> gis,) a'(\ff gis e'-> e,) fis( e cis'-> cis,) a'( gis e'-> e,) |
   dis( cis gis'-> gis,) a'( gis e'-> e,) fis( e cis'-> cis,) a'( gis e'-> e,) |
-  \setTextDim fis(\> e cis' cis,) a'( gis cis cis,) fis( e cis' cis,) a'( gis cis cis,) |
+  \dimTextDim fis(\> e cis' cis,) a'( gis cis cis,) fis( e cis' cis,) a'( gis cis cis,) |
   fis( e cis' cis,) a'( gis cis cis,) fis( e cis' cis,) a'( gis cis cis,) |
   dis( cis gis' gis,) dis'( cis gis' gis,) dis'(\p cis gis' gis,) dis'( cis gis' gis,) |
   dis'( cis gis' gis,) dis'( cis gis' gis,) dis'( cis gis' gis,) dis'( cis gis' gis,) |
@@ -188,7 +206,7 @@ partCright = \relative c' {
   \repeat unfold 5 { dis'( cis gis' gis,) dis'( cis gis' gis,) dis'( cis gis' gis,) dis'( cis gis' gis,) | }
   dis'( cis gis' eis,) dis'( cis gis' eis,) dis'( cis gis' eis,) dis'( cis gis' eis,) |
   \tempo 4 = 120
-  \once \override TextSpanner #'edge-text = #'("riten." . "")
+  \once \override TextSpanner.bound-details.left.text = "riten."
   eis'(\startTextSpan dis gis gis,) eis'( dis gis gis,) eis'( dis gis gis,) eis'( dis gis gis,) |
   <fis gis bis dis>1~(\stopTextSpan\ppp\arpeggio |
   <eis gis cis>1)\arpeggio |
@@ -200,12 +218,12 @@ upper = \relative c'' {
   \clef treble
   \key cis \minor
   \time 4/4
-  \override Score.MetronomeMark #'transparent = ##t
+  \override Score.MetronomeMark.transparent = ##t
   \tempo 2 = 84
-  r1 |
-  r1 |
-  r1 |
-  r1 |
+  R1 |
+  R1 |
+  R1 |
+  R1 |
   %bar 5
   r16 \partAright
   %bar 41
@@ -213,7 +231,7 @@ upper = \relative c'' {
   \key cis \minor
   \tempo 2 = 84
   %bar 83
-  r16^\markup{\huge \bold \pad-markup #2.5 "Presto"}\stopTextSpan
+  r16^\markup{\huge \bold \pad-markup #2.5 "Presto"}
   \partAright
   %bar 119
   \partCright
@@ -225,14 +243,14 @@ upper = \relative c'' {
 %% reoccurring phrases & shortcuts %%
 
 fixTuplets = {
-  \set tupletSpannerDuration = #(ly:make-moment 1 2)
-  \override TupletNumber #'transparent = ##t
-  \override TupletBracket #'transparent = ##t
+  \tupletSpan 2
+  \override TupletNumber.transparent = ##t
+  \override TupletBracket.transparent = ##t
 }
 
 %pedal shortcuts
-pd = \sustainDown
-pu = \sustainUp
+pd = \sustainOn
+pu = \sustainOff
 
 multipleOne = \relative c' {
   <<
@@ -243,12 +261,12 @@ multipleOne = \relative c' {
     \\
     \relative c'{
       \fixTuplets
-      \times 4/6 {des,8[(\pd aes' des f des aes)]\pu des,[(\pd aes' f' \change Staff=upper aes \change Staff=lower f aes,)]\pu} |
-      \set tupletSpannerDuration = #(ly:make-moment 1 4)
-      \times 2/3 {ges'(\pd ees aes,)\pu f'(\pd des aes)\pu ees'(\pd c aes)\pu des(\pd aes f)\pu} |
+      \tuplet 6/4 {des,8[(\pd aes' des f des aes)]\pu des,[(\pd aes' f' \change Staff=upper aes \change Staff=lower f aes,)]\pu} |
+      \tupletSpan 4
+      \tuplet 3/2 {ges'(\pd ees aes,)\pu f'(\pd des aes)\pu ees'(\pd c aes)\pu des(\pd aes f)\pu} |
     }
   >>
-  \times 4/6 {
+  \tuplet 6/4 {
     aes,8(\pd ees' aes c aes ees)\pu ges,(\pd ges' bes des bes ges)\pu |
     bes,(\pd f' bes d bes f)\pu bes,(\pd bes' d aes' d, bes)\pu |
     ees,[(\pd ges' bes,)]\pu f(\pd f' a,)\pu ges[(\pd ees' bes)]\pu aes(\pd ges' c,)\pu |
@@ -266,7 +284,7 @@ multipleTwo = \relative c' {
 %% part A %%
 
 partAleft = \relative c {
-  \times 4/6 {
+  \tuplet 6/4 {
     %bar 5&83
     cis(\pd gis' cis e cis gis) e( gis cis e cis gis)\pu |
     cis,(\pd gis' cis e cis gis) e( gis cis e cis gis)\pu |
@@ -307,7 +325,7 @@ partAleft = \relative c {
   <gis cis e gis>8 r8 r4 <fisis cis' e a>4\pd r4\pu |
   r1 |
   %bar 37&115
-  <gis,, gis'>8-|\pd r \clef treble <e''' e'>4 <cis cis'> <gis gis'> |
+  <gis,, gis'>8-!\pd r \clef treble <e''' e'>4 <cis cis'> <gis gis'> |
   \clef bass <e e'> <cis cis'> <gis gis'> <e e'> |
   <cis cis'> <gis gis'> <gis gis'>\pd <a a'>\pd |
   <gis gis'>\pd <fisis fisis'>\pd <gis gis'>2\pd |
@@ -319,14 +337,14 @@ partAleft = \relative c {
 partBleft = \relative c, { 
   %Largo
   \key des \major
-  \times 4/6 {
+  \tuplet 6/4 {
     %bar 41
     des8(\<\pd aes' des f aes des\! f\> des aes f des aes)\! |
     des,( aes' des f aes des f des aes f des aes~)\pu |
     <des, aes'>\pd aes''[( c ees c aes)] des,( aes' c ges' c, aes)\pu |
   }
   \multipleOne
-  \times 4/6 {
+  \tuplet 6/4 {
     %bar 49
     des,(\pd aes' des f des aes)\pu ees(\pd g des' ees des g,)\pu |
   }
@@ -337,13 +355,13 @@ partBleft = \relative c, {
     \\
     \relative c'{
       \fixTuplets
-      \times 4/6 {aes,8[(\pd ees' aes c aes ees)]\pu aes,[(\pd ees' ges bes ges ees)]\pu} |
+      \tuplet 6/4 {aes,8[(\pd ees' aes c aes ees)]\pu aes,[(\pd ees' ges bes ges ees)]\pu} |
     }
   >>
   %bar 51
-  \times 4/6 {aes,(\pd ees' aes c aes ees)\pu aes,(\pd aes' c ges' c, aes)\pu} |
+  \tuplet 6/4 {aes,(\pd ees' aes c aes ees)\pu aes,(\pd aes' c ges' c, aes)\pu} |
   \multipleOne
-  \times 4/6 {
+  \tuplet 6/4 {
     des,(\pd aes' des f des aes)\pu des,(\pd aes' c ges' c, aes)\pu |
     des,(\pd aes' c ges' c, aes)\pu des,(\pd aes' des f des aes)\pu |
     %bar 59
@@ -352,7 +370,7 @@ partBleft = \relative c, {
     aes,(\pd aes' c ees c aes)\pu ees(\pd aes c ges' c, aes)\pu |
   }
   \multipleOne
-  \times 4/6 {
+  \tuplet 6/4 {
     des,(\pd aes' des f des aes)\pu des,(\pd aes' c ges' c, aes)\pu |
     des,(\pd aes' c ges' c, aes)\pu des,(\pd aes' des f des aes)\pu |
     %bar 71
@@ -361,7 +379,7 @@ partBleft = \relative c, {
     aes,(\pd ees' aes c aes ees)\pu aes,(\pd aes' c ges' c, aes)\pu |
   }
   \multipleOne
-  \times 4/6 {
+  \tuplet 6/4 {
     des,(\pd aes' des f des aes)\pu des,(\pd aes' c ges' c, aes)\pu |
     des,(\pd aes' c ges' c, aes)\pu des,(\pd aes' c ges' c, aes)\pu |
   }
@@ -380,8 +398,7 @@ partCleft = \relative c {
   r1|
   %avoid collision by increasing space between staves
   \overrideProperty
-  #"Score.NonMusicalPaperColumn"
-  #'line-break-system-details
+  Score.NonMusicalPaperColumn.line-break-system-details
   #'((fixed-alignment-extra-space . 3))
   \break
   %bar 129
@@ -406,21 +423,23 @@ lower = \relative c {
   \time 4/4
 
   %create automatic beams every 1/2 note
-  #(revert-auto-beam-setting '(end 1 12 4 4) 1 4)
-  #(revert-auto-beam-setting '(end 1 12 4 4) 3 4)
-  \set tupletSpannerDuration = #(ly:make-moment 1 2)
+  \set Staff.beamExceptions = #'()
+  \set Staff.baseMoment = #(ly:make-moment 1/2)
+  \set Staff.beatStructure = 1,1
+  
+  \tupletSpan 2
  
   \dynamicUp
   <gis gis'>1~\sf\pd |
   <gis gis'>\pu |
-  \times 4/6 {
+  \tuplet 6/4 {
     <cis, cis'>8\f\pd gis''([ cis e cis gis] 
-    \once \override DynamicLineSpanner #'staff-padding = #3
+    \once \override DynamicLineSpanner.staff-padding = #3
     cis,\> gis' cis e cis gis |
     cis, gis' cis e cis gis cis, gis' cis e cis gis\!)\pu |
     %remove all tumplet numbers and brackets from now on
-    \override TupletNumber #'transparent = ##t
-    \override TupletBracket #'transparent = ##t
+    \override TupletNumber.transparent = ##t
+    \override TupletBracket.transparent = ##t
   }
   %bar 5
   \partAleft
@@ -438,8 +457,10 @@ lower = \relative c {
 %%% SCORE %%%
 
 \score {
-  \new PianoStaff <<
-    \set PianoStaff.connectArpeggios = ##t
+  \new PianoStaff \with {
+    \override StaffGrouper.staff-staff-spacing.basic-distance = 10
+    connectArpeggios = ##t
+  } <<
     \new Staff = "upper" \upper
     \new Staff = "lower" \lower
   >>


### PR DESCRIPTION
By comparing the original PDF to the new output, I was able to make minimal changes to the input file while still keeping the output true to its original form.  I added a \paper block and some staff-staff-spacing because the output was too crowded but beyond that, very little was done other than the convertion.